### PR TITLE
Fix JWT secret KMS access for lesser-body MCP auth

### DIFF
--- a/cdk/stacks/lesser_body_stack.go
+++ b/cdk/stacks/lesser_body_stack.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-cdk-go/awscdk/v2/awsiam"
 	"github.com/aws/aws-cdk-go/awscdk/v2/awslambda"
 	"github.com/aws/aws-cdk-go/awscdk/v2/awslogs"
+	"github.com/aws/aws-cdk-go/awscdk/v2/awssecretsmanager"
 	"github.com/aws/aws-cdk-go/awscdk/v2/awsssm"
 	"github.com/aws/constructs-go/constructs/v10"
 	"github.com/aws/jsii-runtime-go"
@@ -60,14 +61,12 @@ func NewLesserBodyStack(scope constructs.Construct, id string, props *LesserBody
 		jsii.String(jwtSecretArnParamName),
 	)
 	handler.AddEnvironment(jsii.String("JWT_SECRET_ARN"), jwtSecretArnParam.StringValue(), nil)
-	handler.AddToRolePolicy(awsiam.NewPolicyStatement(&awsiam.PolicyStatementProps{
-		Actions: &[]*string{
-			jsii.String("secretsmanager:GetSecretValue"),
-		},
-		Resources: &[]*string{
-			jwtSecretArnParam.StringValue(),
-		},
-	}))
+	jwtSecret := awssecretsmanager.Secret_FromSecretCompleteArn(
+		stack,
+		jsii.String("ImportedJWTSecret"),
+		jwtSecretArnParam.StringValue(),
+	)
+	jwtSecret.GrantRead(handler, nil)
 
 	mcpProps := &apptheorycdk.AppTheoryRemoteMcpServerProps{
 		Handler:            handler,


### PR DESCRIPTION
## Summary
- import the shared JWT secret as a Secrets Manager secret in the lesser-body CDK stack
- grant the MCP Lambda read access via `GrantRead(...)` instead of manually granting only `secretsmanager:GetSecretValue`
- preserve the existing `JWT_SECRET_ARN` env wiring while fixing the missing KMS-backed secret access

## Why
Live investigation for #8 showed `lesser-body` was failing JWT auth because the MCP Lambda role could call Secrets Manager but could not decrypt the JWT secret CMK. That caused valid delegated Lesser JWTs to fail with `app.unauthorized` at `/mcp`.

## Verification
- `go test ./...`
- `cdk: go test . ./stacks`

Closes #8.