### PR TITLE
Normalize soul binding username lookups

### DIFF
--- a/internal/mcpapp/identity_surfaces_test.go
+++ b/internal/mcpapp/identity_surfaces_test.go
@@ -1,6 +1,7 @@
 package mcpapp_test
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -15,6 +16,7 @@ import (
 	"github.com/equaltoai/lesser-body/internal/mcpapp"
 	"github.com/equaltoai/lesser-body/internal/soulapi"
 	"github.com/equaltoai/lesser-body/internal/soulbinding"
+	"github.com/equaltoai/lesser-body/internal/trustconfig"
 )
 
 func TestLBM1_IdentityToolsAndChannelResources(t *testing.T) {
@@ -28,7 +30,7 @@ func TestLBM1_IdentityToolsAndChannelResources(t *testing.T) {
 	defer soulbinding.ResetForTests()
 
 	const agentID = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-	const tokenUser = "agent1"
+	const tokenUser = "Agent1"
 
 	var gotBindingPK string
 	var gotBindingSK string
@@ -114,6 +116,10 @@ func TestLBM1_IdentityToolsAndChannelResources(t *testing.T) {
 	t.Setenv("LESSER_SOUL_API_BASE_URL", server.URL)
 	lesserapi.ResetForTests()
 	soulapi.ResetForTests()
+	restoreTrustConfig := mcpapp.SetLoadEffectiveTrustConfigForTests(func(context.Context) (*trustconfig.Effective, error) {
+		return &trustconfig.Effective{}, nil
+	})
+	t.Cleanup(restoreTrustConfig)
 
 	app, err := mcpapp.New("test", "dev")
 	if err != nil {
@@ -147,7 +153,7 @@ func TestLBM1_IdentityToolsAndChannelResources(t *testing.T) {
 		if resp.Status != 200 {
 			t.Fatalf("identity_whoami: status=%d body=%s", resp.Status, string(resp.Body))
 		}
-		if gotBindingPK != "SOUL_BODY_BINDING_USERNAME#"+tokenUser {
+		if gotBindingPK != "SOUL_BODY_BINDING_USERNAME#agent1" {
 			t.Fatalf("expected binding lookup PK, got %q", gotBindingPK)
 		}
 		if gotBindingSK != "SOUL_BODY_BINDING" {

--- a/internal/soulbinding/soulbinding.go
+++ b/internal/soulbinding/soulbinding.go
@@ -52,7 +52,7 @@ func ResetForTests() {
 }
 
 func ResolveAgentID(ctx context.Context, username string) (string, error) {
-	username = strings.TrimSpace(username)
+	username = strings.ToLower(strings.TrimSpace(username))
 	if username == "" {
 		return "", nil
 	}
@@ -85,7 +85,7 @@ func ResolveAgentID(ctx context.Context, username string) (string, error) {
 }
 
 func soulBodyBindingUsernamePartitionKey(username string) string {
-	username = strings.TrimSpace(username)
+	username = strings.ToLower(strings.TrimSpace(username))
 	if username == "" {
 		return ""
 	}

--- a/internal/soulbinding/soulbinding_test.go
+++ b/internal/soulbinding/soulbinding_test.go
@@ -1,0 +1,151 @@
+package soulbinding
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	tablecore "github.com/theory-cloud/tabletheory/pkg/core"
+)
+
+func TestResolveAgentID_NormalizesUsernameBeforeLookup(t *testing.T) {
+	t.Setenv(envTableName, "test-main-table")
+
+	var gotPK string
+	var gotSK string
+	SetDBFactoryForTests(func() (tablecore.DB, error) {
+		return &fakeBindingDB{
+			firstFn: func(dest any, where map[string]any) error {
+				gotPK, _ = where["PK"].(string)
+				gotSK, _ = where["SK"].(string)
+				return setStringFields(dest, map[string]string{
+					"AgentID":  " Agent-ABC ",
+					"Username": "medic",
+				})
+			},
+		}, nil
+	})
+	t.Cleanup(ResetForTests)
+
+	agentID, err := ResolveAgentID(context.Background(), "  Medic ")
+	if err != nil {
+		t.Fatalf("resolve agent id: %v", err)
+	}
+	if gotPK != soulBodyBindingUserPKPre+"medic" {
+		t.Fatalf("expected lowercase binding PK, got %q", gotPK)
+	}
+	if gotSK != skSoulBodyBinding {
+		t.Fatalf("expected binding SK %q, got %q", skSoulBodyBinding, gotSK)
+	}
+	if agentID != "agent-abc" {
+		t.Fatalf("expected normalized agent id, got %q", agentID)
+	}
+}
+
+func TestSoulBodyBindingUsernamePartitionKey_NormalizesUsername(t *testing.T) {
+	if got := soulBodyBindingUsernamePartitionKey("  Medic "); got != soulBodyBindingUserPKPre+"medic" {
+		t.Fatalf("expected lowercase partition key, got %q", got)
+	}
+	if got := soulBodyBindingUsernamePartitionKey("   "); got != "" {
+		t.Fatalf("expected empty partition key for blank username, got %q", got)
+	}
+}
+
+type fakeBindingDB struct {
+	firstFn func(dest any, where map[string]any) error
+}
+
+func (f *fakeBindingDB) Model(any) tablecore.Query {
+	return &fakeBindingQuery{
+		where:   map[string]any{},
+		firstFn: f.firstFn,
+	}
+}
+
+func (f *fakeBindingDB) Transaction(func(tx *tablecore.Tx) error) error { return nil }
+func (f *fakeBindingDB) Migrate() error                                 { return nil }
+func (f *fakeBindingDB) AutoMigrate(...any) error                       { return nil }
+func (f *fakeBindingDB) Close() error                                   { return nil }
+func (f *fakeBindingDB) WithContext(context.Context) tablecore.DB       { return f }
+
+type fakeBindingQuery struct {
+	where   map[string]any
+	firstFn func(dest any, where map[string]any) error
+}
+
+func (q *fakeBindingQuery) Where(field string, _ string, value any) tablecore.Query {
+	q.where[field] = value
+	return q
+}
+
+func (q *fakeBindingQuery) Index(string) tablecore.Query                        { return q }
+func (q *fakeBindingQuery) Filter(string, string, any) tablecore.Query          { return q }
+func (q *fakeBindingQuery) OrFilter(string, string, any) tablecore.Query        { return q }
+func (q *fakeBindingQuery) FilterGroup(func(tablecore.Query)) tablecore.Query   { return q }
+func (q *fakeBindingQuery) OrFilterGroup(func(tablecore.Query)) tablecore.Query { return q }
+func (q *fakeBindingQuery) IfNotExists() tablecore.Query                        { return q }
+func (q *fakeBindingQuery) IfExists() tablecore.Query                           { return q }
+func (q *fakeBindingQuery) WithCondition(string, string, any) tablecore.Query   { return q }
+func (q *fakeBindingQuery) WithConditionExpression(string, map[string]any) tablecore.Query {
+	return q
+}
+func (q *fakeBindingQuery) OrderBy(string, string) tablecore.Query       { return q }
+func (q *fakeBindingQuery) Limit(int) tablecore.Query                    { return q }
+func (q *fakeBindingQuery) Offset(int) tablecore.Query                   { return q }
+func (q *fakeBindingQuery) Select(...string) tablecore.Query             { return q }
+func (q *fakeBindingQuery) ConsistentRead() tablecore.Query              { return q }
+func (q *fakeBindingQuery) WithRetry(int, time.Duration) tablecore.Query { return q }
+func (q *fakeBindingQuery) All(any) error                                { return nil }
+func (q *fakeBindingQuery) AllPaginated(any) (*tablecore.PaginatedResult, error) {
+	return nil, nil
+}
+func (q *fakeBindingQuery) Count() (int64, error)                     { return 0, nil }
+func (q *fakeBindingQuery) Create() error                             { return nil }
+func (q *fakeBindingQuery) CreateOrUpdate() error                     { return nil }
+func (q *fakeBindingQuery) Update(...string) error                    { return nil }
+func (q *fakeBindingQuery) UpdateBuilder() tablecore.UpdateBuilder    { return nil }
+func (q *fakeBindingQuery) Delete() error                             { return nil }
+func (q *fakeBindingQuery) Scan(any) error                            { return nil }
+func (q *fakeBindingQuery) ParallelScan(int32, int32) tablecore.Query { return q }
+func (q *fakeBindingQuery) ScanAllSegments(any, int32) error          { return nil }
+func (q *fakeBindingQuery) BatchGet([]any, any) error                 { return nil }
+func (q *fakeBindingQuery) BatchGetWithOptions([]any, any, *tablecore.BatchGetOptions) error {
+	return nil
+}
+func (q *fakeBindingQuery) BatchGetBuilder() tablecore.BatchGetBuilder { return nil }
+func (q *fakeBindingQuery) BatchCreate(any) error                      { return nil }
+func (q *fakeBindingQuery) BatchDelete([]any) error                    { return nil }
+func (q *fakeBindingQuery) BatchWrite([]any, []any) error              { return nil }
+func (q *fakeBindingQuery) BatchUpdateWithOptions([]any, []string, ...any) error {
+	return nil
+}
+func (q *fakeBindingQuery) Cursor(string) tablecore.Query               { return q }
+func (q *fakeBindingQuery) SetCursor(string) error                      { return nil }
+func (q *fakeBindingQuery) WithContext(context.Context) tablecore.Query { return q }
+
+func (q *fakeBindingQuery) First(dest any) error {
+	if q.firstFn == nil {
+		return nil
+	}
+	return q.firstFn(dest, q.where)
+}
+
+func setStringFields(dest any, values map[string]string) error {
+	rv := reflect.ValueOf(dest)
+	if rv.Kind() != reflect.Ptr || rv.IsNil() {
+		return nil
+	}
+	elem := rv.Elem()
+	if elem.Kind() != reflect.Struct {
+		return nil
+	}
+	for field, value := range values {
+		fv := elem.FieldByName(field)
+		if !fv.IsValid() || !fv.CanSet() || fv.Kind() != reflect.String {
+			continue
+		}
+		fv.SetString(value)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- lowercase and trim soul-binding usernames before the DynamoDB lookup in `ResolveAgentID`
- lowercase the `SOUL_BODY_BINDING_USERNAME#...` partition key helper directly
- add regression coverage for mixed-case OAuth usernames and direct soulbinding normalization

## Rubric
There is no separate rubric file or verifier script in this repo, so I used issue #81's stated fix criteria as the rubric:
- `ResolveAgentID()` lowercases and trims the incoming username before lookup
- `soulBodyBindingUsernamePartitionKey()` lowercases and trims the username
- the authenticated identity flow still resolves the correct agent when the OAuth username is mixed-case

## Verification
- `GOTOOLCHAIN=auto go test ./internal/soulbinding`
- `GOTOOLCHAIN=auto go test ./internal/mcpapp -run TestLBM1_IdentityToolsAndChannelResources -count=1`
- `GOTOOLCHAIN=auto go test ./...`
- `GOTOOLCHAIN=auto ./scripts/build.sh`

Closes #81