### PR TITLE
Fix MCP comm contracts and gateway paths

### DIFF
--- a/internal/lambdaentry/apigw.go
+++ b/internal/lambdaentry/apigw.go
@@ -57,6 +57,7 @@ func requestFromAPIGatewayProxy(event events.APIGatewayProxyRequest) apptheory.R
 	if path == "" {
 		path = event.RequestContext.Path
 	}
+	path = normalizeGatewayPath(path)
 
 	method := event.HTTPMethod
 	if method == "" {
@@ -70,6 +71,18 @@ func requestFromAPIGatewayProxy(event events.APIGatewayProxyRequest) apptheory.R
 		Headers:  headersFromProxyEvent(event.Headers, event.MultiValueHeaders),
 		Body:     []byte(event.Body),
 		IsBase64: event.IsBase64Encoded,
+	}
+}
+
+func normalizeGatewayPath(path string) string {
+	path = strings.TrimSpace(path)
+	switch {
+	case path == "/mcp/" || strings.HasSuffix(path, "/mcp/"):
+		return strings.TrimSuffix(path, "/")
+	case path == "/.well-known/mcp.json/" || strings.HasSuffix(path, "/.well-known/mcp.json/"):
+		return strings.TrimSuffix(path, "/")
+	default:
+		return path
 	}
 }
 

--- a/internal/lambdaentry/apigw_test.go
+++ b/internal/lambdaentry/apigw_test.go
@@ -61,6 +61,44 @@ func TestNewAPIGatewayHandler_McpRouteReturnsStreamingResponseType(t *testing.T)
 	}
 }
 
