### PR TITLE
Fix protected-resource authorization server URL

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -98,7 +98,8 @@ Variables:
 - `LESSER_TABLE_NAME` (string, required for `dynamo`)
   - The Lesser stage DynamoDB table name.
   - Also used to resolve managed trust configuration (`TRUST_CONFIG`) for soul API base URL and instance-key secret ARN.
-  - The managed `TRUST_CONFIG.baseURL` / `TrustBaseURL` is still required for the protected-resource issuer value.
+  - The managed `TRUST_CONFIG.baseURL` / `TrustBaseURL` is still required for soul API fallback routing and
+    instance-key secret resolution, but not for the protected-resource `authorization_servers` value.
   - Startup reachability checks for `/.well-known/oauth-authorization-server` run against the Lesser API host derived
     from `MCP_ENDPOINT`, not against `TrustBaseURL`.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -112,7 +112,7 @@ Fix:
 - Ensure `MCP_ENDPOINT` exactly matches the public URL clients use, for example `https://api.<stageDomain>/mcp`.
 - Verify `curl -sS "https://api.<stageDomain>/.well-known/oauth-authorization-server"` returns `200`.
 - In managed deployments, confirm `PK=INSTANCE#CONFIG, SK=TRUST_CONFIG` contains the correct Lesser trust base URL for
-  the protected-resource issuer field.
+  soul API fallback routing and instance-key secret resolution.
 - If a browser client is involved, ensure `MCP_ALLOWED_ORIGINS` includes the browser origin (for example `https://claude.ai`).
 
 ## Identity / communication tools fail (`not_found`, `not_configured`, or soul API 404)

--- a/internal/mcpapp/discovery_validation.go
+++ b/internal/mcpapp/discovery_validation.go
@@ -125,7 +125,7 @@ func oauthAuthorizationServerMetadataURL(baseURL string) string {
 	return baseURL + oauthAuthorizationServerMetadataPath
 }
 
-func oauthAuthorizationServerMetadataURLForMcpEndpoint(mcpEndpoint string) (string, error) {
+func authorizationServerURLForMcpEndpoint(mcpEndpoint string) (string, error) {
 	u, err := validatedMcpEndpoint(mcpEndpoint)
 	if err != nil {
 		return "", err
@@ -136,7 +136,15 @@ func oauthAuthorizationServerMetadataURLForMcpEndpoint(mcpEndpoint string) (stri
 		return "", fmt.Errorf("parse url: %w", err)
 	}
 	base.Path = strings.TrimSuffix(strings.TrimRight(base.Path, "/"), "/mcp")
-	return oauthAuthorizationServerMetadataURL(base.String()), nil
+	return base.String(), nil
+}
+
+func oauthAuthorizationServerMetadataURLForMcpEndpoint(mcpEndpoint string) (string, error) {
+	baseURL, err := authorizationServerURLForMcpEndpoint(mcpEndpoint)
+	if err != nil {
+		return "", err
+	}
+	return oauthAuthorizationServerMetadataURL(baseURL), nil
 }
 
 func defaultProbeAuthorizationServerMetadata(ctx context.Context, metadataURL string) error {

--- a/internal/mcpapp/oauth_protected_resource_test.go
+++ b/internal/mcpapp/oauth_protected_resource_test.go
@@ -61,7 +61,7 @@ func TestWellKnownOAuthProtectedResource(t *testing.T) {
 	if out.Resource != "https://api.example.com/mcp" {
 		t.Fatalf("unexpected resource: %q", out.Resource)
 	}
-	if len(out.AuthorizationServers) != 1 || out.AuthorizationServers[0] != "https://lesser.example" {
+	if len(out.AuthorizationServers) != 1 || out.AuthorizationServers[0] != "https://api.example.com" {
 		t.Fatalf("unexpected authorization_servers: %#v", out.AuthorizationServers)
 	}
 	if want := []string{"read", "write", "follow", "push"}; !reflect.DeepEqual(out.ScopesSupported, want) {
@@ -110,12 +110,16 @@ func TestWellKnownOAuthProtectedResource_InferEndpointFromRequest(t *testing.T) 
 	}
 
 	var out struct {
-		Resource string `json:"resource"`
+		Resource             string   `json:"resource"`
+		AuthorizationServers []string `json:"authorization_servers"`
 	}
 	if err := json.Unmarshal(resp.Body, &out); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	if out.Resource != "https://tenant.example.com/mcp" {
 		t.Fatalf("unexpected inferred resource: %q", out.Resource)
+	}
+	if want := []string{"https://tenant.example.com"}; !reflect.DeepEqual(out.AuthorizationServers, want) {
+		t.Fatalf("unexpected inferred authorization_servers: got %#v want %#v", out.AuthorizationServers, want)
 	}
 }

--- a/internal/mcpapp/well_known.go
+++ b/internal/mcpapp/well_known.go
@@ -1,7 +1,6 @@
 package mcpapp
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -86,20 +85,12 @@ func WellKnownOAuthProtectedResourceHandler() apptheory.Handler {
 			return apptheory.MustJSON(404, map[string]string{"error": "not_found"}), nil
 		}
 
-		cfg, err := loadEffectiveTrustConfig(trustConfigContext(ctx))
+		authorizationServerURL, err := authorizationServerURLForMcpEndpoint(endpoint)
 		if err != nil {
-			return nil, fmt.Errorf("load trust config: %w", err)
+			return invalidDiscoveryConfigResponse(fmt.Errorf("derive authorization server URL from MCP endpoint: %w", err)), nil
 		}
 
-		issuer := ""
-		if cfg != nil {
-			issuer = strings.TrimSpace(cfg.TrustBaseURL)
-		}
-		if issuer == "" {
-			return invalidDiscoveryConfigResponse(fmt.Errorf("TRUST_CONFIG.TrustBaseURL is required for OAuth discovery")), nil
-		}
-
-		md, err := oauthruntime.NewProtectedResourceMetadata(endpoint, []string{issuer})
+		md, err := oauthruntime.NewProtectedResourceMetadata(endpoint, []string{authorizationServerURL})
 		if err != nil {
 			return nil, fmt.Errorf("build protected resource metadata: %w", err)
 		}
@@ -143,13 +134,6 @@ func protectedResourceMetadataURLForRequest(ctx *apptheory.Context) string {
 		return ""
 	}
 	return url
-}
-
-func trustConfigContext(ctx *apptheory.Context) context.Context {
-	if ctx == nil {
-		return context.Background()
-	}
-	return ctx.Context()
 }
 
 func inferMcpEndpointFromRequest(ctx *apptheory.Context) string {


### PR DESCRIPTION
## Summary
- derive the advertised OAuth authorization server URL from `MCP_ENDPOINT` instead of `TRUST_CONFIG.TrustBaseURL`
- share the MCP-to-auth-host derivation with the startup metadata probe helper
- update tests and docs to match the protected-resource discovery contract

## Verification
- `GOTOOLCHAIN=auto go test ./internal/mcpapp`
- `GOTOOLCHAIN=auto go test ./...`
- `cd cdk && npm ci`
- `cd cdk && CDK_DEFAULT_ACCOUNT=000000000000 CDK_DEFAULT_REGION=us-east-1 GOTOOLCHAIN=auto ./node_modules/.bin/cdk synth --output "$(mktemp -d)" -c app=lesser -c stage=dev -c baseDomain=example.com`
- `GOTOOLCHAIN=auto bash scripts/check_cdk_discovery_routes.sh`

Closes #53
