### PR TITLE
Align discovery scopes with canonical OAuth catalog

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -35,6 +35,16 @@ Canonical bearer token:
 
 - Lesser OAuth access token (HS256 JWT validated via `JWT_SECRET` / `JWT_SECRET_ARN`)
 
+Public OAuth discovery advertises these requestable scopes:
+
+- `read`
+- `write`
+- `follow`
+- `push`
+
+The `admin` scope remains internal/operator-only and is not advertised in `/.well-known/mcp.json` or
+`/.well-known/oauth-protected-resource`.
+
 Deprecated compatibility path:
 
 - Managed instance key (validated via `LESSER_HOST_INSTANCE_KEY` / `LESSER_HOST_INSTANCE_KEY_ARN`) for transitional
@@ -50,6 +60,7 @@ Protected-resource discovery in `lesser-body` only publishes:
 
 - the MCP `resource` URL
 - the Lesser OAuth `authorization_servers` URL
+- the canonical public OAuth scope catalog: `read`, `write`, `follow`, `push`
 
 Client registration remains a Lesser concern. Today the Lesser API exposes public app registration at:
 

--- a/internal/mcpapp/oauth_protected_resource_test.go
+++ b/internal/mcpapp/oauth_protected_resource_test.go
@@ -64,7 +64,7 @@ func TestWellKnownOAuthProtectedResource(t *testing.T) {
 	if len(out.AuthorizationServers) != 1 || out.AuthorizationServers[0] != "https://lesser.example" {
 		t.Fatalf("unexpected authorization_servers: %#v", out.AuthorizationServers)
 	}
-	if want := []string{"read", "write", "follow"}; !reflect.DeepEqual(out.ScopesSupported, want) {
+	if want := []string{"read", "write", "follow", "push"}; !reflect.DeepEqual(out.ScopesSupported, want) {
 		t.Fatalf("unexpected scopes_supported: got %#v want %#v", out.ScopesSupported, want)
 	}
 	if len(out.BearerMethodsSupported) != 1 || out.BearerMethodsSupported[0] != "header" {

--- a/internal/mcpapp/well_known.go
+++ b/internal/mcpapp/well_known.go
@@ -29,6 +29,8 @@ type mcpWellKnownToolHint struct {
 
 var loadEffectiveTrustConfig = trustconfig.Default
 
+var publicOAuthDiscoveryScopes = []string{"read", "write", "follow", "push"}
+
 func WellKnownMcpHandler(srv *mcpserver.Server, name string, version string) apptheory.Handler {
 	return func(ctx *apptheory.Context) (*apptheory.Response, error) {
 		endpoint, err := validatedMcpEndpointForRequest(ctx)
@@ -47,7 +49,7 @@ func WellKnownMcpHandler(srv *mcpserver.Server, name string, version string) app
 			},
 			Auth: map[string]any{
 				"type":   "bearer",
-				"scopes": []string{"read", "write", "admin"},
+				"scopes": append([]string(nil), publicOAuthDiscoveryScopes...),
 				"notes":  "Use a Lesser OAuth access token minted via the connector flow. Managed instance key and hardcoded bearer-token flows are deprecated inbound compatibility paths.",
 			},
 		}
@@ -101,7 +103,7 @@ func WellKnownOAuthProtectedResourceHandler() apptheory.Handler {
 		if err != nil {
 			return nil, fmt.Errorf("build protected resource metadata: %w", err)
 		}
-		md.ScopesSupported = []string{"read", "write", "follow"}
+		md.ScopesSupported = append([]string(nil), publicOAuthDiscoveryScopes...)
 		md.BearerMethodsSupported = []string{"header"}
 
 		body, err := md.MarshalJSONBytes()

--- a/internal/mcpapp/well_known_test.go
+++ b/internal/mcpapp/well_known_test.go
@@ -3,6 +3,7 @@ package mcpapp_test
 import (
 	"context"
 	"encoding/json"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -36,7 +37,11 @@ func TestM7_WellKnownMcpJSON(t *testing.T) {
 		Endpoint     string           `json:"endpoint"`
 		Capabilities map[string]bool  `json:"capabilities"`
 		Tools        []map[string]any `json:"tools"`
-		Auth         map[string]any   `json:"auth"`
+		Auth         struct {
+			Type   string   `json:"type"`
+			Scopes []string `json:"scopes"`
+			Notes  string   `json:"notes"`
+		} `json:"auth"`
 	}
 	if err := json.Unmarshal(resp.Body, &out); err != nil {
 		t.Fatalf("unmarshal: %v", err)
@@ -47,15 +52,17 @@ func TestM7_WellKnownMcpJSON(t *testing.T) {
 	if !out.Capabilities["tools"] {
 		t.Fatalf("expected capabilities.tools=true")
 	}
-	if _, ok := out.Auth["type"]; !ok {
-		t.Fatalf("expected auth hints")
+	if out.Auth.Type != "bearer" {
+		t.Fatalf("expected bearer auth hints, got %q", out.Auth.Type)
 	}
-	notes, _ := out.Auth["notes"].(string)
-	if !strings.Contains(notes, "OAuth access token") {
-		t.Fatalf("expected OAuth-first auth note, got %q", notes)
+	if want := []string{"read", "write", "follow", "push"}; !reflect.DeepEqual(out.Auth.Scopes, want) {
+		t.Fatalf("unexpected auth scopes: got %#v want %#v", out.Auth.Scopes, want)
 	}
-	if strings.Contains(strings.ToLower(notes), "or managed instance key") {
-		t.Fatalf("discovery should not recommend managed instance key, got %q", notes)
+	if !strings.Contains(out.Auth.Notes, "OAuth access token") {
+		t.Fatalf("expected OAuth-first auth note, got %q", out.Auth.Notes)
+	}
+	if strings.Contains(strings.ToLower(out.Auth.Notes), "or managed instance key") {
+		t.Fatalf("discovery should not recommend managed instance key, got %q", out.Auth.Notes)
 	}
 
 	foundEcho := false


### PR DESCRIPTION
## Summary
- align both public discovery surfaces to lesser's canonical public OAuth scopes: `read`, `write`, `follow`, `push`
- stop advertising `admin` in `/.well-known/mcp.json`
- pin the discovery scope contract in tests and document the public scope catalog in `docs/mcp.md`

## Verification
- `GOTOOLCHAIN=auto go test ./internal/mcpapp`
- `GOTOOLCHAIN=auto go test ./...`
- `cd cdk && npm ci`
- `cd cdk && CDK_DEFAULT_ACCOUNT=000000000000 CDK_DEFAULT_REGION=us-east-1 GOTOOLCHAIN=auto ./node_modules/.bin/cdk synth --output "$(mktemp -d)" -c app=lesser -c stage=dev -c baseDomain=example.com`
- `GOTOOLCHAIN=auto bash scripts/check_cdk_discovery_routes.sh`

Closes #51
