### PR TITLE
Implement comm tools and identity verification

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -130,11 +130,28 @@ Scope key:
 | `profile_update` | Write | Update display name, bio, and avatar (best-effort). |
 | `memory_append` | Write | Append a memory event to the authenticated agent's memory timeline. |
 | `memory_query` | Read | Query memory events for the authenticated agent. |
+| `email_send` | Write | Send an email through lesser-host on behalf of the authenticated soul agent. |
+| `email_read` | Read | Read recent email messages from notification-backed inbox data. |
+| `email_search` | Read | Search recent email messages. |
+| `email_reply` | Write | Reply to a specific communication thread by `messageId`. |
+| `email_delete` | Write | Archive or delete an email by dismissing the backing notification. |
+| `sms_send` | Write | Send an SMS through lesser-host; supports `messageId`/`inReplyTo` for threaded replies. |
+| `sms_read` | Read | Read recent inbound SMS messages delivered to the instance. |
+| `phone_call` | Write | Request an outbound voice call through lesser-host; older hosts that predate outbound voice support return a structured `host_gap` error. |
+| `voicemail_read` | Read | Read voicemail notifications and transcriptions. |
+| `identity_whoami` | Read | Return the current soul agent identity, channels, and contact preferences. |
+| `identity_lookup` | Read | Resolve a soul identity by ENS name, email address, or agent id. |
+| `identity_verify` | Read | Verify that a recent communication matches a resolved soul identity using channel resolution plus notification provenance. |
 
 Notes:
 
 - Social tools require an **OAuth JWT** bearer token (not just an instance key) because they call the Lesser API on behalf
   of the authenticated agent.
+- Communication and identity tools also require an **OAuth JWT** bearer token for agent-context reads such as `identity_whoami`
+  and inbox-backed verification.
+- Outbound communication tools (`email_send`, `email_reply`, `sms_send`, `phone_call`) additionally require the managed
+  `LESSER_HOST_INSTANCE_KEY` (or `LESSER_HOST_INSTANCE_KEY_ARN`) so lesser-body can authenticate to lesser-host's
+  `/api/v1/soul/comm/*` endpoints.
 - Memory tools require an authenticated identity; the identity is derived from the JWT username claim, or set to
   `instance` for managed-instance-key auth.
 
