### PR TITLE
Use probed issuer for protected-resource metadata

### DIFF
--- a/internal/lambdaentry/apigw_test.go
+++ b/internal/lambdaentry/apigw_test.go
@@ -174,7 +174,9 @@ func TestNewAPIGatewayHandler_OAuthProtectedResourceReturnsProxyResponseType(t *
 		}, nil
 	})
 	t.Cleanup(restore)
-	restoreProbe := mcpapp.SetProbeAuthorizationServerMetadataForTests(func(context.Context, string) error { return nil })
+	restoreProbe := mcpapp.SetProbeAuthorizationServerMetadataForTests(func(context.Context, string) (string, error) {
+		return "https://dev.example.com", nil
+	})
 	t.Cleanup(restoreProbe)
 
 	app, err := mcpapp.New("test", "dev")
@@ -242,7 +244,9 @@ func TestNewAPIGatewayHandler_OAuthProtectedResourceTrailingSlashNormalizes(t *t
 		}, nil
 	})
 	t.Cleanup(restore)
-	restoreProbe := mcpapp.SetProbeAuthorizationServerMetadataForTests(func(context.Context, string) error { return nil })
+	restoreProbe := mcpapp.SetProbeAuthorizationServerMetadataForTests(func(context.Context, string) (string, error) {
+		return "https://dev.example.com", nil
+	})
 	t.Cleanup(restoreProbe)
 
 	app, err := mcpapp.New("test", "dev")

--- a/internal/mcpapp/app.go
+++ b/internal/mcpapp/app.go
@@ -26,7 +26,7 @@ func New(name, version string) (*apptheory.App, error) {
 	)
 
 	app.Get("/.well-known/mcp.json", WithBrowserCORS(WellKnownMcpHandler(srv, name, version)))
-	app.Get("/.well-known/oauth-protected-resource", WithBrowserCORS(WellKnownOAuthProtectedResourceHandler()))
+	app.Get("/.well-known/oauth-protected-resource", WithBrowserCORS(WellKnownOAuthProtectedResourceHandler(cachedAuthorizationServerIssuer())))
 
 	handler := WithBrowserCORS(WithClientCompatibilityHeaders(WithMCPAuthorization(WithAudit(WithToolContext(srv.Handler()), logger))))
 	app.Post("/mcp", handler)

--- a/internal/mcpapp/discovery_validation.go
+++ b/internal/mcpapp/discovery_validation.go
@@ -2,12 +2,14 @@ package mcpapp
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	apptheory "github.com/theory-cloud/apptheory/runtime"
@@ -15,12 +17,22 @@ import (
 
 const oauthAuthorizationServerMetadataPath = "/.well-known/oauth-authorization-server"
 
+type authorizationServerMetadata struct {
+	Issuer string `json:"issuer"`
+}
+
 var probeAuthorizationServerMetadata = defaultProbeAuthorizationServerMetadata
+
+var authorizationServerIssuerCache struct {
+	mu     sync.RWMutex
+	issuer string
+}
 
 func validateDiscoveryStartupConfig(ctx context.Context) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	setAuthorizationServerIssuer("")
 
 	validatedEndpoint := ""
 	if raw := strings.TrimSpace(os.Getenv("MCP_ENDPOINT")); raw != "" {
@@ -55,9 +67,14 @@ func validateDiscoveryStartupConfig(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("validate MCP_ENDPOINT: %w", err)
 	}
-	if err := probeAuthorizationServerMetadata(ctx, metadataURL); err != nil {
+	issuer, err := probeAuthorizationServerMetadata(ctx, metadataURL)
+	if err != nil {
 		return fmt.Errorf("validate MCP_ENDPOINT reachability via %s: %w", metadataURL, err)
 	}
+	if _, err := validatedPublicBaseURL(issuer); err != nil {
+		return fmt.Errorf("validate authorization server issuer %q: %w", issuer, err)
+	}
+	setAuthorizationServerIssuer(issuer)
 
 	return nil
 }
@@ -147,27 +164,49 @@ func oauthAuthorizationServerMetadataURLForMcpEndpoint(mcpEndpoint string) (stri
 	return oauthAuthorizationServerMetadataURL(baseURL), nil
 }
 
-func defaultProbeAuthorizationServerMetadata(ctx context.Context, metadataURL string) error {
+func defaultProbeAuthorizationServerMetadata(ctx context.Context, metadataURL string) (string, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, metadataURL, nil)
 	if err != nil {
-		return fmt.Errorf("create request: %w", err)
+		return "", fmt.Errorf("create request: %w", err)
 	}
 	req.Header.Set("Accept", "application/json")
 
 	client := &http.Client{Timeout: 3 * time.Second}
 	resp, err := client.Do(req)
 	if err != nil {
-		return fmt.Errorf("request metadata: %w", err)
+		return "", fmt.Errorf("request metadata: %w", err)
 	}
 	defer resp.Body.Close()
-	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 8<<10))
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("unexpected status %d", resp.StatusCode)
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 8<<10))
+		return "", fmt.Errorf("unexpected status %d", resp.StatusCode)
 	}
