### PR TITLE
Fall back to Lesser base URL for soul API calls

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -59,6 +59,9 @@ Variables:
 - `LESSER_API_BASE_URL` (string, optional)
   - Base URL used by social tools when calling the Lesser REST API (for example: `https://api.dev.example.com`).
   - If not set, it is derived from `MCP_ENDPOINT` by stripping `/mcp`.
+- `LESSER_SOUL_API_BASE_URL` (string, optional)
+  - Base URL used by identity and communication tools when calling the soul API (for example: `https://api.dev.example.com`).
+  - If not set, it falls back to `LESSER_API_BASE_URL`, then to `MCP_ENDPOINT` with `/mcp` stripped.
 - `LESSER_API_TIMEOUT_SECONDS` (string, optional)
   - HTTP timeout for Lesser API calls (default: `10`).
 
@@ -102,4 +105,3 @@ Published by this repo’s CDK stack:
   - Convenience value intended to equal `https://api.<stageDomain>/mcp`.
 - `/<app>/<stage>/lesser-body/exports/v1/mcp_session_table_name`
   - Session table name (if provisioned).
-

--- a/internal/mcpapp/identity_surfaces_test.go
+++ b/internal/mcpapp/identity_surfaces_test.go
@@ -97,7 +97,6 @@ func TestLBM1_IdentityToolsAndChannelResources(t *testing.T) {
 	}))
 	defer server.Close()
 
-	t.Setenv("LESSER_SOUL_API_BASE_URL", server.URL)
 	t.Setenv("LESSER_API_BASE_URL", server.URL)
 	lesserapi.ResetForTests()
 	soulapi.ResetForTests()

--- a/internal/soulapi/client.go
+++ b/internal/soulapi/client.go
@@ -16,8 +16,10 @@ import (
 )
 
 const (
-	envBaseURL  = "LESSER_SOUL_API_BASE_URL"
-	envTimeoutS = "LESSER_SOUL_API_TIMEOUT_SECONDS"
+	envBaseURL      = "LESSER_SOUL_API_BASE_URL"
+	envLesserAPIURL = "LESSER_API_BASE_URL"
+	envMcpURL       = "MCP_ENDPOINT"
+	envTimeoutS     = "LESSER_SOUL_API_TIMEOUT_SECONDS"
 )
 
 type Client struct {
@@ -159,11 +161,24 @@ func (c *Client) DoJSON(ctx context.Context, method string, path string, query u
 }
 
 func resolveBaseURL() (*url.URL, error) {
-	raw := strings.TrimSpace(os.Getenv(envBaseURL))
-	if raw == "" {
-		return nil, fmt.Errorf("%s is required", envBaseURL)
+	if raw := strings.TrimSpace(os.Getenv(envBaseURL)); raw != "" {
+		return parseBaseURL(raw)
 	}
-	return parseBaseURL(raw)
+	if raw := strings.TrimSpace(os.Getenv(envLesserAPIURL)); raw != "" {
+		return parseBaseURL(raw)
+	}
+	if raw := strings.TrimSpace(os.Getenv(envMcpURL)); raw != "" {
+		u, err := parseBaseURL(raw)
+		if err != nil {
+			return nil, err
+		}
+		u.Path = strings.TrimSuffix(u.Path, "/mcp")
+		if u.Path == "/mcp" {
+			u.Path = ""
+		}
+		return u, nil
+	}
+	return nil, fmt.Errorf("%s, %s, or %s is required", envBaseURL, envLesserAPIURL, envMcpURL)
 }
 
 func parseBaseURL(raw string) (*url.URL, error) {

--- a/internal/soulapi/client_test.go
+++ b/internal/soulapi/client_test.go
@@ -1,0 +1,45 @@
+package soulapi
+
+import "testing"
+
+func TestResolveBaseURL_PrefersExplicitSoulBaseURL(t *testing.T) {
+	t.Setenv(envBaseURL, "https://soul.example.com")
+	t.Setenv(envLesserAPIURL, "https://api.example.com")
+	t.Setenv(envMcpURL, "https://api.example.com/mcp")
+
+	u, err := resolveBaseURL()
+	if err != nil {
+		t.Fatalf("resolveBaseURL: %v", err)
+	}
+	if got := u.String(); got != "https://soul.example.com" {
+		t.Fatalf("expected explicit soul base url, got %q", got)
+	}
+}
+
+func TestResolveBaseURL_FallsBackToLesserAPIBaseURL(t *testing.T) {
+	t.Setenv(envBaseURL, "")
+	t.Setenv(envLesserAPIURL, "https://api.example.com")
+	t.Setenv(envMcpURL, "")
+
+	u, err := resolveBaseURL()
+	if err != nil {
+		t.Fatalf("resolveBaseURL: %v", err)
+	}
+	if got := u.String(); got != "https://api.example.com" {
+		t.Fatalf("expected lesser api base url fallback, got %q", got)
+	}
+}
+
+func TestResolveBaseURL_FallsBackToMcpEndpoint(t *testing.T) {
+	t.Setenv(envBaseURL, "")
+	t.Setenv(envLesserAPIURL, "")
+	t.Setenv(envMcpURL, "https://api.example.com/mcp")
+
+	u, err := resolveBaseURL()
+	if err != nil {
+		t.Fatalf("resolveBaseURL: %v", err)
+	}
+	if got := u.String(); got != "https://api.example.com" {
+		t.Fatalf("expected mcp endpoint fallback, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- let soul API calls fall back from `LESSER_SOUL_API_BASE_URL` to `LESSER_API_BASE_URL` or `MCP_ENDPOINT`
- cover the fallback behavior with unit and MCP identity-surface tests
- document the fallback in the configuration reference

## Verification
- go test ./...