@@ -153,6 +170,12 @@ Resources are read-only JSON snapshots. Resource access happens through MCP (`re
 | `agent://memory/recent` | Recent memory events |
 | `agent://capabilities` | Capabilities (best-effort) |
 | `agent://config` | Instance configuration (non-sensitive) |
+| `agent://channels` | Soul channels and registration summary |
+| `agent://channels/preferences` | Soul contact preferences |
+| `agent://email/inbox` | Email inbox snapshot |
+| `agent://email/sent` | Sent email snapshot |
+| `agent://sms/messages` | SMS message snapshot |
+| `agent://voicemail` | Voicemail snapshot |
 
 ## Prompts
 
@@ -163,4 +186,6 @@ Prompts are reusable templates returned via MCP (`prompts/list`, `prompts/get`).
 - `draft_reply`
 - `reputation_report` (best-effort; depends on reputation integrations)
 - `memory_reflect`
-
+- `compose_email`
+- `handle_inbound`
+- `respect_preferences`

--- a/internal/auth/secrets.go
+++ b/internal/auth/secrets.go
@@ -61,6 +61,10 @@ func lesserHostInstanceKey(ctx context.Context) (string, error) {
 	return lesserHostInstanceKeyCache.value, lesserHostInstanceKeyCache.err
 }
 
+func LesserHostInstanceKey(ctx context.Context) (string, error) {
+	return lesserHostInstanceKey(ctx)
+}
+
 func fetchSecretValue(ctx context.Context, secretID string) (string, error) {
 	secretID = strings.TrimSpace(secretID)
 	if secretID == "" {

--- a/internal/mcpapp/comm_contract_test.go
+++ b/internal/mcpapp/comm_contract_test.go
@@ -168,6 +168,20 @@ func TestLBM0_CommunicationToolSchemasMatchSpec(t *testing.T) {
 	}
 
 	{
+		s := mustSchema(t, toolsByName["sms_send"])
+		if s.Type != "object" {
+			t.Fatalf("sms_send schema type: want object got %q", s.Type)
+		}
+		if !reflect.DeepEqual(s.Required, []string{"to", "body"}) {
+			t.Fatalf("sms_send required: want [to body], got %#v", s.Required)
+		}
+		expectPropType(t, s, "to", "string")
+		expectPropType(t, s, "body", "string")
+		expectPropType(t, s, "messageId", "string")
+		expectPropType(t, s, "inReplyTo", "string")
+	}
+
+	{
 		s := mustSchema(t, toolsByName["phone_call"])
 		if s.Type != "object" {
 			t.Fatalf("phone_call schema type: want object got %q", s.Type)
@@ -178,6 +192,8 @@ func TestLBM0_CommunicationToolSchemasMatchSpec(t *testing.T) {
 		expectPropType(t, s, "to", "string")
 		expectPropType(t, s, "purpose", "string")
 		expectPropType(t, s, "maxDurationMinutes", "integer")
+		expectPropType(t, s, "messageId", "string")
+		expectPropType(t, s, "inReplyTo", "string")
 	}
 
 	{
@@ -186,5 +202,15 @@ func TestLBM0_CommunicationToolSchemasMatchSpec(t *testing.T) {
 			t.Fatalf("identity_lookup required: want [query], got %#v", s.Required)
 		}
 		expectPropType(t, s, "query", "string")
+	}
+
+	{
+		s := mustSchema(t, toolsByName["identity_verify"])
+		if !reflect.DeepEqual(s.Required, []string{"channel", "identifier"}) {
+			t.Fatalf("identity_verify required: want [channel identifier], got %#v", s.Required)
+		}
+		expectPropType(t, s, "channel", "string")
+		expectPropType(t, s, "identifier", "string")
+		expectPropType(t, s, "messageId", "string")
 	}
 }

--- a/internal/mcpapp/comm_prompts_test.go
+++ b/internal/mcpapp/comm_prompts_test.go
@@ -90,4 +90,31 @@ func TestLBM4_CommunicationPromptsExistAndReferencePreferences(t *testing.T) {
 	if !strings.Contains(combined, "identity_whoami") || !strings.Contains(combined, "agent://channels/preferences") {
 		t.Fatalf("expected compose_email prompt to reference identity_whoami and agent://channels/preferences, got: %s", combined)
 	}
+
+	getParams, _ = json.Marshal(map[string]any{
+		"name":      "handle_inbound",
+		"arguments": map[string]any{"channel": "sms", "messageId": "comm-msg-123"},
+	})
+	getResp = invokeJSON(t, env, app, map[string][]string{
+		"authorization":  {authHeader},
+		"mcp-session-id": {sessionID},
+	}, &mcpruntime.Request{JSONRPC: "2.0", ID: 4, Method: "prompts/get", Params: getParams})
+	if getResp.Status != 200 {
+		t.Fatalf("prompts/get handle_inbound: status=%d body=%s", getResp.Status, string(getResp.Body))
+	}
+	_ = json.Unmarshal(getResp.Body, &rpcGet)
+	if rpcGet.Error != nil {
+		t.Fatalf("prompts/get handle_inbound error: %+v", rpcGet.Error)
+	}
+	{
+		b, _ := json.Marshal(rpcGet.Result)
+		_ = json.Unmarshal(b, &prompt)
+	}
+	combined = ""
+	for _, m := range prompt.Messages {
+		combined += "\n" + m.Content.Text
+	}
+	if !strings.Contains(combined, "Pass messageId=comm-msg-123") {
+		t.Fatalf("expected handle_inbound prompt to instruct reply threading, got: %s", combined)
+	}
 }

--- a/internal/mcpapp/email_tools_test.go
+++ b/internal/mcpapp/email_tools_test.go
@@ -19,6 +19,7 @@ import (
 func TestLBM2_EmailSendAndReply_TalkToCommAPI(t *testing.T) {
 	t.Setenv("MCP_SESSION_TABLE", "")
 	t.Setenv("JWT_SECRET", "test")
+	t.Setenv("LESSER_HOST_INSTANCE_KEY", "instance-key-123")
 	auth.ResetForTests()
 	soulapi.ResetForTests()
 
@@ -98,8 +99,8 @@ func TestLBM2_EmailSendAndReply_TalkToCommAPI(t *testing.T) {
 		if resp.Status != 200 {
 			t.Fatalf("email_send: status=%d body=%s", resp.Status, string(resp.Body))
 		}
-		if gotAuth != authHeader {
-			t.Fatalf("expected comm api Authorization=%q, got %q", authHeader, gotAuth)
+		if gotAuth != "Bearer instance-key-123" {
+			t.Fatalf("expected comm api Authorization=%q, got %q", "Bearer instance-key-123", gotAuth)
 		}
 		if gotBody["channel"] != "email" || gotBody["agentId"] != agentID {
 			t.Fatalf("unexpected comm api body: %+v", gotBody)
@@ -144,8 +145,8 @@ func TestLBM2_EmailSendAndReply_TalkToCommAPI(t *testing.T) {
 		if resp.Status != 200 {
 			t.Fatalf("email_reply: status=%d body=%s", resp.Status, string(resp.Body))
 		}
-		if gotAuth != authHeader {
-			t.Fatalf("expected comm api Authorization=%q, got %q", authHeader, gotAuth)
+		if gotAuth != "Bearer instance-key-123" {
+			t.Fatalf("expected comm api Authorization=%q, got %q", "Bearer instance-key-123", gotAuth)
 		}
 		if gotBody["inReplyTo"] != "comm-msg-000" {
 			t.Fatalf("expected inReplyTo=comm-msg-000, got %+v", gotBody)

--- a/internal/mcpapp/identity_surfaces_test.go
+++ b/internal/mcpapp/identity_surfaces_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/theory-cloud/apptheory/testkit"
 
 	"github.com/equaltoai/lesser-body/internal/auth"
+	"github.com/equaltoai/lesser-body/internal/lesserapi"
 	"github.com/equaltoai/lesser-body/internal/mcpapp"
 	"github.com/equaltoai/lesser-body/internal/soulapi"
 )
@@ -19,6 +20,7 @@ func TestLBM1_IdentityToolsAndChannelResources(t *testing.T) {
 	t.Setenv("MCP_SESSION_TABLE", "")
 	t.Setenv("JWT_SECRET", "test")
 	auth.ResetForTests()
+	lesserapi.ResetForTests()
 	soulapi.ResetForTests()
 
 	const agentID = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
@@ -60,6 +62,34 @@ func TestLBM1_IdentityToolsAndChannelResources(t *testing.T) {
 					"languages":["en"]
 				}
 			}`))
+		case r.URL.Path == "/api/v1/soul/agents/"+agentID+"/channels":
+			_, _ = w.Write([]byte(`{
+				"agentId":"` + agentID + `",
+				"channels":{
+					"ens":{"name":"agent-alice.lessersoul.eth"},
+					"email":{"address":"agent-alice@lessersoul.ai","capabilities":["receive","send"],"verified":true},
+					"phone":{"number":"+15550142","capabilities":["sms-receive"],"verified":false}
+				},
+				"contactPreferences":{"preferred":"email"},
+				"updatedAt":"2026-03-09T12:00:00Z"
+			}`))
+		case r.URL.Path == "/api/v1/soul/resolve/email/agent-alice@lessersoul.ai":
+			_, _ = w.Write([]byte(`{"version":"1","agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-alice","status":"active"}}`))
+		case r.URL.Path == "/api/v1/soul/resolve/ens/agent-alice.lessersoul.eth":
+			_, _ = w.Write([]byte(`{"version":"1","agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-alice","status":"active"}}`))
+		case r.URL.Path == "/api/v1/notifications":
+			_, _ = w.Write([]byte(`[
+				{
+					"id":"n1",
+					"type":"communication:inbound",
+					"channel":"email",
+					"messageId":"comm-msg-001",
+					"from":{"address":"agent-alice@lessersoul.ai","soulAgentId":"` + agentID + `"},
+					"subject":"Hi",
+					"body":"Hello there",
+					"receivedAt":"2026-03-09T12:00:00Z"
+				}
+			]`))
 		default:
 			w.WriteHeader(http.StatusNotFound)
 			_, _ = w.Write([]byte(`{"error":{"message":"not found"}}`))
@@ -68,6 +98,8 @@ func TestLBM1_IdentityToolsAndChannelResources(t *testing.T) {
 	defer server.Close()
 
 	t.Setenv("LESSER_SOUL_API_BASE_URL", server.URL)
+	t.Setenv("LESSER_API_BASE_URL", server.URL)
+	lesserapi.ResetForTests()
 	soulapi.ResetForTests()
 
 	app, err := mcpapp.New("test", "dev")
@@ -188,6 +220,77 @@ func TestLBM1_IdentityToolsAndChannelResources(t *testing.T) {
 		}, &mcpruntime.Request{JSONRPC: "2.0", ID: 5, Method: "resources/read", Params: params})
 		if resp.Status != 200 {
 			t.Fatalf("resources/read channel preferences: status=%d body=%s", resp.Status, string(resp.Body))
+		}
+	}
+
+	// identity_verify should resolve the identity and verify a concrete inbound message.
+	{
+		callParams, _ := json.Marshal(map[string]any{
+			"name": "identity_verify",
+			"arguments": map[string]any{
+				"channel":    "email",
+				"identifier": "agent-alice@lessersoul.ai",
+				"messageId":  "comm-msg-001",
+			},
+		})
+		resp := invokeJSON(t, env, app, map[string][]string{
+			"authorization":  {authHeader},
+			"mcp-session-id": {sessionID},
+		}, &mcpruntime.Request{JSONRPC: "2.0", ID: 6, Method: "tools/call", Params: callParams})
+		if resp.Status != 200 {
+			t.Fatalf("identity_verify email: status=%d body=%s", resp.Status, string(resp.Body))
+		}
+
+		var rpc mcpruntime.Response
+		_ = json.Unmarshal(resp.Body, &rpc)
+		if rpc.Error != nil {
+			t.Fatalf("identity_verify email rpc error: %+v", rpc.Error)
+		}
+		var out mcpruntime.ToolResult
+		{
+			b, _ := json.Marshal(rpc.Result)
+			_ = json.Unmarshal(b, &out)
+		}
+		data, _ := out.StructuredContent["data"].(map[string]any)
+		if data["verified"] != true {
+			t.Fatalf("expected verified identity match, got %+v", data)
+		}
+		if data["matchedBy"] != "sender.agentId" && data["matchedBy"] != "sender.email" {
+			t.Fatalf("expected sender provenance match, got %+v", data)
+		}
+	}
+
+	// identity_verify should also work when resolving the sender by ENS and using the same message provenance.
+	{
+		callParams, _ := json.Marshal(map[string]any{
+			"name": "identity_verify",
+			"arguments": map[string]any{
+				"channel":    "ens",
+				"identifier": "agent-alice.lessersoul.eth",
+				"messageId":  "comm-msg-001",
+			},
+		})
+		resp := invokeJSON(t, env, app, map[string][]string{
+			"authorization":  {authHeader},
+			"mcp-session-id": {sessionID},
+		}, &mcpruntime.Request{JSONRPC: "2.0", ID: 7, Method: "tools/call", Params: callParams})
+		if resp.Status != 200 {
+			t.Fatalf("identity_verify ens: status=%d body=%s", resp.Status, string(resp.Body))
+		}
+
+		var rpc mcpruntime.Response
+		_ = json.Unmarshal(resp.Body, &rpc)
+		if rpc.Error != nil {
+			t.Fatalf("identity_verify ens rpc error: %+v", rpc.Error)
+		}
+		var out mcpruntime.ToolResult
+		{
+			b, _ := json.Marshal(rpc.Result)
+			_ = json.Unmarshal(b, &out)
+		}
+		data, _ := out.StructuredContent["data"].(map[string]any)
+		if data["verified"] != true {
+			t.Fatalf("expected ENS verification to succeed, got %+v", data)
 		}
 	}
 }

--- a/internal/mcpapp/outbound_comm_tools_test.go
+++ b/internal/mcpapp/outbound_comm_tools_test.go
@@ -1,0 +1,227 @@
+package mcpapp_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	mcpruntime "github.com/theory-cloud/apptheory/runtime/mcp"
+	"github.com/theory-cloud/apptheory/testkit"
+
+	"github.com/equaltoai/lesser-body/internal/auth"
+	"github.com/equaltoai/lesser-body/internal/mcpapp"
+	"github.com/equaltoai/lesser-body/internal/soulapi"
+)
+
+func TestLBM6_SMSAndVoiceOutboundTools(t *testing.T) {
+	t.Setenv("MCP_SESSION_TABLE", "")
+	t.Setenv("JWT_SECRET", "test")
+	t.Setenv("LESSER_HOST_INSTANCE_KEY", "instance-key-123")
+	auth.ResetForTests()
+	soulapi.ResetForTests()
+
+	const agentID = "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+	const tokenUser = "agent1"
+
+	var gotAuth string
+	var gotBody map[string]any
+	voiceStatusCode := http.StatusOK
+	voiceResponseBody := `{"messageId":"comm-msg-call-001","status":"accepted","provider":"telnyx"}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/api/v1/soul/agents/mine":
+			_, _ = w.Write([]byte(`{
+				"agents":[{"agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-carol","status":"active"}}],
+				"count":1
+			}`))
+		case "/api/v1/soul/agents/" + agentID:
+			_, _ = w.Write([]byte(`{"version":"1","agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-carol","status":"active"}}`))
+		case "/api/v1/soul/agents/" + agentID + "/registration":
+			_, _ = w.Write([]byte(`{
+				"version":"3",
+				"channels":{
+					"phone":{"number":"+15550142","capabilities":["sms-send","voice-receive"],"verified":true}
+				},
+				"contactPreferences":{},
+				"boundaries":[{"id":"b1","category":"communication_policy","channel":"sms","statement":"reply in thread"}]
+			}`))
+		case "/api/v1/soul/comm/send":
+			gotAuth = r.Header.Get("Authorization")
+			body, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(body, &gotBody)
+			if gotBody["channel"] == "voice" {
+				w.WriteHeader(voiceStatusCode)
+				_, _ = w.Write([]byte(voiceResponseBody))
+				return
+			}
+			_, _ = w.Write([]byte(`{"messageId":"comm-msg-sms-001","status":"queued"}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":{"message":"not found"}}`))
+		}
+	}))
+	defer server.Close()
+
+	t.Setenv("LESSER_SOUL_API_BASE_URL", server.URL)
+	soulapi.ResetForTests()
+
+	app, err := mcpapp.New("test", "dev")
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+	env := testkit.New()
+	token := newTestToken(t, "test", tokenUser, []string{"write"})
+	authHeader := "Bearer " + token
+
+	initResp := invokeJSON(t, env, app, map[string][]string{
+		"authorization": {authHeader},
+	}, &mcpruntime.Request{JSONRPC: "2.0", ID: 1, Method: "initialize"})
+	if initResp.Status != 200 {
+		t.Fatalf("initialize: status=%d body=%s", initResp.Status, string(initResp.Body))
+	}
+	sessionID := initResp.Headers["mcp-session-id"][0]
+
+	t.Run("sms send uses instance key and reply reference", func(t *testing.T) {
+		gotAuth = ""
+		gotBody = nil
+
+		callParams, _ := json.Marshal(map[string]any{
+			"name": "sms_send",
+			"arguments": map[string]any{
+				"to":        "+1 (555) 0143",
+				"body":      "On it.",
+				"messageId": "comm-msg-prev",
+			},
+		})
+		resp := invokeJSON(t, env, app, map[string][]string{
+			"authorization":  {authHeader},
+			"mcp-session-id": {sessionID},
+		}, &mcpruntime.Request{JSONRPC: "2.0", ID: 2, Method: "tools/call", Params: callParams})
+		if resp.Status != 200 {
+			t.Fatalf("sms_send: status=%d body=%s", resp.Status, string(resp.Body))
+		}
+		if gotAuth != "Bearer instance-key-123" {
+			t.Fatalf("expected comm api Authorization=%q, got %q", "Bearer instance-key-123", gotAuth)
+		}
+		if gotBody["channel"] != "sms" || gotBody["agentId"] != agentID {
+			t.Fatalf("unexpected comm api body: %+v", gotBody)
+		}
+		if gotBody["to"] != "+15550143" || gotBody["inReplyTo"] != "comm-msg-prev" || gotBody["body"] != "On it." {
+			t.Fatalf("unexpected sms payload: %+v", gotBody)
+		}
+
+		var rpc mcpruntime.Response
+		_ = json.Unmarshal(resp.Body, &rpc)
+		if rpc.Error != nil {
+			t.Fatalf("sms_send rpc error: %+v", rpc.Error)
+		}
+		var out mcpruntime.ToolResult
+		{
+			b, _ := json.Marshal(rpc.Result)
+			_ = json.Unmarshal(b, &out)
+		}
+		data, _ := out.StructuredContent["data"].(map[string]any)
+		if data["messageId"] != "comm-msg-sms-001" || data["status"] != "queued" {
+			t.Fatalf("unexpected sms result: %+v", data)
+		}
+	})
+
+	t.Run("phone call succeeds when host supports voice", func(t *testing.T) {
+		gotAuth = ""
+		gotBody = nil
+		voiceStatusCode = http.StatusOK
+		voiceResponseBody = `{"messageId":"comm-msg-call-001","status":"accepted","provider":"telnyx"}`
+
+		callParams, _ := json.Marshal(map[string]any{
+			"name": "phone_call",
+			"arguments": map[string]any{
+				"to":                 "+1 (555) 0143",
+				"purpose":            "Call back to confirm details",
+				"maxDurationMinutes": 15,
+				"messageId":          "comm-msg-prev",
+			},
+		})
+		resp := invokeJSON(t, env, app, map[string][]string{
+			"authorization":  {authHeader},
+			"mcp-session-id": {sessionID},
+		}, &mcpruntime.Request{JSONRPC: "2.0", ID: 3, Method: "tools/call", Params: callParams})
+		if resp.Status != 200 {
+			t.Fatalf("phone_call: status=%d body=%s", resp.Status, string(resp.Body))
+		}
+		if gotAuth != "Bearer instance-key-123" {
+			t.Fatalf("expected comm api Authorization=%q, got %q", "Bearer instance-key-123", gotAuth)
+		}
+		if gotBody["channel"] != "voice" || gotBody["inReplyTo"] != "comm-msg-prev" {
+			t.Fatalf("unexpected voice payload: %+v", gotBody)
+		}
+
+		var rpc mcpruntime.Response
+		_ = json.Unmarshal(resp.Body, &rpc)
+		if rpc.Error != nil {
+			t.Fatalf("phone_call rpc error: %+v", rpc.Error)
+		}
+		var out mcpruntime.ToolResult
+		{
+			b, _ := json.Marshal(rpc.Result)
+			_ = json.Unmarshal(b, &out)
+		}
+		if out.IsError {
+			t.Fatalf("expected success tool result, got %+v", out)
+		}
+		data, _ := out.StructuredContent["data"].(map[string]any)
+		if data["messageId"] != "comm-msg-call-001" || data["status"] != "accepted" {
+			t.Fatalf("unexpected phone_call result: %+v", data)
+		}
+	})
+
+	t.Run("phone call preserves host gap fallback for older hosts", func(t *testing.T) {
+		gotAuth = ""
+		gotBody = nil
+		voiceStatusCode = http.StatusServiceUnavailable
+		voiceResponseBody = `{"error":{"message":"channel not supported"}}`
+
+		callParams, _ := json.Marshal(map[string]any{
+			"name": "phone_call",
+			"arguments": map[string]any{
+				"to":                 "+1 (555) 0143",
+				"purpose":            "Call back to confirm details",
+				"maxDurationMinutes": 15,
+				"messageId":          "comm-msg-prev",
+			},
+		})
+		resp := invokeJSON(t, env, app, map[string][]string{
+			"authorization":  {authHeader},
+			"mcp-session-id": {sessionID},
+		}, &mcpruntime.Request{JSONRPC: "2.0", ID: 4, Method: "tools/call", Params: callParams})
+		if resp.Status != 200 {
+			t.Fatalf("phone_call legacy gap: status=%d body=%s", resp.Status, string(resp.Body))
+		}
+
+		var rpc mcpruntime.Response
+		_ = json.Unmarshal(resp.Body, &rpc)
+		if rpc.Error != nil {
+			t.Fatalf("phone_call legacy gap rpc error: %+v", rpc.Error)
+		}
+		var out mcpruntime.ToolResult
+		{
+			b, _ := json.Marshal(rpc.Result)
+			_ = json.Unmarshal(b, &out)
+		}
+		if !out.IsError {
+			t.Fatalf("expected isError tool result, got %+v", out)
+		}
+		errPayload, _ := out.StructuredContent["error"].(map[string]any)
+		if errPayload["code"] != "host_gap" {
+			t.Fatalf("expected host_gap, got %+v", errPayload)
+		}
+		details, _ := errPayload["details"].(map[string]any)
+		if details["gap"] != "outbound_voice_not_supported" {
+			t.Fatalf("expected outbound voice gap details, got %+v", details)
+		}
+	})
+}

--- a/internal/mcpserver/comm_prompts.go
+++ b/internal/mcpserver/comm_prompts.go
@@ -104,6 +104,7 @@ func promptHandleInbound(_ context.Context, args json.RawMessage) (*mcpruntime.P
 		"2) Assess urgency, safety, and whether it conflicts with any boundaries (especially communication_policy).",
 		"3) If replying, write a respectful response and then call the appropriate outbound tool:",
 		fmt.Sprintf("   - %s (preferred for this channel).", replyTool),
+		fmt.Sprintf("   - Pass messageId=%s so the host can treat it as an in-thread reply.", messageID),
 		"4) If you should not reply, explain why and consider archiving via email_delete when applicable.",
 	}, "\n")
 

--- a/internal/mcpserver/comm_tools.go
+++ b/internal/mcpserver/comm_tools.go
@@ -22,13 +22,13 @@ func registerCommunicationTools(r *mcpruntime.ToolRegistry) error {
 		{Def: emailSearchDef(), Handler: handleEmailSearch},
 		{Def: emailReplyDef(), Handler: handleEmailReply},
 		{Def: emailDeleteDef(), Handler: handleEmailDelete},
-		{Def: smsSendDef(), Handler: handleNotImplemented},
+		{Def: smsSendDef(), Handler: handleSmsSend},
 		{Def: smsReadDef(), Handler: handleSmsRead},
-		{Def: phoneCallDef(), Handler: handleNotImplemented},
+		{Def: phoneCallDef(), Handler: handlePhoneCall},
 		{Def: voicemailReadDef(), Handler: handleVoicemailRead},
 		{Def: identityWhoamiDef(), Handler: handleIdentityWhoami},
 		{Def: identityLookupDef(), Handler: handleIdentityLookup},
-		{Def: identityVerifyDef(), Handler: handleNotImplemented},
+		{Def: identityVerifyDef(), Handler: handleIdentityVerify},
 	} {
 		if err := r.RegisterTool(tool.Def, tool.Handler); err != nil {
 			return err
@@ -132,7 +132,9 @@ func smsSendDef() mcpruntime.ToolDef {
 			"type":"object",
 			"properties":{
 				"to":{"type":"string"},
-				"body":{"type":"string"}
+				"body":{"type":"string"},
+				"messageId":{"type":"string"},
+				"inReplyTo":{"type":"string"}
 			},
 			"required":["to","body"]
 		}`),
@@ -163,7 +165,9 @@ func phoneCallDef() mcpruntime.ToolDef {
 			"properties":{
 				"to":{"type":"string"},
 				"purpose":{"type":"string"},
-				"maxDurationMinutes":{"type":"integer","minimum":1,"maximum":180}
+				"maxDurationMinutes":{"type":"integer","minimum":1,"maximum":180},
+				"messageId":{"type":"string"},
+				"inReplyTo":{"type":"string"}
 			},
 			"required":["to","purpose"]
 		}`),

--- a/internal/mcpserver/email_tools.go
+++ b/internal/mcpserver/email_tools.go
@@ -30,31 +30,12 @@ func handleEmailSend(ctx context.Context, args json.RawMessage) (*mcpruntime.Too
 		return toolErrorResult("invalid_request", "to, subject, and body are required", 400, nil)
 	}
 
-	token, err := requireOAuthBearer(ctx)
-	if err != nil {
-		return toolErrorResult("unauthorized", err.Error(), 401, nil)
+	deps, res, err := loadCommSendDependencies(ctx, "email")
+	if res != nil || err != nil {
+		return res, err
 	}
-
-	identity, err := whoamiChannelsPayload(ctx, token)
-	if err != nil {
-		return identityToolResultFromError(err)
-	}
-	agentID, _ := identity["agentId"].(string)
-	agentID = strings.TrimSpace(agentID)
-	if agentID == "" {
-		return toolErrorResult("upstream_error", "unable to resolve agentId", 502, nil)
-	}
-
-	client, err := soulapi.Default()
-	if err != nil {
-		return toolErrorResult("not_configured", err.Error(), 500, nil)
-	}
-
-	advisory := commBoundaryAdvisoryForEmail(ctx, client, agentID)
 
 	body := map[string]any{
-		"channel": "email",
-		"agentId": agentID,
 		"to":      in.To,
 		"subject": in.Subject,
 		"body":    in.Body,
@@ -72,13 +53,10 @@ func handleEmailSend(ctx context.Context, args json.RawMessage) (*mcpruntime.Too
 		delete(body, "replyTo")
 	}
 
-	out, err := client.DoJSON(ctx, "POST", "/api/v1/soul/comm/send", nil, token, body)
+	normalized, err := sendOutboundComm(ctx, deps, "email", body)
 	if err != nil {
 		return commToolResultFromError(err)
 	}
-
-	normalized := normalizeCommSendResult(out, advisory)
-	_ = maybeHydrateCommStatus(ctx, client, token, normalized)
 	return toolJSONResult(normalized)
 }
 
@@ -97,43 +75,21 @@ func handleEmailReply(ctx context.Context, args json.RawMessage) (*mcpruntime.To
 		return toolErrorResult("invalid_request", "messageId and body are required", 400, nil)
 	}
 
-	token, err := requireOAuthBearer(ctx)
-	if err != nil {
-		return toolErrorResult("unauthorized", err.Error(), 401, nil)
+	deps, res, err := loadCommSendDependencies(ctx, "email")
+	if res != nil || err != nil {
+		return res, err
 	}
-
-	identity, err := whoamiChannelsPayload(ctx, token)
-	if err != nil {
-		return identityToolResultFromError(err)
-	}
-	agentID, _ := identity["agentId"].(string)
-	agentID = strings.TrimSpace(agentID)
-	if agentID == "" {
-		return toolErrorResult("upstream_error", "unable to resolve agentId", 502, nil)
-	}
-
-	client, err := soulapi.Default()
-	if err != nil {
-		return toolErrorResult("not_configured", err.Error(), 500, nil)
-	}
-
-	advisory := commBoundaryAdvisoryForEmail(ctx, client, agentID)
 
 	body := map[string]any{
-		"channel":   "email",
-		"agentId":   agentID,
 		"body":      in.Body,
 		"inReplyTo": in.MessageID,
 		"replyAll":  in.ReplyAll,
 	}
 
-	out, err := client.DoJSON(ctx, "POST", "/api/v1/soul/comm/send", nil, token, body)
+	normalized, err := sendOutboundComm(ctx, deps, "email", body)
 	if err != nil {
 		return commToolResultFromError(err)
 	}
-
-	normalized := normalizeCommSendResult(out, advisory)
-	_ = maybeHydrateCommStatus(ctx, client, token, normalized)
 	return toolJSONResult(normalized)
 }
 
@@ -192,46 +148,6 @@ func maybeHydrateCommStatus(ctx context.Context, client *soulapi.Client, bearerT
 	}
 	payload["delivery"] = m
 	return nil
-}
-
-func commBoundaryAdvisoryForEmail(ctx context.Context, client *soulapi.Client, agentID string) map[string]any {
-	if client == nil || strings.TrimSpace(agentID) == "" {
-		return nil
-	}
-
-	regAny, err := client.DoJSON(ctx, "GET", "/api/v1/soul/agents/"+url.PathEscape(strings.TrimSpace(agentID))+"/registration", nil, "", nil)
-	if err != nil {
-		return nil
-	}
-	reg, _ := regAny.(map[string]any)
-	boundaries, _ := reg["boundaries"].([]any)
-	if len(boundaries) == 0 {
-		return nil
-	}
-
-	relevant := make([]any, 0, len(boundaries))
-	for _, b := range boundaries {
-		m, _ := b.(map[string]any)
-		category, _ := m["category"].(string)
-		category = strings.ToLower(strings.TrimSpace(category))
-		if category != "communication_policy" {
-			continue
-		}
-		channel, _ := m["channel"].(string)
-		channel = strings.ToLower(strings.TrimSpace(channel))
-		if channel != "" && channel != "email" {
-			continue
-		}
-		relevant = append(relevant, m)
-	}
-
-	if len(relevant) == 0 {
-		return nil
-	}
-
-	return map[string]any{
-		"communicationPolicyBoundaries": relevant,
-	}
 }
 
 func normalizeStringSlice(in []string) []string {

--- a/internal/mcpserver/identity_verify_tools.go
+++ b/internal/mcpserver/identity_verify_tools.go
@@ -1,0 +1,386 @@
+package mcpserver
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/url"
+	"strings"
+
+	"github.com/equaltoai/lesser-body/internal/lesserapi"
+	"github.com/equaltoai/lesser-body/internal/soulapi"
+	mcpruntime "github.com/theory-cloud/apptheory/runtime/mcp"
+)
+
+type verificationMarkers struct {
+	agentIDs map[string]bool
+	emails   map[string]bool
+	phones   map[string]bool
+	ensNames map[string]bool
+}
+
+func handleIdentityVerify(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
+	var in struct {
+		Channel    string `json:"channel"`
+		Identifier string `json:"identifier"`
+		MessageID  string `json:"messageId,omitempty"`
+	}
+	if err := json.Unmarshal(args, &in); err != nil {
+		return toolErrorResult("invalid_request", "invalid args: "+err.Error(), 400, nil)
+	}
+
+	in.Channel = strings.ToLower(strings.TrimSpace(in.Channel))
+	in.Identifier = strings.TrimSpace(in.Identifier)
+	in.MessageID = strings.TrimSpace(in.MessageID)
+	if in.Channel != "ens" && in.Channel != "email" && in.Channel != "phone" {
+		return toolErrorResult("invalid_request", "channel must be one of ens, email, or phone", 400, nil)
+	}
+	if in.Identifier == "" {
+		return toolErrorResult("invalid_request", "identifier is required", 400, nil)
+	}
+
+	client, err := soulapi.Default()
+	if err != nil {
+		return toolErrorResult("not_configured", err.Error(), 500, nil)
+	}
+
+	resolvedIdentifier := normalizeVerificationIdentifier(in.Channel, in.Identifier)
+	if resolvedIdentifier == "" {
+		return toolErrorResult("invalid_request", "identifier format is invalid for the selected channel", 400, nil)
+	}
+	agent, channelsPayload, err := resolveIdentityForVerification(ctx, client, in.Channel, resolvedIdentifier)
+	if err != nil {
+		return identityToolResultFromError(err)
+	}
+
+	agentID := normalizeSoulAgentID(stringFromMap(agent, "agent_id"))
+	if agentID == "" {
+		return toolErrorResult("upstream_error", "resolved identity missing agent_id", 502, nil)
+	}
+
+	result := map[string]any{
+		"channel":           in.Channel,
+		"identifier":        resolvedIdentifier,
+		"verificationScope": "identifier",
+		"identityResolved":  true,
+		"verified":          true,
+		"agent":             summarizeResolvedAgent(agent),
+		"channels":          mapOrEmpty(channelsPayload, "channels"),
+		"contactPreferences": func() any {
+			if v, ok := channelsPayload["contactPreferences"]; ok && v != nil {
+				return v
+			}
+			return map[string]any{}
+		}(),
+	}
+
+	if in.MessageID == "" {
+		return toolJSONResult(result)
+	}
+
+	token, err := requireOAuthBearer(ctx)
+	if err != nil {
+		return toolErrorResult("unauthorized", err.Error(), 401, nil)
+	}
+
+	notification, err := findCommunicationNotification(ctx, token, in.MessageID)
+	if err != nil {
+		return identityVerifyNotificationResultFromError(err)
+	}
+
+	result["verificationScope"] = "message"
+	result["messageId"] = in.MessageID
+	if notification == nil {
+		result["verified"] = false
+		result["messageFound"] = false
+		result["reason"] = "message_not_found"
+		return toolJSONResult(result)
+	}
+
+	from := commFrom(notification)
+	match, matchedBy := verifySenderAgainstResolvedIdentity(agentID, in.Channel, resolvedIdentifier, channelsPayload, from)
+	result["messageFound"] = true
+	result["verified"] = match
+	result["message"] = map[string]any{
+		"messageId":      firstNonEmpty(in.MessageID, commMessageID(notification)),
+		"notificationId": strings.TrimSpace(stringFromMap(notification, "id")),
+		"channel":        notificationChannel(notification),
+		"from":           from,
+		"to":             commTo(notification),
+		"subject":        commSubject(notification),
+		"body":           commBody(notification),
+		"receivedAt":     commReceivedAt(notification),
+	}
+	if match {
+		result["matchedBy"] = matchedBy
+		return toolJSONResult(result)
+	}
+
+	result["reason"] = "sender_does_not_match_resolved_identity"
+	return toolJSONResult(result)
+}
+
+func resolveIdentityForVerification(ctx context.Context, client *soulapi.Client, channel string, identifier string) (map[string]any, map[string]any, error) {
+	if client == nil {
+		return nil, nil, errors.New("soul api client is nil")
+	}
+
+	resolvePath := "/api/v1/soul/resolve/email/" + url.PathEscape(identifier)
+	switch channel {
+	case "ens":
+		resolvePath = "/api/v1/soul/resolve/ens/" + url.PathEscape(identifier)
+	case "phone":
+		resolvePath = "/api/v1/soul/resolve/phone/" + url.PathEscape(identifier)
+	}
+
+	resolvedAny, err := client.DoJSON(ctx, "GET", resolvePath, nil, "", nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	resolved, _ := resolvedAny.(map[string]any)
+	agent, _ := resolved["agent"].(map[string]any)
+	if agent == nil {
+		return nil, nil, errors.New("unexpected resolve response")
+	}
+
+	agentID := normalizeSoulAgentID(stringFromMap(agent, "agent_id"))
+	if agentID == "" {
+		return nil, nil, errors.New("unexpected resolve response")
+	}
+
+	channelsAny, err := client.DoJSON(ctx, "GET", "/api/v1/soul/agents/"+url.PathEscape(agentID)+"/channels", nil, "", nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	channelsPayload, _ := channelsAny.(map[string]any)
+	if channelsPayload == nil {
+		channelsPayload = map[string]any{}
+	}
+	return agent, channelsPayload, nil
+}
+
+func summarizeResolvedAgent(agent map[string]any) map[string]any {
+	return map[string]any{
+		"agentId": normalizeSoulAgentID(stringFromMap(agent, "agent_id")),
+		"domain":  stringFromMap(agent, "domain"),
+		"localId": stringFromMap(agent, "local_id"),
+		"status":  stringFromMap(agent, "status"),
+	}
+}
+
+func findCommunicationNotification(ctx context.Context, bearerToken string, messageID string) (map[string]any, error) {
+	messageID = strings.TrimSpace(messageID)
+	if messageID == "" {
+		return nil, nil
+	}
+
+	if _, err := lesserapi.Default(); err != nil {
+		return nil, err
+	}
+
+	for _, direction := range []string{"inbound", "outbound"} {
+		items, _, err := readCommNotifications(ctx, bearerToken, direction, 200, "")
+		if err != nil {
+			return nil, err
+		}
+		for _, item := range items {
+			n, _ := item.(map[string]any)
+			if n == nil {
+				continue
+			}
+			if strings.TrimSpace(stringFromMap(n, "id")) == messageID || commMessageID(n) == messageID {
+				return n, nil
+			}
+		}
+	}
+
+	return nil, nil
+}
+
+func verifySenderAgainstResolvedIdentity(agentID string, channel string, identifier string, channelsPayload map[string]any, from map[string]any) (bool, string) {
+	expected := resolvedVerificationMarkers(agentID, channel, identifier, mapOrEmpty(channelsPayload, "channels"))
+	actual := senderVerificationMarkers(from)
+
+	if overlapKey(expected.agentIDs, actual.agentIDs) != "" {
+		return true, "sender.agentId"
+	}
+	if overlapKey(expected.emails, actual.emails) != "" {
+		return true, "sender.email"
+	}
+	if overlapKey(expected.phones, actual.phones) != "" {
+		return true, "sender.phone"
+	}
+	if overlapKey(expected.ensNames, actual.ensNames) != "" {
+		return true, "sender.ens"
+	}
+	return false, ""
+}
+
+func resolvedVerificationMarkers(agentID string, channel string, identifier string, channels map[string]any) verificationMarkers {
+	out := newVerificationMarkers()
+	out.addAgentID(agentID)
+
+	email, _ := channels["email"].(map[string]any)
+	out.addEmail(stringFromMap(email, "address"))
+	phone, _ := channels["phone"].(map[string]any)
+	out.addPhone(stringFromMap(phone, "number"))
+	ens, _ := channels["ens"].(map[string]any)
+	out.addENS(stringFromMap(ens, "name"))
+
+	switch channel {
+	case "email":
+		out.addEmail(identifier)
+	case "phone":
+		out.addPhone(identifier)
+	case "ens":
+		out.addENS(identifier)
+	}
+	return out
+}
+
+func senderVerificationMarkers(from map[string]any) verificationMarkers {
+	out := newVerificationMarkers()
+	if from == nil {
+		return out
+	}
+
+	for _, key := range []string{"soulAgentId", "soul_agent_id", "agentId", "agent_id"} {
+		out.addAgentID(stringFromMap(from, key))
+	}
+	for _, key := range []string{"address", "email", "identifier", "name"} {
+		value := stringFromMap(from, key)
+		out.addEmail(value)
+		out.addPhone(value)
+		out.addENS(value)
+	}
+	for _, key := range []string{"number", "phone"} {
+		out.addPhone(stringFromMap(from, key))
+	}
+	for _, key := range []string{"ens"} {
+		out.addENS(stringFromMap(from, key))
+	}
+
+	return out
+}
+
+func newVerificationMarkers() verificationMarkers {
+	return verificationMarkers{
+		agentIDs: map[string]bool{},
+		emails:   map[string]bool{},
+		phones:   map[string]bool{},
+		ensNames: map[string]bool{},
+	}
+}
+
+func (m verificationMarkers) addAgentID(value string) {
+	if normalized := normalizeSoulAgentID(value); normalized != "" {
+		m.agentIDs[normalized] = true
+	}
+}
+
+func (m verificationMarkers) addEmail(value string) {
+	if normalized := normalizeVerificationEmail(value); normalized != "" {
+		m.emails[normalized] = true
+	}
+}
+
+func (m verificationMarkers) addPhone(value string) {
+	if normalized := normalizeVerificationPhone(value); normalized != "" {
+		m.phones[normalized] = true
+	}
+}
+
+func (m verificationMarkers) addENS(value string) {
+	if normalized := normalizeVerificationENS(value); normalized != "" {
+		m.ensNames[normalized] = true
+	}
+}
+
+func normalizeVerificationIdentifier(channel string, value string) string {
+	switch channel {
+	case "email":
+		return normalizeVerificationEmail(value)
+	case "phone":
+		return normalizeVerificationPhone(value)
+	case "ens":
+		return normalizeVerificationENS(value)
+	default:
+		return strings.TrimSpace(value)
+	}
+}
+
+func normalizeVerificationEmail(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	if strings.Count(value, "@") != 1 {
+		return ""
+	}
+	return value
+}
+
+func normalizeVerificationPhone(value string) string {
+	value = normalizeCommPhoneE164(value)
+	if value == "" || !strings.HasPrefix(value, "+") {
+		return ""
+	}
+	return value
+}
+
+func normalizeVerificationENS(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	value = strings.TrimSuffix(value, ".")
+	if !strings.HasSuffix(value, ".eth") {
+		return ""
+	}
+	return value
+}
+
+func overlapKey(a map[string]bool, b map[string]bool) string {
+	for key := range a {
+		if b[key] {
+			return key
+		}
+	}
+	return ""
+}
+
+func mapOrEmpty(m map[string]any, key string) map[string]any {
+	if m == nil {
+		return map[string]any{}
+	}
+	if child, ok := m[key].(map[string]any); ok && child != nil {
+		return child
+	}
+	return map[string]any{}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func identityVerifyNotificationResultFromError(err error) (*mcpruntime.ToolResult, error) {
+	if err == nil {
+		return toolErrorResult("upstream_error", "error", 500, nil)
+	}
+
+	var apiErr *lesserapi.APIError
+	if errors.As(err, &apiErr) {
+		code := identityErrorCodeForStatus(apiErr.Status)
+		message, parsed := commExtractAPIErrorMessage(apiErr.Body)
+		details := map[string]any{}
+		if parsed != nil {
+			details["apiError"] = parsed
+		}
+		return toolErrorResult(code, message, apiErr.Status, details)
+	}
+
+	if strings.Contains(strings.ToLower(err.Error()), "LESSER_API_BASE_URL") || strings.Contains(strings.ToLower(err.Error()), "MCP_ENDPOINT") {
+		return toolErrorResult("not_configured", err.Error(), 500, nil)
+	}
+
+	return toolErrorResult("upstream_error", err.Error(), 0, nil)
+}

--- a/internal/mcpserver/outbound_comm_tools.go
+++ b/internal/mcpserver/outbound_comm_tools.go
@@ -1,0 +1,291 @@
+package mcpserver
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/url"
+	"strings"
+
+	"github.com/equaltoai/lesser-body/internal/auth"
+	"github.com/equaltoai/lesser-body/internal/soulapi"
+	mcpruntime "github.com/theory-cloud/apptheory/runtime/mcp"
+)
+
+type commSendDependencies struct {
+	agentID    string
+	client     *soulapi.Client
+	commBearer string
+	advisory   map[string]any
+}
+
+func handleSmsSend(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
+	var in struct {
+		To        string `json:"to"`
+		Body      string `json:"body"`
+		MessageID string `json:"messageId,omitempty"`
+		InReplyTo string `json:"inReplyTo,omitempty"`
+	}
+	if err := json.Unmarshal(args, &in); err != nil {
+		return toolErrorResult("invalid_request", "invalid args: "+err.Error(), 400, nil)
+	}
+
+	in.To = normalizeCommPhoneE164(in.To)
+	in.Body = strings.TrimSpace(in.Body)
+	replyRef, err := resolveCommReplyReference(in.MessageID, in.InReplyTo)
+	if err != nil {
+		return toolErrorResult("invalid_request", err.Error(), 400, nil)
+	}
+	if in.To == "" || in.Body == "" {
+		return toolErrorResult("invalid_request", "to and body are required", 400, nil)
+	}
+
+	deps, res, err := loadCommSendDependencies(ctx, "sms")
+	if res != nil || err != nil {
+		return res, err
+	}
+
+	body := map[string]any{
+		"to":   in.To,
+		"body": in.Body,
+	}
+	if replyRef != "" {
+		body["inReplyTo"] = replyRef
+	}
+
+	normalized, err := sendOutboundComm(ctx, deps, "sms", body)
+	if err != nil {
+		return commToolResultFromError(err)
+	}
+	if replyRef != "" {
+		normalized["inReplyTo"] = replyRef
+	}
+	return toolJSONResult(normalized)
+}
+
+func handlePhoneCall(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
+	var in struct {
+		To                 string `json:"to"`
+		Purpose            string `json:"purpose"`
+		MaxDurationMinutes int    `json:"maxDurationMinutes,omitempty"`
+		MessageID          string `json:"messageId,omitempty"`
+		InReplyTo          string `json:"inReplyTo,omitempty"`
+	}
+	if err := json.Unmarshal(args, &in); err != nil {
+		return toolErrorResult("invalid_request", "invalid args: "+err.Error(), 400, nil)
+	}
+
+	in.To = normalizeCommPhoneE164(in.To)
+	in.Purpose = strings.TrimSpace(in.Purpose)
+	replyRef, err := resolveCommReplyReference(in.MessageID, in.InReplyTo)
+	if err != nil {
+		return toolErrorResult("invalid_request", err.Error(), 400, nil)
+	}
+	if in.To == "" || in.Purpose == "" {
+		return toolErrorResult("invalid_request", "to and purpose are required", 400, nil)
+	}
+
+	deps, res, err := loadCommSendDependencies(ctx, "voice")
+	if res != nil || err != nil {
+		return res, err
+	}
+
+	body := map[string]any{
+		"to":   in.To,
+		"body": in.Purpose,
+	}
+	if replyRef != "" {
+		body["inReplyTo"] = replyRef
+	}
+
+	normalized, err := sendOutboundComm(ctx, deps, "voice", body)
+	if err != nil {
+		if isUnsupportedVoiceGap(err) {
+			return voiceGapToolResult(err)
+		}
+		return commToolResultFromError(err)
+	}
+
+	normalized["purpose"] = in.Purpose
+	normalized["requestedMaxDurationMinutes"] = in.MaxDurationMinutes
+	normalized["maxDurationEnforcedByHost"] = false
+	if replyRef != "" {
+		normalized["inReplyTo"] = replyRef
+	}
+	return toolJSONResult(normalized)
+}
+
+func loadCommSendDependencies(ctx context.Context, channel string) (*commSendDependencies, *mcpruntime.ToolResult, error) {
+	oauthToken, err := requireOAuthBearer(ctx)
+	if err != nil {
+		res, resErr := toolErrorResult("unauthorized", err.Error(), 401, nil)
+		return nil, res, resErr
+	}
+
+	identity, err := whoamiChannelsPayload(ctx, oauthToken)
+	if err != nil {
+		res, resErr := identityToolResultFromError(err)
+		return nil, res, resErr
+	}
+
+	agentID, _ := identity["agentId"].(string)
+	agentID = strings.TrimSpace(agentID)
+	if agentID == "" {
+		res, resErr := toolErrorResult("upstream_error", "unable to resolve agentId", 502, nil)
+		return nil, res, resErr
+	}
+
+	client, err := soulapi.Default()
+	if err != nil {
+		res, resErr := toolErrorResult("not_configured", err.Error(), 500, nil)
+		return nil, res, resErr
+	}
+
+	commBearer, err := requireCommAPIBearer(ctx)
+	if err != nil {
+		res, resErr := toolErrorResult("not_configured", err.Error(), 500, map[string]any{
+			"requiredEnv": []string{"LESSER_HOST_INSTANCE_KEY", "LESSER_HOST_INSTANCE_KEY_ARN"},
+		})
+		return nil, res, resErr
+	}
+
+	return &commSendDependencies{
+		agentID:    agentID,
+		client:     client,
+		commBearer: commBearer,
+		advisory:   commBoundaryAdvisoryForChannel(ctx, client, agentID, channel),
+	}, nil, nil
+}
+
+func requireCommAPIBearer(ctx context.Context) (string, error) {
+	token, err := auth.LesserHostInstanceKey(ctx)
+	if err != nil {
+		return "", err
+	}
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return "", errors.New("LESSER_HOST_INSTANCE_KEY is required for outbound communication")
+	}
+	return token, nil
+}
+
+func sendOutboundComm(ctx context.Context, deps *commSendDependencies, channel string, body map[string]any) (map[string]any, error) {
+	if deps == nil || deps.client == nil {
+		return nil, errors.New("outbound communication dependencies not initialized")
+	}
+
+	payload := map[string]any{
+		"channel": channel,
+		"agentId": deps.agentID,
+	}
+	for key, value := range body {
+		payload[key] = value
+	}
+
+	out, err := deps.client.DoJSON(ctx, "POST", "/api/v1/soul/comm/send", nil, deps.commBearer, payload)
+	if err != nil {
+		return nil, err
+	}
+
+	normalized := normalizeCommSendResult(out, deps.advisory)
+	_ = maybeHydrateCommStatus(ctx, deps.client, deps.commBearer, normalized)
+	return normalized, nil
+}
+
+func commBoundaryAdvisoryForChannel(ctx context.Context, client *soulapi.Client, agentID string, channel string) map[string]any {
+	if client == nil || strings.TrimSpace(agentID) == "" {
+		return nil
+	}
+
+	regAny, err := client.DoJSON(ctx, "GET", "/api/v1/soul/agents/"+url.PathEscape(strings.TrimSpace(agentID))+"/registration", nil, "", nil)
+	if err != nil {
+		return nil
+	}
+	reg, _ := regAny.(map[string]any)
+	boundaries, _ := reg["boundaries"].([]any)
+	if len(boundaries) == 0 {
+		return nil
+	}
+
+	channel = strings.ToLower(strings.TrimSpace(channel))
+	relevant := make([]any, 0, len(boundaries))
+	for _, boundary := range boundaries {
+		m, _ := boundary.(map[string]any)
+		category, _ := m["category"].(string)
+		if strings.ToLower(strings.TrimSpace(category)) != "communication_policy" {
+			continue
+		}
+
+		boundaryChannel, _ := m["channel"].(string)
+		boundaryChannel = strings.ToLower(strings.TrimSpace(boundaryChannel))
+		if boundaryChannel != "" && boundaryChannel != channel {
+			continue
+		}
+		relevant = append(relevant, m)
+	}
+	if len(relevant) == 0 {
+		return nil
+	}
+
+	return map[string]any{
+		"communicationPolicyBoundaries": relevant,
+	}
+}
+
+func normalizeCommPhoneE164(raw string) string {
+	raw = strings.TrimSpace(raw)
+	raw = strings.ReplaceAll(raw, " ", "")
+	raw = strings.ReplaceAll(raw, "-", "")
+	raw = strings.ReplaceAll(raw, "(", "")
+	raw = strings.ReplaceAll(raw, ")", "")
+	raw = strings.ReplaceAll(raw, ".", "")
+	return raw
+}
+
+func resolveCommReplyReference(messageID string, inReplyTo string) (string, error) {
+	messageID = strings.TrimSpace(messageID)
+	inReplyTo = strings.TrimSpace(inReplyTo)
+	switch {
+	case messageID != "" && inReplyTo != "" && messageID != inReplyTo:
+		return "", errors.New("messageId and inReplyTo must match when both are provided")
+	case inReplyTo != "":
+		return inReplyTo, nil
+	default:
+		return messageID, nil
+	}
+}
+
+func isUnsupportedVoiceGap(err error) bool {
+	var apiErr *soulapi.APIError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	if apiErr.Status != 503 {
+		return false
+	}
+	message, _ := commExtractAPIErrorMessage(apiErr.Body)
+	return strings.Contains(strings.ToLower(message), "channel not supported")
+}
+
+func voiceGapToolResult(err error) (*mcpruntime.ToolResult, error) {
+	var apiErr *soulapi.APIError
+	if !errors.As(err, &apiErr) {
+		return commToolResultFromError(err)
+	}
+
+	message, parsed := commExtractAPIErrorMessage(apiErr.Body)
+	if strings.TrimSpace(message) == "" {
+		message = "lesser-host does not yet support outbound voice calls"
+	}
+
+	details := map[string]any{
+		"gap":             "outbound_voice_not_supported",
+		"channel":         "voice",
+		"upstreamMessage": message,
+	}
+	if parsed != nil {
+		details["apiError"] = parsed
+	}
+
+	return toolErrorResult("host_gap", "lesser-host does not yet support outbound voice calls for soul communication", apiErr.Status, details)
+}


### PR DESCRIPTION
## Summary
- implement `sms_send`, `phone_call`, and `identity_verify` in lesser-body
- route outbound comm through the managed lesser-host instance key while preserving agent-context reads via OAuth
- add tests and MCP docs for the communication/identity surfaces, including the legacy voice-gap fallback for older hosts

## Details
- add shared outbound comm helpers for email/SMS/voice sends and status hydration
- wire `phone_call` to the host comm API so it succeeds against lesser-host `v0.1.6+`
- keep a structured `host_gap` fallback for older host versions that still reject outbound voice
- implement `identity_verify` using soul resolve endpoints plus notification provenance matching
- update prompts so inbound reply flows pass `messageId` as the thread reference

## Verification
- `go test ./...`
