### PR TITLE
Fix issue 49 OAuth metadata startup probe

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -98,8 +98,9 @@ Variables:
 - `LESSER_TABLE_NAME` (string, required for `dynamo`)
   - The Lesser stage DynamoDB table name.
   - Also used to resolve managed trust configuration (`TRUST_CONFIG`) for soul API base URL and instance-key secret ARN.
-  - The managed `TRUST_CONFIG.baseURL` / `TrustBaseURL` must resolve to a reachable Lesser OAuth metadata surface at
-    `/.well-known/oauth-authorization-server` for protected-resource discovery to start.
+  - The managed `TRUST_CONFIG.baseURL` / `TrustBaseURL` is still required for the protected-resource issuer value.
+  - Startup reachability checks for `/.well-known/oauth-authorization-server` run against the Lesser API host derived
+    from `MCP_ENDPOINT`, not against `TrustBaseURL`.
 
 ### Misc
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -105,13 +105,14 @@ Common causes:
 - `MCP_ENDPOINT` is malformed or does not end in `/mcp`.
 - Clients are reaching a different public host than the one configured in `MCP_ENDPOINT`.
 - Managed `TRUST_CONFIG.baseURL` / `TrustBaseURL` is empty or points at the wrong Lesser environment.
-- Lesser OAuth metadata is not reachable at `/.well-known/oauth-authorization-server`.
+- Lesser OAuth metadata is not reachable on the Lesser API host derived from `MCP_ENDPOINT`.
 
 Fix:
 
 - Ensure `MCP_ENDPOINT` exactly matches the public URL clients use, for example `https://api.<stageDomain>/mcp`.
 - Verify `curl -sS "https://api.<stageDomain>/.well-known/oauth-authorization-server"` returns `200`.
-- In managed deployments, confirm `PK=INSTANCE#CONFIG, SK=TRUST_CONFIG` contains the correct Lesser trust base URL.
+- In managed deployments, confirm `PK=INSTANCE#CONFIG, SK=TRUST_CONFIG` contains the correct Lesser trust base URL for
+  the protected-resource issuer field.
 - If a browser client is involved, ensure `MCP_ALLOWED_ORIGINS` includes the browser origin (for example `https://claude.ai`).
 
 ## Identity / communication tools fail (`not_found`, `not_configured`, or soul API 404)

--- a/internal/mcpapp/discovery_validation.go
+++ b/internal/mcpapp/discovery_validation.go
@@ -22,8 +22,11 @@ func validateDiscoveryStartupConfig(ctx context.Context) error {
 		ctx = context.Background()
 	}
 
