### PR TITLE
Implement structured notifications_read MCP tool

### DIFF
--- a/internal/mcpapp/social_tools_test.go
+++ b/internal/mcpapp/social_tools_test.go
@@ -463,43 +463,46 @@ func TestM5_NotificationsReadReturnsStructuredNotifications(t *testing.T) {
 	t.Setenv("JWT_SECRET", "test")
 	auth.ResetForTests()
 
-	var gotQuery string
+	var gotQueries []string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/v1/notifications" {
 			w.WriteHeader(http.StatusNotFound)
 			_, _ = w.Write([]byte(`{"error":"not found"}`))
 			return
 		}
-		gotQuery = r.URL.RawQuery
+		gotQueries = append(gotQueries, r.URL.RawQuery)
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`[
-			{
-				"id":"n-follow",
-				"type":"follow",
-				"created_at":"2026-03-16T10:00:00Z",
-				"account":{"id":"acct-follow","username":"bob","acct":"bob@example.com"}
-			},
-			{
-				"id":"n-reply",
-				"type":"mention",
-				"created_at":"2026-03-16T09:00:00Z",
-				"account":{"id":"acct-reply","username":"alice","acct":"alice@example.com","display_name":"Alice"},
-				"status":{
-					"id":"post-1",
-					"content":"@agent1 thanks!",
-					"created_at":"2026-03-16T08:59:00Z",
-					"in_reply_to_id":"root-1",
-					"visibility":"public"
+		switch r.URL.RawQuery {
+		case "limit=5&max_id=n0&types%5B%5D=reply":
+			// Current Lesser instances may still emit mention here; lesser-body should not relabel it.
+			_, _ = w.Write([]byte(`[
+				{
+					"id":"n-reply-like-mention",
+					"type":"mention",
+					"created_at":"2026-03-16T09:00:00Z",
+					"account":{"id":"acct-reply","username":"alice","acct":"alice@example.com","display_name":"Alice"},
+					"status":{
+						"id":"post-1",
+						"content":"@agent1 thanks!",
+						"created_at":"2026-03-16T08:59:00Z",
+						"in_reply_to_id":"root-1",
+						"visibility":"public"
+					}
 				}
-			},
-			{
-				"id":"n-fav",
-				"type":"favourite",
-				"created_at":"2026-03-16T08:00:00Z",
-				"account":{"id":"acct-fav","username":"carol","acct":"carol@example.com"},
-				"status":{"id":"post-2","content":"Great post","visibility":"public"}
-			}
-		]`))
+			]`))
+		case "limit=5&max_id=n0&types%5B%5D=favourite":
+			_, _ = w.Write([]byte(`[
+				{
+					"id":"n-fav",
+					"type":"favourite",
+					"created_at":"2026-03-16T08:00:00Z",
+					"account":{"id":"acct-fav","username":"carol","acct":"carol@example.com"},
+					"status":{"id":"post-2","content":"Great post","visibility":"public"}
+				}
+			]`))
+		default:
+			t.Fatalf("unexpected notifications query: %q", r.URL.RawQuery)
+		}
 	}))
 	defer server.Close()
 
@@ -548,8 +551,11 @@ func TestM5_NotificationsReadReturnsStructuredNotifications(t *testing.T) {
 		t.Fatalf("notifications_read: status=%d body=%s", resp.Status, string(resp.Body))
 	}
 
