### PR TITLE
Fix OAuth protected resource metadata scopes

### DIFF
--- a/internal/mcpapp/oauth_protected_resource_test.go
+++ b/internal/mcpapp/oauth_protected_resource_test.go
@@ -3,6 +3,7 @@ package mcpapp
 import (
 	"context"
 	"encoding/json"
+	"reflect"
 	"testing"
 
 	apptheory "github.com/theory-cloud/apptheory/runtime"
@@ -58,8 +59,8 @@ func TestWellKnownOAuthProtectedResource(t *testing.T) {
 	if len(out.AuthorizationServers) != 1 || out.AuthorizationServers[0] != "https://lesser.example" {
 		t.Fatalf("unexpected authorization_servers: %#v", out.AuthorizationServers)
 	}
-	if got, want := len(out.ScopesSupported), 3; got != want {
-		t.Fatalf("expected %d scopes, got %d (%#v)", want, got, out.ScopesSupported)
+	if want := []string{"read", "write", "follow"}; !reflect.DeepEqual(out.ScopesSupported, want) {
+		t.Fatalf("unexpected scopes_supported: got %#v want %#v", out.ScopesSupported, want)
 	}
 	if len(out.BearerMethodsSupported) != 1 || out.BearerMethodsSupported[0] != "header" {
 		t.Fatalf("unexpected bearer_methods_supported: %#v", out.BearerMethodsSupported)

--- a/internal/mcpapp/well_known.go
+++ b/internal/mcpapp/well_known.go
@@ -96,7 +96,7 @@ func WellKnownOAuthProtectedResourceHandler() apptheory.Handler {
 		if err != nil {
 			return nil, fmt.Errorf("build protected resource metadata: %w", err)
 		}
-		md.ScopesSupported = []string{"read", "write", "admin"}
+		md.ScopesSupported = []string{"read", "write", "follow"}
 		md.BearerMethodsSupported = []string{"header"}
 
 		body, err := md.MarshalJSONBytes()


### PR DESCRIPTION
## Summary
- change OAuth protected resource metadata to advertise read, write, and follow scopes
- stop advertising admin in the RFC 9728 metadata document, which MCP tools do not use
- tighten the metadata test to assert the exact scope list

## Testing
- GOTOOLCHAIN=auto go test ./...

Closes #31