+func TestNewAPIGatewayHandler_McpTrailingSlashPathNormalizes(t *testing.T) {
+	t.Setenv("MCP_SESSION_TABLE", "")
+	t.Setenv("JWT_SECRET", "test")
+	auth.ResetForTests()
+
+	app, err := mcpapp.New("test", "dev")
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+
+	handler := NewAPIGatewayHandler(app)
+	body, _ := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "initialize",
+	})
+
+	out, err := handler(context.Background(), events.APIGatewayProxyRequest{
+		HTTPMethod: "POST",
+		Path:       "/mcp/",
+		Headers: map[string]string{
+			"content-type": "application/json",
+		},
+		Body: string(body),
+	})
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+
+	streaming, ok := out.(*events.APIGatewayProxyStreamingResponse)
+	if !ok {
+		t.Fatalf("expected APIGatewayProxyStreamingResponse for /mcp/, got %T", out)
+	}
+	if streaming.StatusCode != 401 {
+		t.Fatalf("expected 401, got %d", streaming.StatusCode)
+	}
+}
+
 func TestNewAPIGatewayHandler_McpDeleteReturnsProxyResponseType(t *testing.T) {
 	t.Setenv("MCP_SESSION_TABLE", "")
 	t.Setenv("JWT_SECRET", "test")
@@ -108,6 +146,35 @@ func TestNewAPIGatewayHandler_WellKnownReturnsProxyResponseType(t *testing.T) {
 	proxy, ok := out.(events.APIGatewayProxyResponse)
 	if !ok {
 		t.Fatalf("expected APIGatewayProxyResponse for /.well-known/mcp.json, got %T", out)
+	}
+	if proxy.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d (%s)", proxy.StatusCode, proxy.Body)
+	}
+}
+
+func TestNewAPIGatewayHandler_WellKnownTrailingSlashNormalizes(t *testing.T) {
+	t.Setenv("MCP_SESSION_TABLE", "")
+	t.Setenv("JWT_SECRET", "test")
+	auth.ResetForTests()
+	t.Setenv("MCP_ENDPOINT", "https://api.example.com/mcp")
+
+	app, err := mcpapp.New("test", "dev")
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+
+	handler := NewAPIGatewayHandler(app)
+	out, err := handler(context.Background(), events.APIGatewayProxyRequest{
+		HTTPMethod: "GET",
+		Path:       "/.well-known/mcp.json/",
+	})
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+
+	proxy, ok := out.(events.APIGatewayProxyResponse)
+	if !ok {
+		t.Fatalf("expected APIGatewayProxyResponse for /.well-known/mcp.json/, got %T", out)
 	}
 	if proxy.StatusCode != 200 {
 		t.Fatalf("expected 200, got %d (%s)", proxy.StatusCode, proxy.Body)

--- a/internal/mcpapp/comm_contract_test.go
+++ b/internal/mcpapp/comm_contract_test.go
@@ -149,6 +149,23 @@ func TestLBM0_CommunicationToolSchemasMatchSpec(t *testing.T) {
 			t.Fatalf("email_send bcc.items.type: want string got %q", bccItemsType)
 		}
 		expectPropType(t, s, "replyTo", "string")
+		expectPropType(t, s, "messageId", "string")
+		expectPropType(t, s, "inReplyTo", "string")
+	}
+
+	{
+		s := mustSchema(t, toolsByName["email_reply"])
+		if s.Type != "object" {
+			t.Fatalf("email_reply schema type: want object got %q", s.Type)
+		}
+		if !reflect.DeepEqual(s.Required, []string{"messageId", "body"}) {
+			t.Fatalf("email_reply required: want [messageId body], got %#v", s.Required)
+		}
+		expectPropType(t, s, "messageId", "string")
+		expectPropType(t, s, "body", "string")
+		expectPropType(t, s, "to", "string")
+		expectPropType(t, s, "subject", "string")
+		expectPropType(t, s, "replyAll", "boolean")
 	}
 
 	{

--- a/internal/mcpapp/email_tools_test.go
+++ b/internal/mcpapp/email_tools_test.go
@@ -40,6 +40,20 @@ func TestLBM2_EmailSendAndReply_TalkToCommAPI(t *testing.T) {
 			_, _ = w.Write([]byte(`{"version":"1","agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-bob","status":"active"}}`))
 		case r.URL.Path == "/api/v1/soul/agents/"+agentID+"/registration":
 			_, _ = w.Write([]byte(`{"version":"3","channels":{},"contactPreferences":{},"boundaries":[{"id":"b1","category":"communication_policy","channel":"email","statement":"no unsolicited"}]}`))
+		case r.URL.Path == "/api/v1/notifications" && r.Method == http.MethodGet:
+			_, _ = w.Write([]byte(`[
+				{
+					"id":"notif-1",
+					"type":"communication:inbound",
+					"channel":"email",
+					"messageId":"comm-msg-000",
+					"from":{"address":"alice@example.com"},
+					"to":{"address":"agent-bob@lessersoul.ai"},
+					"subject":"Hello",
+					"body":"Original email",
+					"receivedAt":"2026-03-10T21:00:00Z"
+				}
+			]`))
 		case r.URL.Path == "/api/v1/soul/comm/send" && r.Method == http.MethodPost:
 			gotAuth = r.Header.Get("Authorization")
 			body, _ := io.ReadAll(r.Body)
@@ -87,9 +101,10 @@ func TestLBM2_EmailSendAndReply_TalkToCommAPI(t *testing.T) {
 		callParams, _ := json.Marshal(map[string]any{
 			"name": "email_send",
 			"arguments": map[string]any{
-				"to":      "alice@example.com",
-				"subject": "Hello",
-				"body":    "Hi there",
+				"to":        "alice@example.com",
+				"subject":   "Hello",
+				"body":      "Hi there",
+				"inReplyTo": "comm-msg-prev",
 			},
 		})
 		resp := invokeJSON(t, env, app, map[string][]string{
@@ -108,6 +123,9 @@ func TestLBM2_EmailSendAndReply_TalkToCommAPI(t *testing.T) {
 		if gotBody["to"] != "alice@example.com" || gotBody["subject"] != "Hello" || gotBody["body"] != "Hi there" {
 			t.Fatalf("unexpected comm api payload fields: %+v", gotBody)
 		}
+		if gotBody["inReplyTo"] != "comm-msg-prev" {
+			t.Fatalf("expected inReplyTo=comm-msg-prev, got %+v", gotBody)
+		}
 
 		var rpc mcpruntime.Response
 		_ = json.Unmarshal(resp.Body, &rpc)
@@ -122,6 +140,9 @@ func TestLBM2_EmailSendAndReply_TalkToCommAPI(t *testing.T) {
 		data, _ := out.StructuredContent["data"].(map[string]any)
 		if data["messageId"] != "comm-msg-001" || data["status"] != "sent" {
 			t.Fatalf("unexpected tool data: %+v", data)
+		}
+		if data["inReplyTo"] != "comm-msg-prev" {
+			t.Fatalf("expected tool data to include inReplyTo, got %+v", data)
 		}
 	}
 
@@ -150,6 +171,12 @@ func TestLBM2_EmailSendAndReply_TalkToCommAPI(t *testing.T) {
 		}
 		if gotBody["inReplyTo"] != "comm-msg-000" {
 			t.Fatalf("expected inReplyTo=comm-msg-000, got %+v", gotBody)
+		}
+		if gotBody["to"] != "alice@example.com" {
+			t.Fatalf("expected reply to original sender, got %+v", gotBody)
+		}
+		if gotBody["subject"] != "Re: Hello" {
+			t.Fatalf("expected derived reply subject, got %+v", gotBody)
 		}
 
 		var rpc mcpruntime.Response

--- a/internal/mcpapp/identity_surfaces_test.go
+++ b/internal/mcpapp/identity_surfaces_test.go
@@ -32,6 +32,7 @@ func TestLBM1_IdentityToolsAndChannelResources(t *testing.T) {
 
 	var gotBindingPK string
 	var gotBindingSK string
+	var searchQueries []string
 	soulbinding.SetDBFactoryForTests(func() (tablecore.DB, error) {
 		return &fakeTableTheoryDB{
 			firstFn: func(dest any, where map[string]any) error {
@@ -51,6 +52,7 @@ func TestLBM1_IdentityToolsAndChannelResources(t *testing.T) {
 		switch {
 		case r.URL.Path == "/api/v1/soul/search":
 			q := r.URL.Query().Get("q")
+			searchQueries = append(searchQueries, q)
 			if q == "agent-alice" {
 				_, _ = w.Write([]byte(`{"version":"1","results":[{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-alice"}],"count":1,"has_more":false}`))
 				return
@@ -180,7 +182,7 @@ func TestLBM1_IdentityToolsAndChannelResources(t *testing.T) {
 		}
 	}
 
-	// identity_lookup should resolve managed email/ENS by deriving localId and searching.
+	// identity_lookup should resolve managed email/ENS directly without stripping them to bare localIds.
 	for _, q := range []string{"agent-alice@lessersoul.ai", "agent-alice.lessersoul.eth"} {
 		callParams, _ := json.Marshal(map[string]any{
 			"name":      "identity_lookup",
@@ -213,6 +215,9 @@ func TestLBM1_IdentityToolsAndChannelResources(t *testing.T) {
 		if match["agentId"] != agentID {
 			t.Fatalf("identity_lookup(%q): agentId want %s got %v", q, agentID, match["agentId"])
 		}
+	}
+	if len(searchQueries) != 0 {
+		t.Fatalf("identity_lookup for managed identifiers should resolve directly, got search queries %+v", searchQueries)
 	}
 
 	// agent://channels + agent://channels/preferences should read successfully.

--- a/internal/mcpserver/comm_tools.go
+++ b/internal/mcpserver/comm_tools.go
@@ -54,7 +54,9 @@ func emailSendDef() mcpruntime.ToolDef {
 				"body":{"type":"string"},
 				"cc":{"type":"array","items":{"type":"string"}},
 				"bcc":{"type":"array","items":{"type":"string"}},
-				"replyTo":{"type":"string"}
+				"replyTo":{"type":"string"},
+				"messageId":{"type":"string"},
+				"inReplyTo":{"type":"string"}
 			},
 			"required":["to","subject","body"]
 		}`),
@@ -102,6 +104,8 @@ func emailReplyDef() mcpruntime.ToolDef {
 			"properties":{
 				"messageId":{"type":"string"},
 				"body":{"type":"string"},
+				"to":{"type":"string"},
+				"subject":{"type":"string"},
 				"replyAll":{"type":"boolean"}
 			},
 			"required":["messageId","body"]

--- a/internal/mcpserver/email_tools.go
+++ b/internal/mcpserver/email_tools.go
@@ -12,12 +12,14 @@ import (
 
 func handleEmailSend(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
 	var in struct {
-		To      string   `json:"to"`
-		Subject string   `json:"subject"`
-		Body    string   `json:"body"`
-		CC      []string `json:"cc,omitempty"`
-		BCC     []string `json:"bcc,omitempty"`
-		ReplyTo string   `json:"replyTo,omitempty"`
+		To        string   `json:"to"`
+		Subject   string   `json:"subject"`
+		Body      string   `json:"body"`
+		CC        []string `json:"cc,omitempty"`
+		BCC       []string `json:"bcc,omitempty"`
+		ReplyTo   string   `json:"replyTo,omitempty"`
+		MessageID string   `json:"messageId,omitempty"`
+		InReplyTo string   `json:"inReplyTo,omitempty"`
 	}
 	if err := json.Unmarshal(args, &in); err != nil {
 		return toolErrorResult("invalid_request", "invalid args: "+err.Error(), 400, nil)
@@ -26,6 +28,10 @@ func handleEmailSend(ctx context.Context, args json.RawMessage) (*mcpruntime.Too
 	in.Subject = strings.TrimSpace(in.Subject)
 	in.Body = strings.TrimSpace(in.Body)
 	in.ReplyTo = strings.TrimSpace(in.ReplyTo)
+	replyRef, err := resolveCommReplyReference(in.MessageID, in.InReplyTo)
+	if err != nil {
+		return toolErrorResult("invalid_request", err.Error(), 400, nil)
+	}
 	if in.To == "" || in.Subject == "" || in.Body == "" {
 		return toolErrorResult("invalid_request", "to, subject, and body are required", 400, nil)
 	}
@@ -52,10 +58,16 @@ func handleEmailSend(ctx context.Context, args json.RawMessage) (*mcpruntime.Too
 	if strings.TrimSpace(in.ReplyTo) == "" {
 		delete(body, "replyTo")
 	}
+	if replyRef != "" {
+		body["inReplyTo"] = replyRef
+	}
 
 	normalized, err := sendOutboundComm(ctx, deps, "email", body)
 	if err != nil {
 		return commToolResultFromError(err)
+	}
+	if replyRef != "" {
+		normalized["inReplyTo"] = replyRef
 	}
 	return toolJSONResult(normalized)
 }
@@ -64,6 +76,8 @@ func handleEmailReply(ctx context.Context, args json.RawMessage) (*mcpruntime.To
 	var in struct {
 		MessageID string `json:"messageId"`
 		Body      string `json:"body"`
+		To        string `json:"to,omitempty"`
+		Subject   string `json:"subject,omitempty"`
 		ReplyAll  bool   `json:"replyAll,omitempty"`
 	}
 	if err := json.Unmarshal(args, &in); err != nil {
@@ -71,8 +85,33 @@ func handleEmailReply(ctx context.Context, args json.RawMessage) (*mcpruntime.To
 	}
 	in.MessageID = strings.TrimSpace(in.MessageID)
 	in.Body = strings.TrimSpace(in.Body)
+	in.To = strings.TrimSpace(in.To)
+	in.Subject = strings.TrimSpace(in.Subject)
 	if in.MessageID == "" || in.Body == "" {
 		return toolErrorResult("invalid_request", "messageId and body are required", 400, nil)
+	}
+
+	if in.To == "" || in.Subject == "" {
+		bearerToken, err := requireOAuthBearer(ctx)
+		if err != nil {
+			return toolErrorResult("unauthorized", err.Error(), 401, nil)
+		}
+
+		notification, err := findCommunicationNotification(ctx, bearerToken, in.MessageID)
+		if err != nil {
+			return identityVerifyNotificationResultFromError(err)
+		}
+		if notification != nil {
+			if in.To == "" {
+				in.To = emailReplyRecipient(notification)
+			}
+			if in.Subject == "" {
+				in.Subject = emailReplySubject(notification)
+			}
+		}
+	}
+	if in.To == "" || in.Subject == "" {
+		return toolErrorResult("invalid_request", "unable to resolve reply recipient and subject; provide to and subject explicitly", 400, nil)
 	}
 
 	deps, res, err := loadCommSendDependencies(ctx, "email")
@@ -81,16 +120,43 @@ func handleEmailReply(ctx context.Context, args json.RawMessage) (*mcpruntime.To
 	}
 
 	body := map[string]any{
+		"to":        in.To,
+		"subject":   in.Subject,
 		"body":      in.Body,
 		"inReplyTo": in.MessageID,
-		"replyAll":  in.ReplyAll,
 	}
 
 	normalized, err := sendOutboundComm(ctx, deps, "email", body)
 	if err != nil {
 		return commToolResultFromError(err)
 	}
+	normalized["inReplyTo"] = in.MessageID
+	if in.ReplyAll {
+		normalized["replyAllRequested"] = true
+	}
 	return toolJSONResult(normalized)
+}
+
+func emailReplyRecipient(notification map[string]any) string {
+	from := commFrom(notification)
+	for _, key := range []string{"address", "email", "identifier"} {
+		if value, _ := from[key].(string); strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func emailReplySubject(notification map[string]any) string {
+	subject := strings.TrimSpace(commSubject(notification))
+	if subject == "" {
+		return "Re: (no subject)"
+	}
+	lower := strings.ToLower(subject)
+	if strings.HasPrefix(lower, "re:") {
+		return subject
+	}
+	return "Re: " + subject
 }
 
 func normalizeCommSendResult(raw any, advisory map[string]any) map[string]any {

--- a/internal/mcpserver/identity_tools.go
+++ b/internal/mcpserver/identity_tools.go
@@ -65,31 +65,11 @@ func handleIdentityLookup(ctx context.Context, args json.RawMessage) (*mcpruntim
 	if isSoulAgentID(q) {
 		agentIDs = append(agentIDs, normalizeSoulAgentID(q))
 	} else {
-		searchQ := normalizeSoulLookupQuery(q)
-		query := url.Values{}
-		query.Set("q", searchQ)
-		query.Set("limit", "5")
-		out, err := client.DoJSON(ctx, "GET", "/api/v1/soul/search", query, "", nil)
+		resolvedAgentIDs, err := lookupAgentIDs(ctx, client, q)
 		if err != nil {
 			return identityToolResultFromError(err)
 		}
-
-		resp, ok := out.(map[string]any)
-		if !ok {
-			return toolErrorResult("upstream_error", "unexpected soul search response", 502, nil)
-		}
-		results, _ := resp["results"].([]any)
-		for _, r := range results {
-			rm, _ := r.(map[string]any)
-			id, _ := rm["agent_id"].(string)
-			id = normalizeSoulAgentID(id)
-			if id != "" {
-				agentIDs = append(agentIDs, id)
-			}
-			if len(agentIDs) >= 3 {
-				break
-			}
-		}
+		agentIDs = append(agentIDs, resolvedAgentIDs...)
 		if len(agentIDs) == 0 {
 			return toolErrorResult("not_found", "no matching agent found", 404, map[string]any{"query": q})
 		}
@@ -253,50 +233,7 @@ func normalizeSoulLookupQuery(q string) string {
 	if q == "" {
 		return ""
 	}
-
-	lower := strings.ToLower(q)
-	if localID, ok := localIDFromManagedEmail(lower); ok {
-		return localID
-	}
-	if localID, ok := localIDFromManagedENS(lower); ok {
-		return localID
-	}
 	return q
-}
-
-func localIDFromManagedEmail(q string) (string, bool) {
-	parts := strings.Split(q, "@")
-	if len(parts) != 2 {
-		return "", false
-	}
-	localPart := strings.TrimSpace(parts[0])
-	domain := strings.TrimSpace(parts[1])
-	if localPart == "" || domain != "lessersoul.ai" {
-		return "", false
-	}
-	localPart = strings.Split(localPart, "+")[0]
-	localPart = strings.TrimSpace(localPart)
-	if localPart == "" {
-		return "", false
-	}
-	return localPart, true
-}
-
-func localIDFromManagedENS(q string) (string, bool) {
-	if !strings.HasSuffix(q, ".lessersoul.eth") {
-		return "", false
-	}
-	localID := strings.TrimSuffix(q, ".lessersoul.eth")
-	localID = strings.TrimSuffix(localID, ".")
-	localID = strings.TrimSpace(localID)
-	if localID == "" {
-		return "", false
-	}
-	if strings.Contains(localID, ".") {
-		parts := strings.Split(localID, ".")
-		localID = strings.TrimSpace(parts[0])
-	}
-	return localID, localID != ""
 }
 
 func isSoulAgentID(q string) bool {
@@ -330,4 +267,91 @@ func stringFromMap(m map[string]any, key string) string {
 	}
 	raw, _ := m[key].(string)
 	return strings.TrimSpace(raw)
+}
+
+func lookupAgentIDs(ctx context.Context, client *soulapi.Client, q string) ([]string, error) {
+	if client == nil {
+		return nil, errors.New("soul api client is nil")
+	}
+
+	if agentID, err := resolveAgentIDByIdentifier(ctx, client, q); err == nil && agentID != "" {
+		return []string{agentID}, nil
+	} else if err != nil {
+		var apiErr *soulapi.APIError
+		if !errors.As(err, &apiErr) || apiErr.Status != 404 {
+			return nil, err
+		}
+	}
+
+	searchQ := normalizeSoulLookupQuery(q)
+	query := url.Values{}
+	query.Set("q", searchQ)
+	query.Set("limit", "5")
+	out, err := client.DoJSON(ctx, "GET", "/api/v1/soul/search", query, "", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, ok := out.(map[string]any)
+	if !ok {
+		return nil, errors.New("unexpected soul search response")
+	}
+	results, _ := resp["results"].([]any)
+	agentIDs := make([]string, 0, len(results))
+	for _, r := range results {
+		rm, _ := r.(map[string]any)
+		id, _ := rm["agent_id"].(string)
+		id = normalizeSoulAgentID(id)
+		if id == "" {
+			continue
+		}
+		agentIDs = append(agentIDs, id)
+		if len(agentIDs) >= 3 {
+			break
+		}
+	}
+	return agentIDs, nil
+}
+
+func resolveAgentIDByIdentifier(ctx context.Context, client *soulapi.Client, q string) (string, error) {
+	q = strings.TrimSpace(q)
+	if q == "" {
+		return "", nil
+	}
+
+	var path string
+	switch {
+	case looksLikeEmail(q):
+		path = "/api/v1/soul/resolve/email/" + url.PathEscape(q)
+	case looksLikeENSName(q):
+		path = "/api/v1/soul/resolve/ens/" + url.PathEscape(q)
+	default:
+		return "", nil
+	}
+
+	out, err := client.DoJSON(ctx, "GET", path, nil, "", nil)
+	if err != nil {
+		return "", err
+	}
+
+	resp, _ := out.(map[string]any)
+	agent, _ := resp["agent"].(map[string]any)
+	return normalizeSoulAgentID(stringFromMap(agent, "agent_id")), nil
+}
+
+func looksLikeEmail(q string) bool {
+	q = strings.TrimSpace(q)
+	if q == "" || strings.Contains(q, " ") {
+		return false
+	}
+	parts := strings.Split(q, "@")
+	return len(parts) == 2 && strings.TrimSpace(parts[0]) != "" && strings.TrimSpace(parts[1]) != ""
+}
+
+func looksLikeENSName(q string) bool {
+	q = strings.TrimSpace(strings.TrimSuffix(q, "."))
+	if q == "" || strings.Contains(q, " ") {
+		return false
+	}
+	return strings.HasSuffix(strings.ToLower(q), ".eth")
 }


### PR DESCRIPTION
## Summary
- normalize API Gateway MCP trailing-slash paths for `/mcp/` and `/.well-known/mcp.json/`
- add missing email reply-context support and derive reply recipient/subject from the original message when needed
- resolve managed email and ENS identifiers directly in `identity_lookup` and lock the MCP schemas/tests to the updated contract

## Testing
- go test ./...

## Upstream follow-ups
- equaltoai/lesser#166
- equaltoai/lesser#167
