### PR TITLE
Fix release workflow MCP protocol version

### DIFF
--- a/scripts/build_release_assets.sh
+++ b/scripts/build_release_assets.sh
@@ -32,9 +32,9 @@ MCP_PROTOCOL_VERSION="$(awk '
     print $4
     exit
   }
-' internal/mcpserver/server.go)"
+' "$(go list -f '{{.Dir}}' github.com/theory-cloud/apptheory/runtime/mcp)/server.go")"
 if [[ -z "${MCP_PROTOCOL_VERSION}" ]]; then
-  echo "failed to resolve MCP protocol version from internal/mcpserver/server.go" >&2
+  echo "failed to resolve MCP protocol version from github.com/theory-cloud/apptheory/runtime/mcp" >&2
   exit 1
 fi
 


### PR DESCRIPTION
The `release` workflow started failing after the MCP server refactor (AppTheory v0.15.1) because `scripts/build_release_assets.sh` was still trying to read `internal/mcpserver/server.go`.

This updates the script to resolve the MCP protocol version from AppTheory’s runtime package (`github.com/theory-cloud/apptheory/runtime/mcp`) instead.
