### PR TITLE
[codex] canonicalize MCP protected resource host

### DIFF
--- a/cdk/stacks/lesser_body_deploy_template_stack.go
+++ b/cdk/stacks/lesser_body_deploy_template_stack.go
@@ -85,6 +85,7 @@ func NewLesserBodyDeployTemplateStack(scope constructs.Construct, id string, pro
 		}),
 		ServiceVersion:        jsii.String(serviceVersion),
 		PublicEndpoint:        publicMcpEndpoint(stageDomain),
+		LesserAPIBaseURL:      lesserAPIBaseURL(stageDomain),
 		AllowedOrigins:        mcpAllowedOrigins(stageDomain),
 		JWTSecretArnParamPath: jwtSecretArnParamPathParam.ValueAsString(),
 		JWTSecretKeyParamPath: jwtSecretKeyParamPathParam.ValueAsString(),

--- a/cdk/stacks/lesser_body_stack.go
+++ b/cdk/stacks/lesser_body_stack.go
@@ -35,12 +35,13 @@ func NewLesserBodyStack(scope constructs.Construct, id string, props *LesserBody
 	}
 	stageDomain := resolvedStageDomain(stack, appName, stage, props.BaseDomain)
 	configureLesserBodyStack(stack, &lesserBodyRuntimeProps{
-		AppName:        jsii.String(appName),
-		Stage:          jsii.String(stage),
-		Code:           awslambda.Code_FromAsset(jsii.String("../dist/lesser-body.zip"), nil),
-		ServiceVersion: jsii.String("dev"),
-		PublicEndpoint: publicMcpEndpoint(stageDomain),
-		AllowedOrigins: mcpAllowedOrigins(stageDomain),
+		AppName:          jsii.String(appName),
+		Stage:            jsii.String(stage),
+		Code:             awslambda.Code_FromAsset(jsii.String("../dist/lesser-body.zip"), nil),
+		ServiceVersion:   jsii.String("dev"),
+		PublicEndpoint:   publicMcpEndpoint(stageDomain),
+		LesserAPIBaseURL: lesserAPIBaseURL(stageDomain),
+		AllowedOrigins:   mcpAllowedOrigins(stageDomain),
 	})
 
 	return &LesserBodyStack{Stack: stack}
@@ -60,6 +61,13 @@ func publicMcpEndpoint(stageDomain *string) *string {
 		jsii.String("https://api."),
 		stageDomain,
 		jsii.String("/mcp/{actor}"),
+	})
+}
+
+func lesserAPIBaseURL(stageDomain *string) *string {
+	return awscdk.Fn_Join(jsii.String(""), &[]*string{
+		jsii.String("https://api."),
+		stageDomain,
 	})
 }
 

--- a/cdk/stacks/lesser_body_stack_shared.go
+++ b/cdk/stacks/lesser_body_stack_shared.go
@@ -19,6 +19,7 @@ type lesserBodyRuntimeProps struct {
 	Code                  awslambda.Code
 	ServiceVersion        *string
 	PublicEndpoint        *string
+	LesserAPIBaseURL      *string
 	AllowedOrigins        *string
 	JWTSecretArnParamPath *string
 	JWTSecretKeyParamPath *string
@@ -193,6 +194,9 @@ func configureLesserBodyStack(stack awscdk.Stack, props *lesserBodyRuntimeProps)
 	)
 
 	handler.AddEnvironment(jsii.String("MCP_ENDPOINT"), props.PublicEndpoint, nil)
+	if props.LesserAPIBaseURL != nil && *props.LesserAPIBaseURL != "" {
+		handler.AddEnvironment(jsii.String("LESSER_API_BASE_URL"), props.LesserAPIBaseURL, nil)
+	}
 	handler.AddEnvironment(jsii.String("MCP_ALLOWED_ORIGINS"), props.AllowedOrigins, nil)
 	handler.AddEnvironment(jsii.String("MCP_SESSION_TTL_MINUTES"), jsii.String("60"), nil)
 