-	if gotQuery != "limit=5&max_id=n0&types%5B%5D=mention&types%5B%5D=favourite" {
-		t.Fatalf("unexpected notifications query: %q", gotQuery)
+	if len(gotQueries) != 2 {
+		t.Fatalf("expected 2 notifications queries, got %v", gotQueries)
+	}
+	if gotQueries[0] != "limit=5&max_id=n0&types%5B%5D=reply" || gotQueries[1] != "limit=5&max_id=n0&types%5B%5D=favourite" {
+		t.Fatalf("unexpected notifications queries: %v", gotQueries)
 	}
 
 	var rpc mcpruntime.Response
@@ -566,32 +572,19 @@ func TestM5_NotificationsReadReturnsStructuredNotifications(t *testing.T) {
 		_ = json.Unmarshal(b, &out)
 	}
 	data, _ := out.StructuredContent["data"].(map[string]any)
-	if data["count"] != float64(2) {
-		t.Fatalf("expected filtered count=2, got %+v", data)
+	if data["count"] != float64(1) {
+		t.Fatalf("expected filtered count=1, got %+v", data)
 	}
 	if data["nextSince"] != "n-fav" {
 		t.Fatalf("expected nextSince=n-fav, got %+v", data)
 	}
 
 	notifications, _ := data["notifications"].([]any)
-	if len(notifications) != 2 {
-		t.Fatalf("expected 2 notifications, got %+v", notifications)
+	if len(notifications) != 1 {
+		t.Fatalf("expected 1 notification, got %+v", notifications)
 	}
 
-	reply, _ := notifications[0].(map[string]any)
-	if reply["type"] != "reply" {
-		t.Fatalf("expected reply notification type, got %+v", reply)
-	}
-	actor, _ := reply["actor"].(map[string]any)
-	if actor["username"] != "alice" {
-		t.Fatalf("expected actor.username=alice, got %+v", actor)
-	}
-	targetPost, _ := reply["targetPost"].(map[string]any)
-	if targetPost["id"] != "post-1" || targetPost["inReplyToId"] != "root-1" {
-		t.Fatalf("unexpected targetPost: %+v", targetPost)
-	}
-
-	favourite, _ := notifications[1].(map[string]any)
+	favourite, _ := notifications[0].(map[string]any)
 	if favourite["type"] != "favourite" {
 		t.Fatalf("expected favourite notification type, got %+v", favourite)
 	}

--- a/internal/mcpserver/social_tools.go
+++ b/internal/mcpserver/social_tools.go
@@ -6,8 +6,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/equaltoai/lesser-body/internal/auth"
 	"github.com/equaltoai/lesser-body/internal/lesserapi"
@@ -307,37 +309,24 @@ func handleNotificationsRead(ctx context.Context, args json.RawMessage) (*mcprun
 		return nil, err
 	}
 
-	query := url.Values{}
-	if in.Limit > 0 {
-		query.Set("limit", strconv.Itoa(in.Limit))
-	}
-	if strings.TrimSpace(in.Since) != "" {
-		query.Set("max_id", strings.TrimSpace(in.Since))
-	}
-	for _, typ := range upstreamTypes {
-		query.Add("types[]", typ)
-	}
-
-	out, err := client.DoJSON(ctx, "GET", "/api/v1/notifications", query, token, nil)
+	list, err := readSocialNotifications(ctx, client, token, upstreamTypes, in.Limit, in.Since)
 	if err != nil {
 		return nil, err
-	}
-
-	list, ok := out.([]any)
-	if !ok {
-		return nil, fmt.Errorf("unexpected notifications response")
-	}
-
-	nextSince := ""
-	if len(list) > 0 {
-		if item, ok := list[len(list)-1].(map[string]any); ok {
-			nextSince = strings.TrimSpace(stringFromMap(item, "id"))
-		}
 	}
 
 	notifications := socialNotificationsFromAPI(list)
 	if len(requestedTypes) > 0 {
 		notifications = filterSocialNotificationsByType(notifications, requestedTypes)
+	}
+	if in.Limit > 0 && len(notifications) > in.Limit {
+		notifications = notifications[:in.Limit]
+	}
+
+	nextSince := ""
+	if len(notifications) > 0 {
+		if item, ok := notifications[len(notifications)-1].(map[string]any); ok {
+			nextSince = strings.TrimSpace(firstNonEmptyStringMap(item, "id"))
+		}
 	}
 
 	return toolJSONResult(map[string]any{
@@ -651,18 +640,93 @@ func normalizeRequestedNotificationTypes(in []string) ([]string, []string) {
 			seenRequested[typ] = struct{}{}
 			requested = append(requested, typ)
 		}
-
-		upstreamType := typ
-		if typ == "reply" {
-			upstreamType = "mention"
-		}
-		if _, ok := seenUpstream[upstreamType]; !ok {
-			seenUpstream[upstreamType] = struct{}{}
-			upstream = append(upstream, upstreamType)
+		if _, ok := seenUpstream[typ]; !ok {
+			seenUpstream[typ] = struct{}{}
+			upstream = append(upstream, typ)
 		}
 	}
 
 	return requested, upstream
+}
+
+func readSocialNotifications(ctx context.Context, client *lesserapi.Client, token string, upstreamTypes []string, limit int, since string) ([]any, error) {
+	if client == nil {
+		return nil, fmt.Errorf("lesser api client not initialized")
+	}
+
+	queries := upstreamTypes
+	if len(queries) == 0 {
+		queries = nil
+	}
+
+	if len(queries) <= 1 {
+		return readSocialNotificationsByType(ctx, client, token, firstString(queries), limit, since)
+	}
+
+	combined := make([]map[string]any, 0, len(queries)*max(1, limit))
+	seenIDs := make(map[string]struct{}, len(queries)*max(1, limit))
+	for _, typ := range queries {
+		items, err := readSocialNotificationsByType(ctx, client, token, typ, limit, since)
+		if err != nil {
+			return nil, err
+		}
+		for _, item := range items {
+			raw, ok := item.(map[string]any)
+			if !ok || raw == nil {
+				continue
+			}
+			id := strings.TrimSpace(stringFromMap(raw, "id"))
+			if id != "" {
+				if _, ok := seenIDs[id]; ok {
+					continue
+				}
+				seenIDs[id] = struct{}{}
+			}
+			combined = append(combined, raw)
+		}
+	}
+
+	sort.SliceStable(combined, func(i, j int) bool {
+		leftTime, leftOK := notificationCreatedAt(combined[i])
+		rightTime, rightOK := notificationCreatedAt(combined[j])
+		switch {
+		case leftOK && rightOK && !leftTime.Equal(rightTime):
+			return leftTime.After(rightTime)
+		case leftOK != rightOK:
+			return leftOK
+		}
+		return strings.TrimSpace(stringFromMap(combined[i], "id")) > strings.TrimSpace(stringFromMap(combined[j], "id"))
+	})
+
+	out := make([]any, 0, len(combined))
+	for _, item := range combined {
+		out = append(out, item)
+	}
+	return out, nil
+}
+
+func readSocialNotificationsByType(ctx context.Context, client *lesserapi.Client, token string, notificationType string, limit int, since string) ([]any, error) {
+	query := url.Values{}
+	if limit > 0 {
+		query.Set("limit", strconv.Itoa(limit))
+	}
+	if strings.TrimSpace(since) != "" {
+		query.Set("max_id", strings.TrimSpace(since))
+	}
+	if strings.TrimSpace(notificationType) != "" {
+		query.Add("types[]", strings.TrimSpace(notificationType))
+	}
+
+	out, err := client.DoJSON(ctx, "GET", "/api/v1/notifications", query, token, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	list, ok := out.([]any)
+	if !ok {
+		return nil, fmt.Errorf("unexpected notifications response")
+	}
+	return list, nil
 }
 
 func socialNotificationsFromAPI(items []any) []any {
@@ -723,11 +787,6 @@ func normalizeSocialNotificationType(raw map[string]any) string {
 	switch rawType {
 	case "favorite":
 		return "favourite"
-	case "mention":
-		post := firstMap(raw, "status", "post", "targetPost")
-		if post != nil && firstNonEmptyStringMap(post, "in_reply_to_id", "inReplyToId") != "" {
-			return "reply"
-		}
 	}
 	return rawType
 }
@@ -795,6 +854,25 @@ func putIfNotEmpty(dest map[string]any, key string, value string) {
 		return
 	}
 	dest[key] = strings.TrimSpace(value)
+}
+
+func notificationCreatedAt(raw map[string]any) (time.Time, bool) {
+	value := firstNonEmptyStringMap(raw, "created_at", "createdAt")
+	if value == "" {
+		return time.Time{}, false
+	}
+	t, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return t.UTC(), true
+}
+
+func firstString(values []string) string {
+	if len(values) == 0 {
+		return ""
+	}
+	return strings.TrimSpace(values[0])
 }
 
 func postCreateDef() mcpruntime.ToolDef {


### PR DESCRIPTION
## Summary
- return normalized MCP notification objects instead of the raw Lesser API array
- include structured `type`, `actor`, and `targetPost` data in notifications_read results
- translate MCP-facing notification filters into Lesser notification queries without relying on multi-value `types[]` support
- add focused coverage for the upstream query fanout and normalized response shape

## Dependency Note
- This does **not** fully close issue #23 against current `lesser` main yet.
- `reply` notifications remain blocked on upstream Lesser exposing a first-class `reply` notification type.
- Until that lands, lesser-body can query `reply` cleanly, but current Lesser instances will still under-return that type because they do not emit it yet.

## Testing
- `GOTOOLCHAIN=auto go test ./...`