### PR TITLE
Implement issue 47 comm auth contract preservation

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -103,6 +103,13 @@ fields aligned:
 - `details.refreshRequired`
 - `details.reauthorize`
 
+For outbound communication tools, Lesser-origin auth failures also preserve the Lesser contract fields at the top level
+of the MCP error payload:
+
+- `error`
+- `error_description`
+- `scope` on `insufficient_scope`
+
 Upstream Lesser payload normalization still belongs to `equaltoai/lesser#249`; lesser-body translates those failures
 into the MCP-visible contract above.
 

--- a/internal/mcpserver/comm_errors.go
+++ b/internal/mcpserver/comm_errors.go
@@ -10,6 +10,38 @@ import (
 	mcpruntime "github.com/theory-cloud/apptheory/runtime/mcp"
 )
 
+type commOAuthErrorPayload struct {
+	Error            string
+	ErrorDescription string
+	Scope            string
+	Raw              map[string]any
+}
+
+func toolErrorResultPayload(payload map[string]any) (*mcpruntime.ToolResult, error) {
+	if payload == nil {
+		payload = map[string]any{
+			"code":    "unknown_error",
+			"message": "error",
+		}
+	}
+
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("marshal tool error: %w", err)
+	}
+
+	return &mcpruntime.ToolResult{
+		Content: []mcpruntime.ContentBlock{{
+			Type: "text",
+			Text: string(b),
+		}},
+		IsError: true,
+		StructuredContent: map[string]any{
+			"error": payload,
+		},
+	}, nil
+}
+
 func toolErrorResult(code string, message string, status int, details map[string]any) (*mcpruntime.ToolResult, error) {
 	code = strings.TrimSpace(code)
 	if code == "" {
@@ -31,21 +63,7 @@ func toolErrorResult(code string, message string, status int, details map[string
 		payload["details"] = details
 	}
 
-	b, err := json.Marshal(payload)
-	if err != nil {
-		return nil, fmt.Errorf("marshal tool error: %w", err)
-	}
-
-	return &mcpruntime.ToolResult{
-		Content: []mcpruntime.ContentBlock{{
-			Type: "text",
-			Text: string(b),
-		}},
-		IsError: true,
-		StructuredContent: map[string]any{
-			"error": payload,
-		},
-	}, nil
+	return toolErrorResultPayload(payload)
 }
 
 func commToolResultFromError(err error) (*mcpruntime.ToolResult, error) {
@@ -53,11 +71,17 @@ func commToolResultFromError(err error) (*mcpruntime.ToolResult, error) {
 		return nil, nil
 	}
 
+	var apiErr *soulapi.APIError
+	if errors.As(err, &apiErr) {
+		if res, handled, resErr := commToolResultFromOAuthContract(apiErr); handled {
+			return res, resErr
+		}
+	}
+
 	if failure := mcpAuthFailureFromError(err); failure != nil {
 		return toolErrorResult(failure.Code, failure.Message, failure.Status, failure.Details)
 	}
 
-	var apiErr *soulapi.APIError
 	if errors.As(err, &apiErr) {
 		code := commErrorCodeForStatus(apiErr.Status)
 		message, parsed := commExtractAPIErrorMessage(apiErr.Body)
@@ -74,6 +98,101 @@ func commToolResultFromError(err error) (*mcpruntime.ToolResult, error) {
 	}
 
 	return toolErrorResult("upstream_error", err.Error(), 0, nil)
+}
+
+func commToolResultFromOAuthContract(apiErr *soulapi.APIError) (*mcpruntime.ToolResult, bool, error) {
+	oauthPayload := parseCommOAuthErrorPayload(apiErr.Body)
+	if oauthPayload == nil {
+		return nil, false, nil
+	}
+
+	action := commClientActionForOAuthError(apiErr.Status, oauthPayload.Error)
+	details := map[string]any{
+		"source":          "soul_api",
+		"authAction":      action,
+		"refreshRequired": action == "refresh",
+		"reauthorize":     action == "reauth",
+		"upstreamCode":    apiErr.Status,
+		"apiError":        oauthPayload.Raw,
+	}
+	if retryAfter := apiErr.RetryAfterSeconds(); retryAfter > 0 {
+		details["retryAfterSeconds"] = retryAfter
+	}
+
+	message := oauthPayload.ErrorDescription
+	if message == "" {
+		message = oauthPayload.Error
+	}
+
+	payload := map[string]any{
+		"code":    oauthPayload.Error,
+		"message": message,
+		"status":  apiErr.Status,
+		"error":   oauthPayload.Error,
+		"details": details,
+	}
+	if oauthPayload.ErrorDescription != "" {
+		payload["error_description"] = oauthPayload.ErrorDescription
+	}
+	if oauthPayload.Scope != "" {
+		payload["scope"] = oauthPayload.Scope
+	}
+
+	res, err := toolErrorResultPayload(payload)
+	return res, true, err
+}
+
+func parseCommOAuthErrorPayload(body []byte) *commOAuthErrorPayload {
+	raw := strings.TrimSpace(string(body))
+	if raw == "" || !strings.HasPrefix(raw, "{") {
+		return nil
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+		return nil
+	}
+
+	errorCode := extractString(parsed, "error")
+	if errorCode == "" {
+		return nil
+	}
+
+	return &commOAuthErrorPayload{
+		Error:            errorCode,
+		ErrorDescription: extractString(parsed, "error_description"),
+		Scope:            extractString(parsed, "scope"),
+		Raw:              parsed,
+	}
+}
+
+func commClientActionForOAuthError(status int, errorCode string) string {
+	switch {
+	case status == 401 && errorCode == "invalid_token":
+		return "refresh"
+	case status == 403 && errorCode == "insufficient_scope":
+		return "fail"
+	case status == 400 && errorCode == "invalid_grant":
+		return "reauth"
+	case status == 401 && errorCode == "invalid_client":
+		return "reconfigure"
+	case status == 400 && (errorCode == "unauthorized_client" || errorCode == "invalid_scope"):
+		return "reconfigure"
+	case status == 429 && errorCode == "slow_down":
+		return "backoff"
+	case status >= 500 && errorCode == "server_error":
+		return "retry"
+	case status == 401:
+		return "refresh"
+	case status == 403:
+		return "fail"
+	case status == 429:
+		return "backoff"
+	case status >= 500:
+		return "retry"
+	default:
+		return "fail"
+	}
 }
 
 func commErrorCodeForStatus(status int) string {

--- a/internal/mcpserver/comm_errors_test.go
+++ b/internal/mcpserver/comm_errors_test.go
@@ -50,26 +50,124 @@ func TestCommToolResultFromError_MapsCommAPIErrors(t *testing.T) {
 	}
 }
 
-func TestCommToolResultFromError_MapsSoulAuthFailures(t *testing.T) {
-	res, err := commToolResultFromError(&soulapi.APIError{
-		Status: 401,
-		Body:   []byte(`{"error":{"message":"token expired"}}`),
-	})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+func TestCommToolResultFromError_PreservesLesserAuthContract(t *testing.T) {
+	tests := []struct {
+		name                  string
+		status                int
+		body                  string
+		headers               http.Header
+		wantError             string
+		wantDescription       string
+		wantScope             string
+		wantAction            string
+		wantRefreshRequired   bool
+		wantReauthorize       bool
+		wantRetryAfterSeconds int
+	}{
+		{
+			name:                "invalid token refresh",
+			status:              401,
+			body:                `{"error":"invalid_token","error_description":"invalid token"}`,
+			wantError:           "invalid_token",
+			wantDescription:     "invalid token",
+			wantAction:          "refresh",
+			wantRefreshRequired: true,
+		},
+		{
+			name:            "insufficient scope fails",
+			status:          403,
+			body:            `{"error":"insufficient_scope","error_description":"insufficient scope: requires read","scope":"read"}`,
+			wantError:       "insufficient_scope",
+			wantDescription: "insufficient scope: requires read",
+			wantScope:       "read",
+			wantAction:      "fail",
+			wantReauthorize: false,
+		},
+		{
+			name:            "invalid grant requires reauth",
+			status:          400,
+			body:            `{"error":"invalid_grant","error_description":"Invalid or expired refresh token"}`,
+			wantError:       "invalid_grant",
+			wantDescription: "Invalid or expired refresh token",
+			wantAction:      "reauth",
+			wantReauthorize: true,
+		},
+		{
+			name:            "invalid client requires reconfigure",
+			status:          401,
+			body:            `{"error":"invalid_client","error_description":"Invalid client credentials"}`,
+			wantError:       "invalid_client",
+			wantDescription: "Invalid client credentials",
+			wantAction:      "reconfigure",
+			wantReauthorize: false,
+		},
+		{
+			name:                  "slow down backs off",
+			status:                429,
+			body:                  `{"error":"slow_down","error_description":"Too many client_credentials token requests"}`,
+			headers:               http.Header{"Retry-After": []string{"23"}},
+			wantError:             "slow_down",
+			wantDescription:       "Too many client_credentials token requests",
+			wantAction:            "backoff",
+			wantRetryAfterSeconds: 23,
+		},
 	}
-	if res == nil || !res.IsError {
-		t.Fatalf("expected isError tool result, got %+v", res)
-	}
-	errPayload, ok := res.StructuredContent["error"].(map[string]any)
-	if !ok {
-		t.Fatalf("expected structuredContent.error, got %+v", res.StructuredContent)
-	}
-	if errPayload["code"] != "unauthorized" || errPayload["status"] != 401 {
-		t.Fatalf("unexpected payload: %+v", errPayload)
-	}
-	details, _ := errPayload["details"].(map[string]any)
-	if details["source"] != "soul_api" || details["authAction"] != "refresh_or_reauthorize" {
-		t.Fatalf("unexpected auth details: %+v", details)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := commToolResultFromError(&soulapi.APIError{
+				Status:  tt.status,
+				Body:    []byte(tt.body),
+				Headers: tt.headers,
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if res == nil || !res.IsError {
+				t.Fatalf("expected isError tool result, got %+v", res)
+			}
+
+			errPayload, ok := res.StructuredContent["error"].(map[string]any)
+			if !ok {
+				t.Fatalf("expected structuredContent.error, got %+v", res.StructuredContent)
+			}
+			if errPayload["status"] != tt.status {
+				t.Fatalf("expected status=%d, got %+v", tt.status, errPayload)
+			}
+			if errPayload["code"] != tt.wantError {
+				t.Fatalf("expected code=%q, got %+v", tt.wantError, errPayload)
+			}
+			if errPayload["error"] != tt.wantError {
+				t.Fatalf("expected error=%q, got %+v", tt.wantError, errPayload)
+			}
+			if errPayload["error_description"] != tt.wantDescription {
+				t.Fatalf("expected error_description=%q, got %+v", tt.wantDescription, errPayload)
+			}
+			if tt.wantScope != "" && errPayload["scope"] != tt.wantScope {
+				t.Fatalf("expected scope=%q, got %+v", tt.wantScope, errPayload)
+			}
+
+			details, _ := errPayload["details"].(map[string]any)
+			if details["source"] != "soul_api" {
+				t.Fatalf("expected source=soul_api, got %+v", details)
+			}
+			if details["authAction"] != tt.wantAction {
+				t.Fatalf("expected authAction=%q, got %+v", tt.wantAction, details)
+			}
+			if details["refreshRequired"] != tt.wantRefreshRequired {
+				t.Fatalf("expected refreshRequired=%t, got %+v", tt.wantRefreshRequired, details)
+			}
+			if details["reauthorize"] != tt.wantReauthorize {
+				t.Fatalf("expected reauthorize=%t, got %+v", tt.wantReauthorize, details)
+			}
+			if tt.wantRetryAfterSeconds > 0 && details["retryAfterSeconds"] != tt.wantRetryAfterSeconds {
+				t.Fatalf("expected retryAfterSeconds=%d, got %+v", tt.wantRetryAfterSeconds, details)
+			}
+
+			apiError, _ := details["apiError"].(map[string]any)
+			if apiError["error"] != tt.wantError {
+				t.Fatalf("expected preserved apiError.error=%q, got %+v", tt.wantError, apiError)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- preserve Lesser OAuth-style auth fields in comm tool error payloads instead of collapsing them into generic MCP-only codes
- pin the five required auth fixtures in comm_errors tests, including client actions and Retry-After backoff handling
- document that outbound communication auth failures preserve top-level `error`, `error_description`, and `scope`

## Verification
- `GOTOOLCHAIN=auto go test ./...`
- `cd cdk && npm ci`
- `cd cdk && CDK_DEFAULT_ACCOUNT=000000000000 CDK_DEFAULT_REGION=us-east-1 GOTOOLCHAIN=auto ./node_modules/.bin/cdk synth --output "$(mktemp -d)" -c app=lesser -c stage=dev -c baseDomain=example.com`
- `GOTOOLCHAIN=auto bash scripts/check_cdk_discovery_routes.sh`

Closes #47