### PR TITLE
[codex] fix main CI workflow syntax after issue-98 merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Verify release assets
         run: bash scripts/verify_release_assets.sh v0.0.0-test dist/release-test
 
-      - name: Regression: release manifest checksum coverage
+      - name: Regression check for release manifest checksum coverage
         run: bash scripts/check_release_asset_checksum_regression.sh v0.0.0-test dist/release-test
 
       - name: Install CDK dependencies


### PR DESCRIPTION
## Summary

This is a narrow post-merge CI repair for the `#98` rollout.

- removes the raw colon from the new regression step label in `.github/workflows/ci.yml`
- restores valid YAML parsing for GitHub Actions on `main`

## Root Cause

The issue-98 merge introduced this step name:

`Regression: release manifest checksum coverage`

That unquoted colon made GitHub reject `.github/workflows/ci.yml` as invalid YAML, which is why the push run at:

`https://github.com/equaltoai/lesser-body/actions/runs/23770477186`

failed before any jobs were created.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); YAML.load_file(".github/workflows/release.yml")'`
- `rg -n "name:\\s+.*:\\s" .github/workflows`