+	validatedEndpoint := ""
 	if raw := strings.TrimSpace(os.Getenv("MCP_ENDPOINT")); raw != "" {
-		if _, err := validatedMcpEndpoint(raw); err != nil {
+		var err error
+		validatedEndpoint, err = validatedMcpEndpoint(raw)
+		if err != nil {
 			return fmt.Errorf("validate MCP_ENDPOINT: %w", err)
 		}
 	}
@@ -44,9 +47,16 @@ func validateDiscoveryStartupConfig(ctx context.Context) error {
 		return fmt.Errorf("validate TRUST_CONFIG.TrustBaseURL: %w", err)
 	}
 
-	metadataURL := oauthAuthorizationServerMetadataURL(trustBaseURL)
+	if validatedEndpoint == "" {
+		return nil
+	}
+
+	metadataURL, err := oauthAuthorizationServerMetadataURLForMcpEndpoint(validatedEndpoint)
+	if err != nil {
+		return fmt.Errorf("validate MCP_ENDPOINT: %w", err)
+	}
 	if err := probeAuthorizationServerMetadata(ctx, metadataURL); err != nil {
-		return fmt.Errorf("validate TRUST_CONFIG.TrustBaseURL reachability via %s: %w", metadataURL, err)
+		return fmt.Errorf("validate MCP_ENDPOINT reachability via %s: %w", metadataURL, err)
 	}
 
 	return nil
@@ -113,6 +123,20 @@ func validatedPublicBaseURL(raw string) (*url.URL, error) {
 func oauthAuthorizationServerMetadataURL(baseURL string) string {
 	baseURL = strings.TrimRight(strings.TrimSpace(baseURL), "/")
 	return baseURL + oauthAuthorizationServerMetadataPath
+}
+
+func oauthAuthorizationServerMetadataURLForMcpEndpoint(mcpEndpoint string) (string, error) {
+	u, err := validatedMcpEndpoint(mcpEndpoint)
+	if err != nil {
+		return "", err
+	}
+
+	base, err := url.Parse(u)
+	if err != nil {
+		return "", fmt.Errorf("parse url: %w", err)
+	}
+	base.Path = strings.TrimSuffix(strings.TrimRight(base.Path, "/"), "/mcp")
+	return oauthAuthorizationServerMetadataURL(base.String()), nil
 }
 
 func defaultProbeAuthorizationServerMetadata(ctx context.Context, metadataURL string) error {

--- a/internal/mcpapp/discovery_validation_test.go
+++ b/internal/mcpapp/discovery_validation_test.go
@@ -22,7 +22,7 @@ func TestNew_ValidatesConfiguredMCPEndpoint(t *testing.T) {
 	}
 }
 
-func TestNew_ValidatesTrustBaseURLReachability(t *testing.T) {
+func TestNew_ValidatesAuthorizationServerMetadataReachabilityFromMCPEndpoint(t *testing.T) {
 	t.Setenv("MCP_SESSION_TABLE", "")
 	t.Setenv("MCP_ENDPOINT", "https://api.example.com/mcp")
 
@@ -38,7 +38,9 @@ func TestNew_ValidatesTrustBaseURLReachability(t *testing.T) {
 	})
 
 	previousProbe := probeAuthorizationServerMetadata
-	probeAuthorizationServerMetadata = func(context.Context, string) error {
+	probedURL := ""
+	probeAuthorizationServerMetadata = func(_ context.Context, metadataURL string) error {
+		probedURL = metadataURL
 		return errors.New("dial tcp: i/o timeout")
 	}
 	t.Cleanup(func() {
@@ -46,8 +48,43 @@ func TestNew_ValidatesTrustBaseURLReachability(t *testing.T) {
 	})
 
 	_, err := New("test", "dev")
-	if err == nil || !strings.Contains(err.Error(), "TrustBaseURL") {
-		t.Fatalf("expected TrustBaseURL validation error, got %v", err)
+	if err == nil || !strings.Contains(err.Error(), "MCP_ENDPOINT") {
+		t.Fatalf("expected MCP_ENDPOINT validation error, got %v", err)
+	}
+	if want := "https://api.example.com/.well-known/oauth-authorization-server"; probedURL != want {
+		t.Fatalf("unexpected metadata probe url: got %q want %q", probedURL, want)
+	}
+}
+
+func TestNew_SkipsAuthorizationServerMetadataProbeWithoutMCPEndpoint(t *testing.T) {
+	t.Setenv("MCP_SESSION_TABLE", "")
+
+	previousLoader := loadEffectiveTrustConfig
+	loadEffectiveTrustConfig = func(context.Context) (*trustconfig.Effective, error) {
+		return &trustconfig.Effective{
+			TrustBaseURL: "https://lesser.example",
+			Present:      true,
+		}, nil
+	}
+	t.Cleanup(func() {
+		loadEffectiveTrustConfig = previousLoader
+	})
+
+	previousProbe := probeAuthorizationServerMetadata
+	probeCalled := false
+	probeAuthorizationServerMetadata = func(context.Context, string) error {
+		probeCalled = true
+		return nil
+	}
+	t.Cleanup(func() {
+		probeAuthorizationServerMetadata = previousProbe
+	})
+
+	if _, err := New("test", "dev"); err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+	if probeCalled {
+		t.Fatalf("expected metadata probe to be skipped without MCP_ENDPOINT")
 	}
 }
 


### PR DESCRIPTION
## Summary
- derive the startup OAuth metadata probe URL from MCP_ENDPOINT instead of TrustBaseURL
- keep TrustBaseURL validation for the protected-resource issuer input
- update tests and discovery docs to match the corrected deployment model

## Verification
- GOTOOLCHAIN=auto go test ./internal/mcpapp
- GOTOOLCHAIN=auto go test ./...
- cd cdk && npm ci
- cd cdk && CDK_DEFAULT_ACCOUNT=000000000000 CDK_DEFAULT_REGION=us-east-1 GOTOOLCHAIN=auto ./node_modules/.bin/cdk synth --output "$(mktemp -d)" -c app=lesser -c stage=dev -c baseDomain=example.com
- GOTOOLCHAIN=auto bash scripts/check_cdk_discovery_routes.sh

Closes #49
