### PR TITLE
Serve OAuth protected resource metadata and 401 challenge

### DIFF
--- a/internal/lambdaentry/apigw.go
+++ b/internal/lambdaentry/apigw.go
@@ -81,6 +81,8 @@ func normalizeGatewayPath(path string) string {
 		return strings.TrimSuffix(path, "/")
 	case path == "/.well-known/mcp.json/" || strings.HasSuffix(path, "/.well-known/mcp.json/"):
 		return strings.TrimSuffix(path, "/")
+	case path == "/.well-known/oauth-protected-resource/" || strings.HasSuffix(path, "/.well-known/oauth-protected-resource/"):
+		return strings.TrimSuffix(path, "/")
 	default:
 		return path
 	}

--- a/internal/lambdaentry/apigw_test.go
+++ b/internal/lambdaentry/apigw_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-lambda-go/events"
@@ -14,6 +15,7 @@ import (
 
 func TestNewAPIGatewayHandler_McpRouteReturnsStreamingResponseType(t *testing.T) {
 	t.Setenv("MCP_SESSION_TABLE", "")
+	t.Setenv("MCP_ENDPOINT", "https://api.example.com/mcp")
 	t.Setenv("JWT_SECRET", "test")
 	auth.ResetForTests()
 
@@ -58,6 +60,12 @@ func TestNewAPIGatewayHandler_McpRouteReturnsStreamingResponseType(t *testing.T)
 	}
 	if len(b) == 0 {
 		t.Fatalf("expected non-empty body")
+	}
+	if got := streaming.Headers["www-authenticate"]; got != `Bearer resource_metadata="https://api.example.com/.well-known/oauth-protected-resource"` {
+		t.Fatalf("unexpected WWW-Authenticate header: %q", got)
+	}
+	if expose := streaming.Headers["access-control-expose-headers"]; !strings.Contains(strings.ToLower(expose), "www-authenticate") {
+		t.Fatalf("expected access-control-expose-headers to include www-authenticate, got %q", expose)
 	}
 }
 
@@ -178,5 +186,14 @@ func TestNewAPIGatewayHandler_WellKnownTrailingSlashNormalizes(t *testing.T) {
 	}
 	if proxy.StatusCode != 200 {
 		t.Fatalf("expected 200, got %d (%s)", proxy.StatusCode, proxy.Body)
+	}
+}
+
+func TestNormalizeGatewayPath_OAuthProtectedResourceTrailingSlash(t *testing.T) {
+	if got := normalizeGatewayPath("/.well-known/oauth-protected-resource/"); got != "/.well-known/oauth-protected-resource" {
+		t.Fatalf("unexpected normalized path: %q", got)
+	}
+	if got := normalizeGatewayPath("/prod/.well-known/oauth-protected-resource/"); got != "/prod/.well-known/oauth-protected-resource" {
+		t.Fatalf("unexpected normalized nested path: %q", got)
 	}
 }

--- a/internal/mcpapp/app.go
+++ b/internal/mcpapp/app.go
@@ -21,11 +21,12 @@ func New(name, version string) (*apptheory.App, error) {
 	)
 
 	app.Get("/.well-known/mcp.json", WellKnownMcpHandler(srv, name, version))
+	app.Get("/.well-known/oauth-protected-resource", WellKnownOAuthProtectedResourceHandler())
 
-	handler := WithClientCompatibilityHeaders(WithAudit(WithToolContext(srv.Handler()), logger))
-	app.Post("/mcp", handler, apptheory.RequireAuth())
-	app.Get("/mcp", handler, apptheory.RequireAuth())
-	app.Delete("/mcp", handler, apptheory.RequireAuth())
+	handler := WithClientCompatibilityHeaders(WithMCPAuthorization(WithAudit(WithToolContext(srv.Handler()), logger)))
+	app.Post("/mcp", handler)
+	app.Get("/mcp", handler)
+	app.Delete("/mcp", handler)
 
 	return app, nil
 }

