### PR TITLE
Grant managed instance-key secret access to MCP

### DIFF
--- a/cdk/stacks/lesser_body_stack.go
+++ b/cdk/stacks/lesser_body_stack.go
@@ -82,6 +82,25 @@ func NewLesserBodyStack(scope constructs.Construct, id string, props *LesserBody
 		},
 	}))
 
+	// Managed lesser-host stores the instance key in the instance account under
+	// a stable secret name: <app>/instance-key. The runtime resolves the exact
+	// ARN from TRUST_CONFIG, so the Lambda only needs permission to read the
+	// matching secret resource in this account.
+	handler.AddToRolePolicy(awsiam.NewPolicyStatement(&awsiam.PolicyStatementProps{
+		Actions: &[]*string{
+			jsii.String("secretsmanager:GetSecretValue"),
+			jsii.String("secretsmanager:DescribeSecret"),
+		},
+		Resources: &[]*string{
+			stack.FormatArn(&awscdk.ArnComponents{
+				Service:      jsii.String("secretsmanager"),
+				Resource:     jsii.String("secret"),
+				ArnFormat:    awscdk.ArnFormat_COLON_RESOURCE_NAME,
+				ResourceName: jsii.String(fmt.Sprintf("%s/instance-key*", appName)),
+			}),
+		},
+	}))
+
 	mcpProps := &apptheorycdk.AppTheoryRemoteMcpServerProps{
 		Handler: handler,
 		ApiName: jsii.String(fmt.Sprintf("%s-%s-mcp", appName, stage)),


### PR DESCRIPTION
## Summary
Add the missing CDK IAM grant that lets the lesser-body MCP Lambda read the managed lesser-host instance key secret from Secrets Manager.

## Why
Outbound communication tools (`email_send`, `sms_send`, `phone_call`) resolve the managed instance key from `TRUST_CONFIG.instanceKeySecretARN`. The deployed Lambda role currently lacks `secretsmanager:GetSecretValue` / `DescribeSecret` on the managed `<app>/instance-key` secret, so comm tools fail with `AccessDeniedException`.

## Changes
- add a scoped Secrets Manager policy for `secret:<app>/instance-key*`
- use `ArnFormat_COLON_RESOURCE_NAME` so the generated ARN matches real Secrets Manager secret ARNs

## Verification
- `cd cdk && go test . ./stacks`
- live IAM simulation before the fix showed `implicitDeny` for the MCP Lambda role on `simulacrum/instance-key`