-	return nil
+
+	var metadata authorizationServerMetadata
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 8<<10)).Decode(&metadata); err != nil {
+		return "", fmt.Errorf("decode metadata response: %w", err)
+	}
+
+	issuer := strings.TrimSpace(metadata.Issuer)
+	if issuer == "" {
+		return "", fmt.Errorf("metadata response missing issuer")
+	}
+	return issuer, nil
+}
+
+func cachedAuthorizationServerIssuer() string {
+	authorizationServerIssuerCache.mu.RLock()
+	defer authorizationServerIssuerCache.mu.RUnlock()
+	return authorizationServerIssuerCache.issuer
+}
+
+func setAuthorizationServerIssuer(issuer string) {
+	authorizationServerIssuerCache.mu.Lock()
+	defer authorizationServerIssuerCache.mu.Unlock()
+	authorizationServerIssuerCache.issuer = strings.TrimSpace(issuer)
 }

--- a/internal/mcpapp/discovery_validation_test.go
+++ b/internal/mcpapp/discovery_validation_test.go
@@ -39,9 +39,9 @@ func TestNew_ValidatesAuthorizationServerMetadataReachabilityFromMCPEndpoint(t *
 
 	previousProbe := probeAuthorizationServerMetadata
 	probedURL := ""
-	probeAuthorizationServerMetadata = func(_ context.Context, metadataURL string) error {
+	probeAuthorizationServerMetadata = func(_ context.Context, metadataURL string) (string, error) {
 		probedURL = metadataURL
-		return errors.New("dial tcp: i/o timeout")
+		return "", errors.New("dial tcp: i/o timeout")
 	}
 	t.Cleanup(func() {
 		probeAuthorizationServerMetadata = previousProbe
@@ -53,6 +53,37 @@ func TestNew_ValidatesAuthorizationServerMetadataReachabilityFromMCPEndpoint(t *
 	}
 	if want := "https://api.example.com/.well-known/oauth-authorization-server"; probedURL != want {
 		t.Fatalf("unexpected metadata probe url: got %q want %q", probedURL, want)
+	}
+}
+
+func TestNew_CachesAuthorizationServerIssuerFromMetadataProbe(t *testing.T) {
+	t.Setenv("MCP_SESSION_TABLE", "")
+	t.Setenv("MCP_ENDPOINT", "https://api.example.com/mcp")
+
+	previousLoader := loadEffectiveTrustConfig
+	loadEffectiveTrustConfig = func(context.Context) (*trustconfig.Effective, error) {
+		return &trustconfig.Effective{
+			TrustBaseURL: "https://lesser.example",
+			Present:      true,
+		}, nil
+	}
+	t.Cleanup(func() {
+		loadEffectiveTrustConfig = previousLoader
+	})
+
+	previousProbe := probeAuthorizationServerMetadata
+	probeAuthorizationServerMetadata = func(context.Context, string) (string, error) {
+		return "https://issuer.example", nil
+	}
+	t.Cleanup(func() {
+		probeAuthorizationServerMetadata = previousProbe
+	})
+
+	if _, err := New("test", "dev"); err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+	if got := cachedAuthorizationServerIssuer(); got != "https://issuer.example" {
+		t.Fatalf("unexpected cached issuer: got %q want %q", got, "https://issuer.example")
 	}
 }
 
@@ -72,9 +103,9 @@ func TestNew_SkipsAuthorizationServerMetadataProbeWithoutMCPEndpoint(t *testing.
 
 	previousProbe := probeAuthorizationServerMetadata
 	probeCalled := false
-	probeAuthorizationServerMetadata = func(context.Context, string) error {
+	probeAuthorizationServerMetadata = func(context.Context, string) (string, error) {
 		probeCalled = true
-		return nil
+		return "https://issuer.example", nil
 	}
 	t.Cleanup(func() {
 		probeAuthorizationServerMetadata = previousProbe
@@ -104,7 +135,9 @@ func TestWellKnownOAuthProtectedResource_RejectsConfiguredEndpointMismatch(t *te
 	})
 
 	previousProbe := probeAuthorizationServerMetadata
-	probeAuthorizationServerMetadata = func(context.Context, string) error { return nil }
+	probeAuthorizationServerMetadata = func(context.Context, string) (string, error) {
+		return "https://issuer.example", nil
+	}
 	t.Cleanup(func() {
 		probeAuthorizationServerMetadata = previousProbe
 	})
@@ -148,7 +181,9 @@ func TestWellKnownOAuthProtectedResource_AddsCORSForAllowedOrigin(t *testing.T) 
 	})
 
 	previousProbe := probeAuthorizationServerMetadata
-	probeAuthorizationServerMetadata = func(context.Context, string) error { return nil }
+	probeAuthorizationServerMetadata = func(context.Context, string) (string, error) {
+		return "https://issuer.example", nil
+	}
 	t.Cleanup(func() {
 		probeAuthorizationServerMetadata = previousProbe
 	})

--- a/internal/mcpapp/oauth_protected_resource_test.go
+++ b/internal/mcpapp/oauth_protected_resource_test.go
@@ -24,7 +24,9 @@ func TestWellKnownOAuthProtectedResource(t *testing.T) {
 		loadEffectiveTrustConfig = previous
 	})
 	previousProbe := probeAuthorizationServerMetadata
-	probeAuthorizationServerMetadata = func(context.Context, string) error { return nil }
+	probeAuthorizationServerMetadata = func(context.Context, string) (string, error) {
+		return "https://dev.example.com", nil
+	}
 	t.Cleanup(func() {
 		probeAuthorizationServerMetadata = previousProbe
 	})
@@ -61,7 +63,7 @@ func TestWellKnownOAuthProtectedResource(t *testing.T) {
 	if out.Resource != "https://api.example.com/mcp" {
 		t.Fatalf("unexpected resource: %q", out.Resource)
 	}
-	if len(out.AuthorizationServers) != 1 || out.AuthorizationServers[0] != "https://api.example.com" {
+	if len(out.AuthorizationServers) != 1 || out.AuthorizationServers[0] != "https://dev.example.com" {
 		t.Fatalf("unexpected authorization_servers: %#v", out.AuthorizationServers)
 	}
 	if want := []string{"read", "write", "follow", "push"}; !reflect.DeepEqual(out.ScopesSupported, want) {
@@ -84,7 +86,9 @@ func TestWellKnownOAuthProtectedResource_InferEndpointFromRequest(t *testing.T) 
 		loadEffectiveTrustConfig = previous
 	})
 	previousProbe := probeAuthorizationServerMetadata
-	probeAuthorizationServerMetadata = func(context.Context, string) error { return nil }
+	probeAuthorizationServerMetadata = func(context.Context, string) (string, error) {
+		return "https://dev.example.com", nil
+	}
 	t.Cleanup(func() {
 		probeAuthorizationServerMetadata = previousProbe
 	})

--- a/internal/mcpapp/testing_exports.go
+++ b/internal/mcpapp/testing_exports.go
@@ -20,7 +20,7 @@ func SetLoadEffectiveTrustConfigForTests(fn func(context.Context) (*trustconfig.
 }
 
 // SetProbeAuthorizationServerMetadataForTests lets sibling-package tests stub discovery validation probes.
-func SetProbeAuthorizationServerMetadataForTests(fn func(context.Context, string) error) func() {
+func SetProbeAuthorizationServerMetadataForTests(fn func(context.Context, string) (string, error)) func() {
 	previous := probeAuthorizationServerMetadata
 	if fn == nil {
 		probeAuthorizationServerMetadata = defaultProbeAuthorizationServerMetadata

--- a/internal/mcpapp/well_known.go
+++ b/internal/mcpapp/well_known.go
@@ -75,7 +75,9 @@ func WellKnownMcpHandler(srv *mcpserver.Server, name string, version string) app
 	}
 }
 
-func WellKnownOAuthProtectedResourceHandler() apptheory.Handler {
+func WellKnownOAuthProtectedResourceHandler(probedAuthorizationServerIssuer string) apptheory.Handler {
+	probedAuthorizationServerIssuer = strings.TrimSpace(probedAuthorizationServerIssuer)
+
 	return func(ctx *apptheory.Context) (*apptheory.Response, error) {
 		endpoint, err := validatedMcpEndpointForRequest(ctx)
 		if err != nil {
@@ -85,9 +87,12 @@ func WellKnownOAuthProtectedResourceHandler() apptheory.Handler {
 			return apptheory.MustJSON(404, map[string]string{"error": "not_found"}), nil
 		}
 
-		authorizationServerURL, err := authorizationServerURLForMcpEndpoint(endpoint)
-		if err != nil {
-			return invalidDiscoveryConfigResponse(fmt.Errorf("derive authorization server URL from MCP endpoint: %w", err)), nil
+		authorizationServerURL := probedAuthorizationServerIssuer
+		if authorizationServerURL == "" {
+			authorizationServerURL, err = authorizationServerURLForMcpEndpoint(endpoint)
+			if err != nil {
+				return invalidDiscoveryConfigResponse(fmt.Errorf("derive authorization server URL from MCP endpoint: %w", err)), nil
+			}
 		}
 
 		md, err := oauthruntime.NewProtectedResourceMetadata(endpoint, []string{authorizationServerURL})


### PR DESCRIPTION
## Summary
- parse the startup OAuth metadata probe response and cache the discovered issuer
- publish the probed issuer from `/.well-known/oauth-protected-resource`, with MCP-endpoint derivation kept only as the no-probe fallback
- update discovery and API Gateway tests to pin the issuer-caching contract end to end

## Testing
- GOTOOLCHAIN=auto go test ./internal/mcpapp
- GOTOOLCHAIN=auto go test ./internal/lambdaentry
- GOTOOLCHAIN=auto go test ./...
- cd cdk && npm ci
- cd cdk && CDK_DEFAULT_ACCOUNT=000000000000 CDK_DEFAULT_REGION=us-east-1 GOTOOLCHAIN=auto ./node_modules/.bin/cdk synth --output "$(mktemp -d)" -c app=lesser -c stage=dev -c baseDomain=example.com
- GOTOOLCHAIN=auto bash scripts/check_cdk_discovery_routes.sh

Closes #55
