### PR TITLE
Fix inbox tools for communication notifications

### DIFF
--- a/internal/mcpapp/inbox_tools_test.go
+++ b/internal/mcpapp/inbox_tools_test.go
@@ -30,12 +30,15 @@ func TestLBM3_InboxToolsFilterNotifications(t *testing.T) {
 				{
 					"id":"n1",
 					"type":"communication:inbound",
-					"channel":"email",
-					"messageId":"comm-msg-001",
-					"from":{"address":"alice@example.com"},
-					"subject":"Hi",
-					"body":"Hello",
-					"receivedAt":"2026-03-04T12:00:00Z"
+					"communication":{
+						"channel":"email",
+						"message_id":"comm-msg-001",
+						"from":{"address":"alice@example.com"},
+						"to":{"address":"agent1@lessersoul.ai"},
+						"subject":"Hi",
+						"body":"Hello",
+						"received_at":"2026-03-04T12:00:00Z"
+					}
 				},
 				{
 					"id":"n2",

--- a/internal/mcpserver/inbox_tools.go
+++ b/internal/mcpserver/inbox_tools.go
@@ -339,7 +339,7 @@ func notificationChannel(n map[string]any) string {
 			return strings.ToLower(strings.TrimSpace(v))
 		}
 	}
-	for _, container := range []string{"data", "payload"} {
+	for _, container := range []string{"communication", "data", "payload"} {
 		if m, ok := n[container].(map[string]any); ok {
 			if v, _ := m["channel"].(string); strings.TrimSpace(v) != "" {
 				return strings.ToLower(strings.TrimSpace(v))
@@ -355,7 +355,7 @@ func commMessageID(n map[string]any) string {
 			return strings.TrimSpace(v)
 		}
 	}
-	for _, container := range []string{"data", "payload"} {
+	for _, container := range []string{"communication", "data", "payload"} {
 		if m, ok := n[container].(map[string]any); ok {
 			for _, key := range []string{"messageId", "message_id"} {
 				if v, _ := m[key].(string); strings.TrimSpace(v) != "" {
@@ -373,7 +373,7 @@ func commFrom(n map[string]any) map[string]any {
 			return m
 		}
 	}
-	for _, container := range []string{"data", "payload"} {
+	for _, container := range []string{"communication", "data", "payload"} {
 		if m, ok := n[container].(map[string]any); ok {
 			if from, ok := m["from"].(map[string]any); ok {
 				return from
@@ -389,7 +389,7 @@ func commTo(n map[string]any) any {
 			return v
 		}
 	}
-	for _, container := range []string{"data", "payload"} {
+	for _, container := range []string{"communication", "data", "payload"} {
 		if m, ok := n[container].(map[string]any); ok {
 			if v, ok := m["to"]; ok && v != nil {
 				return v
@@ -405,7 +405,7 @@ func commSubject(n map[string]any) string {
 			return strings.TrimSpace(v)
 		}
 	}
-	for _, container := range []string{"data", "payload"} {
+	for _, container := range []string{"communication", "data", "payload"} {
 		if m, ok := n[container].(map[string]any); ok {
 			if v, _ := m["subject"].(string); strings.TrimSpace(v) != "" {
 				return strings.TrimSpace(v)
@@ -421,7 +421,7 @@ func commBody(n map[string]any) string {
 			return strings.TrimSpace(v)
 		}
 	}
-	for _, container := range []string{"data", "payload"} {
+	for _, container := range []string{"communication", "data", "payload"} {
 		if m, ok := n[container].(map[string]any); ok {
 			if v, _ := m["body"].(string); strings.TrimSpace(v) != "" {
 				return strings.TrimSpace(v)
@@ -437,7 +437,7 @@ func commReceivedAt(n map[string]any) string {
 			return strings.TrimSpace(v)
 		}
 	}
-	for _, container := range []string{"data", "payload"} {
+	for _, container := range []string{"communication", "data", "payload"} {
 		if m, ok := n[container].(map[string]any); ok {
 			for _, key := range []string{"receivedAt", "received_at"} {
 				if v, _ := m[key].(string); strings.TrimSpace(v) != "" {


### PR DESCRIPTION
## Summary
- teach inbox tools to read Lesser communication notifications from the live `communication` payload shape
- keep support for the older flat/data payloads used by existing tests and callers
- add regression coverage for email inbox filtering against the live-shaped notification payload

## Testing
- go test ./internal/mcpapp -run TestLBM3_InboxToolsFilterNotifications
- go test ./internal/mcpapp ./internal/mcpserver
- go test ./...