@@ -228,28 +232,33 @@ func configureLesserBodyStack(stack awscdk.Stack, props *lesserBodyRuntimeProps)
 		Resources: &[]*string{tableArn, indexArn},
 	}))
 
-	awsssm.NewCfnParameter(stack, jsii.String("McpLambdaArnParam"), &awsssm.CfnParameterProps{
+	mcpLambdaArnParam := awsssm.NewCfnParameter(stack, jsii.String("McpLambdaArnParam"), &awsssm.CfnParameterProps{
 		Name:  ssmParamName(props.AppName, props.Stage, jsii.String("lesser-body"), jsii.String("exports"), jsii.String("v1"), jsii.String("mcp_lambda_arn")),
 		Type:  jsii.String("String"),
 		Value: handler.FunctionArn(),
 	})
-	awsssm.NewCfnParameter(stack, jsii.String("McpEndpointParam"), &awsssm.CfnParameterProps{
+	mcpLambdaArnParam.OverrideLogicalId(jsii.String("McpLambdaArnParamE9C053F0"))
+
+	mcpEndpointParam := awsssm.NewCfnParameter(stack, jsii.String("McpEndpointParam"), &awsssm.CfnParameterProps{
 		Name:  ssmParamName(props.AppName, props.Stage, jsii.String("lesser-body"), jsii.String("exports"), jsii.String("v1"), jsii.String("mcp_endpoint_url")),
 		Type:  jsii.String("String"),
 		Value: props.PublicEndpoint,
 	})
+	mcpEndpointParam.OverrideLogicalId(jsii.String("McpEndpointParam71B07820"))
 	if server.SessionTable() != nil {
-		awsssm.NewCfnParameter(stack, jsii.String("McpSessionTableParam"), &awsssm.CfnParameterProps{
+		mcpSessionTableParam := awsssm.NewCfnParameter(stack, jsii.String("McpSessionTableParam"), &awsssm.CfnParameterProps{
 			Name:  ssmParamName(props.AppName, props.Stage, jsii.String("lesser-body"), jsii.String("exports"), jsii.String("v1"), jsii.String("mcp_session_table_name")),
 			Type:  jsii.String("String"),
 			Value: server.SessionTable().TableName(),
 		})
+		mcpSessionTableParam.OverrideLogicalId(jsii.String("McpSessionTableParam11A03692"))
 	}
-	awsssm.NewCfnParameter(stack, jsii.String("McpStreamTableParam"), &awsssm.CfnParameterProps{
+	mcpStreamTableParam := awsssm.NewCfnParameter(stack, jsii.String("McpStreamTableParam"), &awsssm.CfnParameterProps{
 		Name:  ssmParamName(props.AppName, props.Stage, jsii.String("lesser-body"), jsii.String("exports"), jsii.String("v1"), jsii.String("mcp_stream_table_name")),
 		Type:  jsii.String("String"),
 		Value: streamTable.TableName(),
 	})
+	mcpStreamTableParam.OverrideLogicalId(jsii.String("McpStreamTableParam604E9EFA"))
 }
 
 func ssmParamName(parts ...*string) *string {

--- a/internal/lambdaentry/apigw_test.go
+++ b/internal/lambdaentry/apigw_test.go
@@ -109,6 +109,55 @@ func TestNewAPIGatewayHandler_McpTrailingSlashPathNormalizes(t *testing.T) {
 	}
 }
 
+func TestNewAPIGatewayHandler_McpRouteRejectsWrongPublicHost(t *testing.T) {
+	t.Setenv("MCP_SESSION_TABLE", "")
+	t.Setenv("MCP_ENDPOINT", "https://example.com/mcp/{actor}")
+	t.Setenv("JWT_SECRET", "test")
+	auth.ResetForTests()
+
+	app, err := mcpapp.New("test", "dev")
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+
+	handler := NewAPIGatewayHandler(app)
+	body, _ := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "initialize",
+	})
+
+	out, err := handler(context.Background(), events.APIGatewayProxyRequest{
+		HTTPMethod: "POST",
+		Path:       "/mcp/agent1",
+		Headers: map[string]string{
+			"content-type":      "application/json",
+			"x-forwarded-proto": "https",
+			"x-forwarded-host":  "api.example.com",
+		},
+		Body:            string(body),
+		IsBase64Encoded: false,
+	})
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+
+	streaming, ok := out.(*events.APIGatewayProxyStreamingResponse)
+	if !ok {
+		t.Fatalf("expected APIGatewayProxyStreamingResponse for /mcp/{actor}, got %T", out)
+	}
+	if streaming.StatusCode != 400 {
+		t.Fatalf("expected 400, got %d", streaming.StatusCode)
+	}
+	b, readErr := io.ReadAll(streaming.Body)
+	if readErr != nil {
+		t.Fatalf("read body: %v", readErr)
+	}
+	if !strings.Contains(string(b), "app.invalid_public_url") {
+		t.Fatalf("expected invalid public url body, got %s", string(b))
+	}
+}
+
 func TestNewAPIGatewayHandler_McpDeleteReturnsProxyResponseType(t *testing.T) {
 	t.Setenv("MCP_SESSION_TABLE", "")
 	t.Setenv("MCP_ENDPOINT", "https://api.example.com/mcp/{actor}")

--- a/internal/mcpapp/app_test.go
+++ b/internal/mcpapp/app_test.go
@@ -351,6 +351,41 @@ func TestMcpActorRoute_UnauthorizedAdvertisesActorMetadata(t *testing.T) {
 	}
 }
 
+func TestMcpActorRoute_RejectsWrongPublicHost(t *testing.T) {
+	t.Setenv("MCP_SESSION_TABLE", "")
+	t.Setenv("MCP_ENDPOINT", "https://example.com/mcp/{actor}")
+	t.Setenv("JWT_SECRET", "test")
+	auth.ResetForTests()
+
+	token := newTestTokenWithAudience(t, "test", "agent1", []string{"read"}, []string{"https://example.com/mcp/agent1"})
+
+	app, err := mcpapp.New("test", "dev")
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+
+	env := testkit.New()
+	resp := invokeJSONAtPath(t, env, app, "/mcp/agent1", map[string][]string{
+		"authorization":     {"Bearer " + token},
+		"x-forwarded-proto": {"https"},
+		"x-forwarded-host":  {"api.example.com"},
+	}, &mcpruntime.Request{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "initialize",
+	})
+
+	if resp.Status != 400 {
+		t.Fatalf("expected 400 for wrong public host, got %d (%s)", resp.Status, string(resp.Body))
+	}
+	if !strings.Contains(string(resp.Body), "app.invalid_public_url") {
+		t.Fatalf("expected invalid public url body, got %s", string(resp.Body))
+	}
+	if !strings.Contains(string(resp.Body), "https://example.com/mcp/agent1") {
+		t.Fatalf("expected canonical MCP url in body, got %s", string(resp.Body))
+	}
+}
+
 func TestSharedMcpRoute_ReturnsRetiredResponse(t *testing.T) {
 	t.Setenv("MCP_SESSION_TABLE", "")
 	t.Setenv("JWT_SECRET", "test")

--- a/internal/mcpapp/discovery_validation.go
+++ b/internal/mcpapp/discovery_validation.go
@@ -27,6 +27,18 @@ type mcpEndpointInfo struct {
 	Actor    string
 }
 
+type mcpEndpointMismatchError struct {
+	Configured string
+	Requested  string
+}
+
+func (e *mcpEndpointMismatchError) Error() string {
+	if e == nil {
+		return "configured MCP_ENDPOINT does not match request URL"
+	}
+	return fmt.Sprintf("configured MCP_ENDPOINT %q does not match request URL %q", e.Configured, e.Requested)
+}
+
 var probeAuthorizationServerMetadata = defaultProbeAuthorizationServerMetadata
 
 var authorizationServerIssuerCache struct {
@@ -86,6 +98,31 @@ func validateDiscoveryStartupConfig(ctx context.Context) error {
 }
 
 func validatedMcpEndpointForRequest(ctx *apptheory.Context) (string, error) {
+	resolvedConfigured, err := configuredMcpEndpointForRequest(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	inferred := inferMcpEndpointFromRequest(ctx)
+	if inferred == "" {
+		return resolvedConfigured, nil
+	}
+
+	validatedInferred, err := validatedMcpEndpoint(inferred)
+	if err != nil {
+		return "", fmt.Errorf("infer MCP endpoint from request: %w", err)
+	}
+	if validatedInferred != resolvedConfigured {
+		return "", &mcpEndpointMismatchError{
+			Configured: resolvedConfigured,
+			Requested:  validatedInferred,
+		}
+	}
+
+	return resolvedConfigured, nil
+}
+
+func configuredMcpEndpointForRequest(ctx *apptheory.Context) (string, error) {
 	configured := strings.TrimSpace(os.Getenv("MCP_ENDPOINT"))
 	if configured == "" {
 		inferred := inferMcpEndpointFromRequest(ctx)
@@ -103,19 +140,6 @@ func validatedMcpEndpointForRequest(ctx *apptheory.Context) (string, error) {
 	resolvedConfigured, err := resolveConfiguredMcpEndpointForRequest(validatedConfigured, ctx)
 	if err != nil {
 		return "", fmt.Errorf("resolve configured MCP endpoint: %w", err)
-	}
-
-	inferred := inferMcpEndpointFromRequest(ctx)
-	if inferred == "" {
-		return resolvedConfigured, nil
-	}
-
-	validatedInferred, err := validatedMcpEndpoint(inferred)
-	if err != nil {
-		return "", fmt.Errorf("infer MCP endpoint from request: %w", err)
-	}
-	if validatedInferred != resolvedConfigured {
-		return "", fmt.Errorf("configured MCP_ENDPOINT %q does not match request URL %q", resolvedConfigured, validatedInferred)
 	}
 
 	return resolvedConfigured, nil

--- a/internal/mcpapp/discovery_validation_test.go
+++ b/internal/mcpapp/discovery_validation_test.go
@@ -187,11 +187,14 @@ func TestWellKnownOAuthProtectedResource_RejectsConfiguredEndpointMismatch(t *te
 			"x-forwarded-host":  {"other.example.com"},
 		},
 	})
-	if resp.Status != 500 {
-		t.Fatalf("expected 500, got %d (%s)", resp.Status, string(resp.Body))
+	if resp.Status != 400 {
+		t.Fatalf("expected 400, got %d (%s)", resp.Status, string(resp.Body))
 	}
-	if !strings.Contains(string(resp.Body), "MCP_ENDPOINT") {
-		t.Fatalf("expected MCP_ENDPOINT mismatch details, got %s", string(resp.Body))
+	if !strings.Contains(string(resp.Body), "app.invalid_public_url") {
+		t.Fatalf("expected invalid public url details, got %s", string(resp.Body))
+	}
+	if !strings.Contains(string(resp.Body), "https://api.example.com/.well-known/oauth-protected-resource/mcp/agent1") {
+		t.Fatalf("expected canonical resource metadata url in body, got %s", string(resp.Body))
 	}
 }
 

--- a/internal/mcpapp/mcp_auth.go
+++ b/internal/mcpapp/mcp_auth.go
@@ -27,6 +27,11 @@ func WithMCPAuthorization(next apptheory.Handler) apptheory.Handler {
 	authHook := auth.Hook(nil)
 
 	return func(ctx *apptheory.Context) (*apptheory.Response, error) {
+		expectedAudience, err := validatedMcpEndpointForRequest(ctx)
+		if err != nil {
+			return invalidDiscoveryConfigResponse(err), nil
+		}
+
 		identity, err := authHook(ctx)
 		if err != nil {
 			return unauthorizedMCPResponse(ctx), nil
@@ -35,7 +40,7 @@ func WithMCPAuthorization(next apptheory.Handler) apptheory.Handler {
 			return unauthorizedMCPResponse(ctx), nil
 		}
 		if principal := auth.PrincipalFromContext(ctx); principal != nil && principal.Type == auth.PrincipalTypeOAuthToken {
-			if err := auth.ValidateTokenAudience(principal.Claims, mcpEndpointForRequest(ctx)); err != nil {
+			if err := auth.ValidateTokenAudience(principal.Claims, expectedAudience); err != nil {
 				return unauthorizedMCPResponse(ctx), nil
 			}
 		}

--- a/internal/mcpapp/well_known.go
+++ b/internal/mcpapp/well_known.go
@@ -2,6 +2,7 @@ package mcpapp
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -148,7 +149,13 @@ func mcpEndpointForRequest(ctx *apptheory.Context) string {
 }
 
 func protectedResourceMetadataURLForRequest(ctx *apptheory.Context) string {
-	endpoint := mcpEndpointForRequest(ctx)
+	endpoint, err := configuredMcpEndpointForRequest(ctx)
+	if err != nil {
+		endpoint = ""
+	}
+	if endpoint == "" {
+		endpoint = mcpEndpointForRequest(ctx)
+	}
 	if url, ok := oauthruntime.ResourceMetadataURLFromMcpEndpoint(endpoint); ok {
 		return url
 	}
@@ -220,15 +227,30 @@ func mcpEndpointPathFromRequest(requestPath string) string {
 }
 
 func invalidDiscoveryConfigResponse(err error) *apptheory.Response {
+	status := 500
+	code := "app.config_invalid"
 	message := "invalid discovery configuration"
+	details := map[string]any{}
 	if err != nil && strings.TrimSpace(err.Error()) != "" {
 		message = strings.TrimSpace(err.Error())
 	}
+	var mismatch *mcpEndpointMismatchError
+	if errors.As(err, &mismatch) {
+		status = 400
+		code = "app.invalid_public_url"
+		details["reason"] = "configured_endpoint_mismatch"
+		details["canonical_mcp_url"] = mismatch.Configured
+		details["requested_mcp_url"] = mismatch.Requested
+		if resourceMetadataURL, ok := oauthruntime.ResourceMetadataURLFromMcpEndpoint(mismatch.Configured); ok {
+			details["canonical_resource_metadata_url"] = resourceMetadataURL
+		}
+	}
 
-	return apptheory.MustJSON(500, map[string]any{
+	return apptheory.MustJSON(status, map[string]any{
 		"error": map[string]any{
-			"code":    "app.config_invalid",
+			"code":    code,
 			"message": message,
+			"details": details,
 		},
 	})
 }


### PR DESCRIPTION
## What changed
- canonicalize the public MCP endpoint and actor-scoped protected-resource metadata to the `api.<stage-domain>` host
- pass `LESSER_API_BASE_URL` into the runtime so downstream social tools resolve the same API origin
- reject actor-scoped MCP/discovery requests that arrive on a non-canonical public host with `app.invalid_public_url`
- add coverage for the wrong-host rejection path and keep the large-template SSM export logical IDs stable

## Why
CloudFront sends the actor-scoped MCP traffic through the API origin, so the runtime was effectively seeing `api.<stage-domain>` as the resource host even when the public snippets or stack config treated the apex host as canonical. That split caused protected-resource discovery and auth challenges to disagree.

## Impact
- MCP clients now get one canonical protected resource URL: `https://api.<stage-domain>/mcp/{actor}`
- actor-scoped discovery documents point at that same host consistently
- requests that hit the wrong public host fail explicitly instead of drifting into mismatched OIDC metadata

## Validation
- `GOTOOLCHAIN=auto go test ./...`
- `bash scripts/verify_release_assets.sh v0.0.0-test dist/release-test-ci`
- `bash scripts/check_release_asset_checksum_regression.sh v0.0.0-test dist/release-test-ci`
- `bash scripts/check_managed_template_default_regression.sh v0.0.0-test dist/release-test-ci`
- `npm ci` in `cdk/`
- `CDK_DEFAULT_ACCOUNT=000000000000 CDK_DEFAULT_REGION=us-east-1 GOTOOLCHAIN=auto ./node_modules/.bin/cdk synth -c app=lesser -c stage=dev -c baseDomain=example.com`
- `GOTOOLCHAIN=auto bash scripts/check_cdk_discovery_routes.sh`