--- a/internal/mcpapp/app_test.go
+++ b/internal/mcpapp/app_test.go
@@ -99,6 +99,7 @@ func TestMcpAuth_AllowsOldButUnexpiredJwt(t *testing.T) {
 
 func TestMcpAuth_ExpiredJwtRejected(t *testing.T) {
 	t.Setenv("MCP_SESSION_TABLE", "")
+	t.Setenv("MCP_ENDPOINT", "https://api.example.com/mcp")
 	t.Setenv("JWT_SECRET", "test")
 	auth.ResetForTests()
 
@@ -122,10 +123,14 @@ func TestMcpAuth_ExpiredJwtRejected(t *testing.T) {
 	if resp.Status != 401 {
 		t.Fatalf("expected 401 for expired token, got %d (%s)", resp.Status, string(resp.Body))
 	}
+	if got := firstHeader(resp.Headers, "www-authenticate"); got != `Bearer resource_metadata="https://api.example.com/.well-known/oauth-protected-resource"` {
+		t.Fatalf("unexpected WWW-Authenticate header: %q", got)
+	}
 }
 
 func TestMcpAuth_Unauthorized(t *testing.T) {
 	t.Setenv("MCP_SESSION_TABLE", "")
+	t.Setenv("MCP_ENDPOINT", "https://api.example.com/mcp")
 	t.Setenv("JWT_SECRET", "test")
 	auth.ResetForTests()
 
@@ -154,6 +159,12 @@ func TestMcpAuth_Unauthorized(t *testing.T) {
 	}
 	if out.Error.Code != "app.unauthorized" {
 		t.Fatalf("expected app.unauthorized, got %q", out.Error.Code)
+	}
+	if got := firstHeader(resp.Headers, "www-authenticate"); got != `Bearer resource_metadata="https://api.example.com/.well-known/oauth-protected-resource"` {
+		t.Fatalf("unexpected WWW-Authenticate header: %q", got)
+	}
+	if expose := firstHeader(resp.Headers, "access-control-expose-headers"); !strings.Contains(strings.ToLower(expose), "www-authenticate") {
+		t.Fatalf("expected access-control-expose-headers to include www-authenticate, got %q", expose)
 	}
 }
 
@@ -388,4 +399,17 @@ func TestMcpAuth_AuthorizedJwt_AllowsConfiguredBrowserOrigin(t *testing.T) {
 	if !strings.Contains(strings.ToLower(exposeHeaders), "mcp-session-id") {
 		t.Fatalf("expected access-control-expose-headers to include mcp-session-id, got %q", exposeHeaders)
 	}
+}
+
+func firstHeader(headers map[string][]string, key string) string {
+	for candidate, values := range headers {
+		if !strings.EqualFold(candidate, key) {
+			continue
+		}
+		if len(values) == 0 {
+			return ""
+		}
+		return values[0]
+	}
+	return ""
 }

--- a/internal/mcpapp/mcp_auth.go
+++ b/internal/mcpapp/mcp_auth.go
@@ -1,0 +1,64 @@
+package mcpapp
+
+import (
+	"encoding/json"
+	"strings"
+
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+	oauthruntime "github.com/theory-cloud/apptheory/runtime/oauth"
+
+	"github.com/equaltoai/lesser-body/internal/auth"
+)
+
+func WithMCPAuthorization(next apptheory.Handler) apptheory.Handler {
+	if next == nil {
+		return nil
+	}
+
+	authHook := auth.Hook(nil)
+
+	return func(ctx *apptheory.Context) (*apptheory.Response, error) {
+		identity, err := authHook(ctx)
+		if err != nil {
+			return unauthorizedMCPResponse(ctx), nil
+		}
+		if strings.TrimSpace(identity) == "" {
+			return unauthorizedMCPResponse(ctx), nil
+		}
+		ctx.AuthIdentity = identity
+		return next(ctx)
+	}
+}
+
+func unauthorizedMCPResponse(ctx *apptheory.Context) *apptheory.Response {
+	headers := map[string][]string{}
+	if resourceMetadataURL := protectedResourceMetadataURLForRequest(ctx); resourceMetadataURL != "" {
+		headers["www-authenticate"] = []string{oauthruntime.ProtectedResourceWWWAuthenticate(resourceMetadataURL)}
+	}
+	headers["content-type"] = []string{"application/json; charset=utf-8"}
+
+	errBody := map[string]any{
+		"code":    "app.unauthorized",
+		"message": "unauthorized",
+	}
+	if ctx != nil && strings.TrimSpace(ctx.RequestID) != "" {
+		errBody["request_id"] = ctx.RequestID
+	}
+
+	body, err := json.Marshal(map[string]any{"error": errBody})
+	if err != nil {
+		body = []byte(`{"error":{"code":"app.internal","message":"internal error"}}`)
+		headers["content-type"] = []string{"application/json; charset=utf-8"}
+		return &apptheory.Response{
+			Status:  500,
+			Headers: headers,
+			Body:    body,
+		}
+	}
+
+	return &apptheory.Response{
+		Status:  401,
+		Headers: headers,
+		Body:    body,
+	}
+}

--- a/internal/mcpapp/oauth_protected_resource_test.go
+++ b/internal/mcpapp/oauth_protected_resource_test.go
@@ -1,0 +1,110 @@
+package mcpapp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+	"github.com/theory-cloud/apptheory/testkit"
+
+	"github.com/equaltoai/lesser-body/internal/trustconfig"
+)
+
+func TestWellKnownOAuthProtectedResource(t *testing.T) {
+	previous := loadEffectiveTrustConfig
+	loadEffectiveTrustConfig = func(context.Context) (*trustconfig.Effective, error) {
+		return &trustconfig.Effective{
+			TrustBaseURL: "https://lesser.example",
+			Present:      true,
+		}, nil
+	}
+	t.Cleanup(func() {
+		loadEffectiveTrustConfig = previous
+	})
+
+	t.Setenv("MCP_SESSION_TABLE", "")
+	t.Setenv("MCP_ENDPOINT", "https://api.example.com/mcp")
+
+	app, err := New("test", "dev")
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+
+	env := testkit.New()
+	resp := env.Invoke(context.Background(), app, apptheory.Request{
+		Method: "GET",
+		Path:   "/.well-known/oauth-protected-resource",
+	})
+	if resp.Status != 200 {
+		t.Fatalf("unexpected status: %d (%s)", resp.Status, string(resp.Body))
+	}
+	if got := resp.Headers["cache-control"]; len(got) == 0 || got[0] != "public, max-age=60" {
+		t.Fatalf("unexpected cache-control header: %#v", resp.Headers["cache-control"])
+	}
+
+	var out struct {
+		Resource               string   `json:"resource"`
+		AuthorizationServers   []string `json:"authorization_servers"`
+		ScopesSupported        []string `json:"scopes_supported"`
+		BearerMethodsSupported []string `json:"bearer_methods_supported"`
+	}
+	if err := json.Unmarshal(resp.Body, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Resource != "https://api.example.com/mcp" {
+		t.Fatalf("unexpected resource: %q", out.Resource)
+	}
+	if len(out.AuthorizationServers) != 1 || out.AuthorizationServers[0] != "https://lesser.example" {
+		t.Fatalf("unexpected authorization_servers: %#v", out.AuthorizationServers)
+	}
+	if got, want := len(out.ScopesSupported), 3; got != want {
+		t.Fatalf("expected %d scopes, got %d (%#v)", want, got, out.ScopesSupported)
+	}
+	if len(out.BearerMethodsSupported) != 1 || out.BearerMethodsSupported[0] != "header" {
+		t.Fatalf("unexpected bearer_methods_supported: %#v", out.BearerMethodsSupported)
+	}
+}
+
+func TestWellKnownOAuthProtectedResource_InferEndpointFromRequest(t *testing.T) {
+	previous := loadEffectiveTrustConfig
+	loadEffectiveTrustConfig = func(context.Context) (*trustconfig.Effective, error) {
+		return &trustconfig.Effective{
+			TrustBaseURL: "https://lesser.example",
+			Present:      true,
+		}, nil
+	}
+	t.Cleanup(func() {
+		loadEffectiveTrustConfig = previous
+	})
+
+	t.Setenv("MCP_SESSION_TABLE", "")
+
+	app, err := New("test", "dev")
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+
+	env := testkit.New()
+	resp := env.Invoke(context.Background(), app, apptheory.Request{
+		Method: "GET",
+		Path:   "/.well-known/oauth-protected-resource",
+		Headers: map[string][]string{
+			"x-forwarded-proto": {"https"},
+			"x-forwarded-host":  {"tenant.example.com"},
+		},
+	})
+	if resp.Status != 200 {
+		t.Fatalf("unexpected status: %d (%s)", resp.Status, string(resp.Body))
+	}
+
+	var out struct {
+		Resource string `json:"resource"`
+	}
+	if err := json.Unmarshal(resp.Body, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Resource != "https://tenant.example.com/mcp" {
+		t.Fatalf("unexpected inferred resource: %q", out.Resource)
+	}
+}

--- a/internal/mcpapp/well_known.go
+++ b/internal/mcpapp/well_known.go
@@ -1,14 +1,17 @@
 package mcpapp
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
 
 	apptheory "github.com/theory-cloud/apptheory/runtime"
+	oauthruntime "github.com/theory-cloud/apptheory/runtime/oauth"
 
 	"github.com/equaltoai/lesser-body/internal/mcpserver"
+	"github.com/equaltoai/lesser-body/internal/trustconfig"
 )
 
 type mcpWellKnownDoc struct {
@@ -25,12 +28,11 @@ type mcpWellKnownToolHint struct {
 	Description string `json:"description,omitempty"`
 }
 
+var loadEffectiveTrustConfig = trustconfig.Default
+
 func WellKnownMcpHandler(srv *mcpserver.Server, name string, version string) apptheory.Handler {
 	return func(ctx *apptheory.Context) (*apptheory.Response, error) {
-		endpoint := strings.TrimSpace(os.Getenv("MCP_ENDPOINT"))
-		if endpoint == "" {
-			endpoint = inferMcpEndpointFromRequest(ctx)
-		}
+		endpoint := mcpEndpointForRequest(ctx)
 
 		doc := mcpWellKnownDoc{
 			Name:     strings.TrimSpace(name),
@@ -68,6 +70,79 @@ func WellKnownMcpHandler(srv *mcpserver.Server, name string, version string) app
 		}
 		return &apptheory.Response{Status: 200, Headers: headers, Body: b}, nil
 	}
+}
+
+func WellKnownOAuthProtectedResourceHandler() apptheory.Handler {
+	return func(ctx *apptheory.Context) (*apptheory.Response, error) {
+		endpoint := mcpEndpointForRequest(ctx)
+		if endpoint == "" {
+			return apptheory.MustJSON(404, map[string]string{"error": "not_found"}), nil
+		}
+
+		cfg, err := loadEffectiveTrustConfig(trustConfigContext(ctx))
+		if err != nil {
+			return nil, fmt.Errorf("load trust config: %w", err)
+		}
+
+		issuer := ""
+		if cfg != nil {
+			issuer = strings.TrimSpace(cfg.TrustBaseURL)
+		}
+		if issuer == "" {
+			return apptheory.MustJSON(404, map[string]string{"error": "not_found"}), nil
+		}
+
+		md, err := oauthruntime.NewProtectedResourceMetadata(endpoint, []string{issuer})
+		if err != nil {
+			return nil, fmt.Errorf("build protected resource metadata: %w", err)
+		}
+		md.ScopesSupported = []string{"read", "write", "admin"}
+		md.BearerMethodsSupported = []string{"header"}
+
+		body, err := md.MarshalJSONBytes()
+		if err != nil {
+			return nil, fmt.Errorf("marshal protected resource metadata: %w", err)
+		}
+
+		return &apptheory.Response{
+			Status: 200,
+			Headers: map[string][]string{
+				"content-type":  {"application/json"},
+				"cache-control": {"public, max-age=60"},
+			},
+			Body: body,
+		}, nil
+	}
+}
+
+func mcpEndpointForRequest(ctx *apptheory.Context) string {
+	endpoint := strings.TrimSpace(os.Getenv("MCP_ENDPOINT"))
+	if endpoint != "" {
+		return endpoint
+	}
+	return inferMcpEndpointFromRequest(ctx)
+}
+
+func protectedResourceMetadataURLForRequest(ctx *apptheory.Context) string {
+	endpoint := mcpEndpointForRequest(ctx)
+	if url, ok := oauthruntime.ResourceMetadataURLFromMcpEndpoint(endpoint); ok {
+		return url
+	}
+	if ctx == nil {
+		return ""
+	}
+	url, ok := oauthruntime.ProtectedResourceMetadataURLForRequest(ctx.Request.Headers)
+	if !ok {
+		return ""
+	}
+	return url
+}
+
+func trustConfigContext(ctx *apptheory.Context) context.Context {
+	if ctx == nil {
+		return context.Background()
+	}
+	return ctx.Context()
 }
 
 func inferMcpEndpointFromRequest(ctx *apptheory.Context) string {


### PR DESCRIPTION
## Summary
- add /.well-known/oauth-protected-resource with RFC 9728 metadata derived from the MCP endpoint and Lesser trust config
- return a WWW-Authenticate Bearer resource_metadata challenge on unauthorized /mcp requests while preserving MCP compatibility headers
- add coverage for metadata discovery, unauthorized challenge behavior, and API Gateway path normalization

## Testing
- GOTOOLCHAIN=auto go test ./...

Closes #29