### PR TITLE
fix(cdk): reset managed MCP stream table baseline

### DIFF
--- a/cdk/stacks/lesser_body_stack_shared.go
+++ b/cdk/stacks/lesser_body_stack_shared.go
@@ -122,7 +122,7 @@ func configureLesserBodyStack(stack awscdk.Stack, props *lesserBodyRuntimeProps)
 		SessionTableName:   tokenJoin("-", props.AppName, props.Stage, jsii.String("mcp"), jsii.String("sessions")),
 		SessionTtlMinutes:  jsii.Number(60),
 		EnableStreamTable:  jsii.Bool(true),
-		StreamTableName:    tokenJoin("-", props.AppName, props.Stage, jsii.String("mcp"), jsii.String("streams")),
+		StreamTableName:    tokenJoin("-", props.AppName, props.Stage, jsii.String("mcp"), jsii.String("streams"), jsii.String("v2")),
 		StreamTtlMinutes:   jsii.Number(60),
 		Stage: &apptheorycdk.AppTheoryRestApiRouterStageOptions{
 			StageName:          props.Stage,

--- a/cdk/stacks/lesser_body_stack_shared.go
+++ b/cdk/stacks/lesser_body_stack_shared.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/aws/aws-cdk-go/awscdk/v2"
+	"github.com/aws/aws-cdk-go/awscdk/v2/awsdynamodb"
 	"github.com/aws/aws-cdk-go/awscdk/v2/awsiam"
 	"github.com/aws/aws-cdk-go/awscdk/v2/awslambda"
 	"github.com/aws/aws-cdk-go/awscdk/v2/awslogs"
@@ -27,6 +28,11 @@ type lesserBodyRuntimeProps struct {
 	LesserTableParamPath     *string
 	LesserHostInstanceKeyARN *string
 }
+
+const (
+	mcpSessionTableLogicalID = "McpServerSessionTable469EA0FB"
+	mcpStreamTableLogicalID  = "McpServerStreamTableC6A2DC7E"
+)
 
 func configureLesserBodyStack(stack awscdk.Stack, props *lesserBodyRuntimeProps) {
 	serviceVersion := props.ServiceVersion
@@ -152,6 +158,8 @@ func configureLesserBodyStack(stack awscdk.Stack, props *lesserBodyRuntimeProps)
 	}))
 
 	server := apptheorycdk.NewAppTheoryRemoteMcpServer(stack, jsii.String("McpServer"), mcpProps)
+	overrideRemoteMcpTableLogicalID(server.SessionTable(), mcpSessionTableLogicalID)
+	overrideRemoteMcpTableLogicalID(server.StreamTable(), mcpStreamTableLogicalID)
 
 	handler.AddEnvironment(jsii.String("MCP_ENDPOINT"), props.PublicEndpoint, nil)
 	if props.LesserAPIBaseURL != nil && *props.LesserAPIBaseURL != "" {
@@ -220,6 +228,23 @@ func configureLesserBodyStack(stack awscdk.Stack, props *lesserBodyRuntimeProps)
 		})
 		mcpStreamTableParam.OverrideLogicalId(jsii.String("McpStreamTableParam604E9EFA"))
 	}
+}
+
+func overrideRemoteMcpTableLogicalID(table awsdynamodb.ITable, logicalID string) {
+	if table == nil {
+		return
+	}
+
+	defaultChild := table.Node().DefaultChild()
+	if defaultChild == nil {
+		panic("remote MCP table is missing a default child")
+	}
+
+	cfnResource, ok := defaultChild.(awscdk.CfnResource)
+	if !ok {
+		panic("remote MCP table default child is not a CloudFormation resource")
+	}
+	cfnResource.OverrideLogicalId(jsii.String(logicalID))
 }
 
 func ssmParamName(parts ...*string) *string {

--- a/cdk/stacks/lesser_body_stack_shared_test.go
+++ b/cdk/stacks/lesser_body_stack_shared_test.go
@@ -116,6 +116,30 @@ func TestManagedDeployTemplateSupportsExactLesserHostInstanceKeyARN(t *testing.T
 	}
 }
 
+func TestManagedDeployTemplatePinsMcpTableLogicalIDs(t *testing.T) {
+	template := synthTemplate(t, "TestStack", func(app awscdk.App) {
+		_ = NewLesserBodyDeployTemplateStack(app, "TestStack", &LesserBodyDeployTemplateStackProps{
+			StackProps: awscdk.StackProps{
+				Env: &awscdk.Environment{
+					Account: jsii.String("123456789012"),
+					Region:  jsii.String("us-east-1"),
+				},
+			},
+			ServiceVersion: "test",
+			Stage:          "dev",
+		})
+	})
+
+	got := dynamoTableLogicalIDs(t, mustResources(t, template))
+	want := []string{
+		"McpServerSessionTable469EA0FB",
+		"McpServerStreamTableC6A2DC7E",
+	}
+	if mustJSON(t, got) != mustJSON(t, want) {
+		t.Fatalf("unexpected managed DynamoDB logical IDs: got=%s want=%s", mustJSON(t, got), mustJSON(t, want))
+	}
+}
+
 func TestLesserBodyUsesAppTheoryDurableStreamTableSchema(t *testing.T) {
 	assetDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(assetDir, "bootstrap"), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
@@ -548,6 +572,23 @@ func dynamoTableFingerprints(t *testing.T, resources map[string]any) map[string]
 		}
 	}
 
+	return out
+}
+
+func dynamoTableLogicalIDs(t *testing.T, resources map[string]any) []string {
+	t.Helper()
+
+	var out []string
+	for logicalID, raw := range resources {
+		resource, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		if typ, _ := resource["Type"].(string); typ == "AWS::DynamoDB::Table" {
+			out = append(out, logicalID)
+		}
+	}
+	sort.Strings(out)
 	return out
 }
 

--- a/cdk/stacks/lesser_body_stack_shared_test.go
+++ b/cdk/stacks/lesser_body_stack_shared_test.go
@@ -144,7 +144,7 @@ func TestLesserBodyUsesAppTheoryDurableStreamTableSchema(t *testing.T) {
 		})
 	})
 
-	streamTable := findDynamoTableByName(t, mustResources(t, template), "theory-dev-mcp-streams")
+	streamTable := findDynamoTableByName(t, mustResources(t, template), "theory-dev-mcp-streams-v2")
 	props, ok := streamTable["Properties"].(map[string]any)
 	if !ok {
 		t.Fatalf("stream table missing Properties")
@@ -276,7 +276,7 @@ func TestLesserBodyNamedMcpTableFingerprints(t *testing.T) {
 		},
 		{
 			LogicalID:    "McpServerStreamTableC6A2DC7E",
-			TableName:    "theory-dev-mcp-streams",
+			TableName:    "theory-dev-mcp-streams-v2",
 			PartitionKey: "sessionId",
 			SortKey:      "eventId",
 			TTLAttribute: "expiresAt",
@@ -296,6 +296,44 @@ func TestLesserBodyNamedMcpTableFingerprints(t *testing.T) {
 		if actual != expected {
 			t.Fatalf("unexpected fingerprint for %q: got=%s want=%s", expected.TableName, mustJSON(t, actual), mustJSON(t, expected))
 		}
+	}
+}
+
+func TestLesserBodyStreamTableExportNameStaysStableAcrossBaselineReset(t *testing.T) {
+	assetDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(assetDir, "bootstrap"), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write bootstrap: %v", err)
+	}
+
+	template := synthTemplate(t, "TestStack", func(app awscdk.App) {
+		stack := awscdk.NewStack(app, jsii.String("TestStack"), &awscdk.StackProps{
+			Env: &awscdk.Environment{
+				Account: jsii.String("123456789012"),
+				Region:  jsii.String("us-east-1"),
+			},
+		})
+
+		configureLesserBodyStack(stack, &lesserBodyRuntimeProps{
+			AppName:               jsii.String("theory"),
+			Stage:                 jsii.String("dev"),
+			Code:                  awslambda.Code_FromAsset(jsii.String(assetDir), nil),
+			ServiceVersion:        jsii.String("test"),
+			PublicEndpoint:        jsii.String("https://api.dev.example.com/mcp/{actor}"),
+			LesserAPIBaseURL:      jsii.String("https://api.dev.example.com"),
+			AllowedOrigins:        jsii.String("https://claude.ai"),
+			JWTSecretArnParamPath: jsii.String("/theory/shared/secrets/jwt-secret-arn"),
+			JWTSecretKeyParamPath: jsii.String("/theory/shared/kms/encryption-key-arn"),
+			LesserTableParamPath:  jsii.String("/theory/dev/lesser/exports/v1/table_name"),
+		})
+	})
+
+	streamExport := findSSMParameterByName(t, mustResources(t, template), "/theory/dev/lesser-body/exports/v1/mcp_stream_table_name")
+	props, ok := streamExport["Properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("stream export missing Properties")
+	}
+	if got := mustJSON(t, props["Value"]); got != `{"Ref":"McpServerStreamTableC6A2DC7E"}` {
+		t.Fatalf("expected stream export value to ref McpServerStreamTableC6A2DC7E, got %s", got)
 	}
 }
 
@@ -435,6 +473,30 @@ func findDynamoTableByName(t *testing.T, resources map[string]any, tableName str
 	}
 
 	t.Fatalf("template missing AWS::DynamoDB::Table %q", tableName)
+	return nil
+}
+
+func findSSMParameterByName(t *testing.T, resources map[string]any, paramName string) map[string]any {
+	t.Helper()
+
+	for _, raw := range resources {
+		resource, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		if typ, _ := resource["Type"].(string); typ != "AWS::SSM::Parameter" {
+			continue
+		}
+		props, ok := resource["Properties"].(map[string]any)
+		if !ok {
+			continue
+		}
+		if got, _ := props["Name"].(string); got == paramName {
+			return resource
+		}
+	}
+
+	t.Fatalf("template missing AWS::SSM::Parameter %q", paramName)
 	return nil
 }
 

--- a/cdk/stacks/lesser_body_stack_shared_test.go
+++ b/cdk/stacks/lesser_body_stack_shared_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
@@ -235,6 +236,69 @@ func TestLesserBodyRemoteMcpServerUsesActorPathWiring(t *testing.T) {
 	}
 }
 
+func TestLesserBodyNamedMcpTableFingerprints(t *testing.T) {
+	assetDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(assetDir, "bootstrap"), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write bootstrap: %v", err)
+	}
+
+	template := synthTemplate(t, "TestStack", func(app awscdk.App) {
+		stack := awscdk.NewStack(app, jsii.String("TestStack"), &awscdk.StackProps{
+			Env: &awscdk.Environment{
+				Account: jsii.String("123456789012"),
+				Region:  jsii.String("us-east-1"),
+			},
+		})
+
+		configureLesserBodyStack(stack, &lesserBodyRuntimeProps{
+			AppName:               jsii.String("theory"),
+			Stage:                 jsii.String("dev"),
+			Code:                  awslambda.Code_FromAsset(jsii.String(assetDir), nil),
+			ServiceVersion:        jsii.String("test"),
+			PublicEndpoint:        jsii.String("https://api.dev.example.com/mcp/{actor}"),
+			LesserAPIBaseURL:      jsii.String("https://api.dev.example.com"),
+			AllowedOrigins:        jsii.String("https://claude.ai"),
+			JWTSecretArnParamPath: jsii.String("/theory/shared/secrets/jwt-secret-arn"),
+			JWTSecretKeyParamPath: jsii.String("/theory/shared/kms/encryption-key-arn"),
+			LesserTableParamPath:  jsii.String("/theory/dev/lesser/exports/v1/table_name"),
+		})
+	})
+
+	resources := mustResources(t, template)
+
+	want := []dynamoTableFingerprint{
+		{
+			LogicalID:    "McpServerSessionTable469EA0FB",
+			TableName:    "theory-dev-mcp-sessions",
+			PartitionKey: "sessionId",
+			SortKey:      "",
+			TTLAttribute: "expiresAt",
+		},
+		{
+			LogicalID:    "McpServerStreamTableC6A2DC7E",
+			TableName:    "theory-dev-mcp-streams",
+			PartitionKey: "sessionId",
+			SortKey:      "eventId",
+			TTLAttribute: "expiresAt",
+		},
+	}
+
+	got := dynamoTableFingerprints(t, resources)
+	if len(got) != len(want) {
+		t.Fatalf("expected %d DynamoDB tables, got %d: %s", len(want), len(got), mustJSON(t, got))
+	}
+
+	for _, expected := range want {
+		actual, ok := got[expected.TableName]
+		if !ok {
+			t.Fatalf("missing DynamoDB table %q in %s", expected.TableName, mustJSON(t, got))
+		}
+		if actual != expected {
+			t.Fatalf("unexpected fingerprint for %q: got=%s want=%s", expected.TableName, mustJSON(t, actual), mustJSON(t, expected))
+		}
+	}
+}
+
 func synthTemplate(t *testing.T, stackName string, build func(app awscdk.App)) map[string]any {
 	t.Helper()
 
@@ -372,6 +436,103 @@ func findDynamoTableByName(t *testing.T, resources map[string]any, tableName str
 
 	t.Fatalf("template missing AWS::DynamoDB::Table %q", tableName)
 	return nil
+}
+
+type dynamoTableFingerprint struct {
+	LogicalID    string `json:"logical_id"`
+	TableName    string `json:"table_name"`
+	PartitionKey string `json:"partition_key"`
+	SortKey      string `json:"sort_key,omitempty"`
+	TTLAttribute string `json:"ttl_attribute,omitempty"`
+}
+
+func dynamoTableFingerprints(t *testing.T, resources map[string]any) map[string]dynamoTableFingerprint {
+	t.Helper()
+
+	out := make(map[string]dynamoTableFingerprint)
+	logicalIDs := make([]string, 0, len(resources))
+	for logicalID := range resources {
+		logicalIDs = append(logicalIDs, logicalID)
+	}
+	sort.Strings(logicalIDs)
+
+	for _, logicalID := range logicalIDs {
+		raw := resources[logicalID]
+		resource, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		if typ, _ := resource["Type"].(string); typ != "AWS::DynamoDB::Table" {
+			continue
+		}
+
+		props, ok := resource["Properties"].(map[string]any)
+		if !ok {
+			t.Fatalf("table %q missing Properties", logicalID)
+		}
+
+		tableName, ok := props["TableName"].(string)
+		if !ok || tableName == "" {
+			t.Fatalf("table %q missing TableName", logicalID)
+		}
+
+		partitionKey, sortKey := dynamoTableKeyNames(t, logicalID, props)
+		out[tableName] = dynamoTableFingerprint{
+			LogicalID:    logicalID,
+			TableName:    tableName,
+			PartitionKey: partitionKey,
+			SortKey:      sortKey,
+			TTLAttribute: dynamoTableTTLAttribute(t, logicalID, props),
+		}
+	}
+
+	return out
+}
+
+func dynamoTableKeyNames(t *testing.T, logicalID string, props map[string]any) (string, string) {
+	t.Helper()
+
+	keySchema, ok := props["KeySchema"].([]any)
+	if !ok {
+		t.Fatalf("table %q missing KeySchema", logicalID)
+	}
+
+	var partitionKey string
+	var sortKey string
+	for _, raw := range keySchema {
+		entry, ok := raw.(map[string]any)
+		if !ok {
+			t.Fatalf("table %q KeySchema entry has unexpected type %T", logicalID, raw)
+		}
+		attrName, _ := entry["AttributeName"].(string)
+		keyType, _ := entry["KeyType"].(string)
+		switch keyType {
+		case "HASH":
+			partitionKey = attrName
+		case "RANGE":
+			sortKey = attrName
+		}
+	}
+
+	if partitionKey == "" {
+		t.Fatalf("table %q missing HASH key", logicalID)
+	}
+
+	return partitionKey, sortKey
+}
+
+func dynamoTableTTLAttribute(t *testing.T, logicalID string, props map[string]any) string {
+	t.Helper()
+
+	spec, ok := props["TimeToLiveSpecification"].(map[string]any)
+	if !ok {
+		t.Fatalf("table %q missing TimeToLiveSpecification", logicalID)
+	}
+	attrName, _ := spec["AttributeName"].(string)
+	if attrName == "" {
+		t.Fatalf("table %q missing TTL attribute name", logicalID)
+	}
+	return attrName
 }
 
 func mustJSON(t *testing.T, value any) string {

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -140,6 +140,9 @@ Notes:
 - `--lesser-host-instance-key-arn` is optional. If omitted, the helper also checks the shell environment for
   `LESSER_HOST_INSTANCE_KEY_ARN` and forwards it automatically when present.
 - Add `--no-execute-changeset` to exercise the real `aws cloudformation deploy` path without executing the change set.
+- The corrected MCP stream-table baseline is a versioned physical table (`...-mcp-streams-v2`) while the exported SSM
+  parameter name remains `mcp_stream_table_name`. Existing durable Lesser actor data is preserved; only transient MCP
+  session/stream state may reset during the update.
 
 See `docs/managed-deploy-contract.md` for the full release contract.
 

--- a/docs/managed-deploy-contract.md
+++ b/docs/managed-deploy-contract.md
@@ -105,6 +105,19 @@ Template behavior:
 - The release helper also forwards `--lesser-host-instance-key-arn` (or `$LESSER_HOST_INSTANCE_KEY_ARN` when set) into
   `LesserHostInstanceKeyARN`, so managed runners can keep IAM access aligned with the exact secret ARN they already hold.
 
+### Named MCP resource baseline
+
+Managed templates treat the MCP DynamoDB tables as an explicit compatibility boundary:
+
+- session table logical ID: `McpServerSessionTable469EA0FB`
+- stream table logical ID: `McpServerStreamTableC6A2DC7E`
+- session table physical-name suffix: `mcp-sessions`
+- stream table physical-name suffix: `mcp-streams-v2`
+
+The stream table is transient MCP transport state, not durable agent identity or long-term memory. The published SSM
+export name remains stable at `mcp_stream_table_name` even though the corrected physical stream-table baseline is the
+versioned `...-mcp-streams-v2` table.
+
 ## Published exports
 
 On deploy, `lesser-body` writes these SSM parameters:
@@ -156,6 +169,8 @@ That verification fails if:
 - `checksums.txt` omits any published managed asset, including `lesser-body-release.json`
 - a checksum does not match
 - a managed template contains a non-string `Parameters.*.Default`
+- a managed template drifts the pinned MCP session/stream table logical IDs
+- a managed template drifts the versioned MCP stream-table name baseline (`mcp-streams-v2`)
 - a template regresses to CDK asset/bootstrap assumptions
 - the helper script no longer operates purely from the produced release directory
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -32,10 +32,26 @@ exact built `dist/release` directory and uploads that same asset list to GitHub.
 The managed templates now use only CloudFormation-legal plain-string parameter defaults. Stage-specific SSM lookup paths
 are carried through explicit string parameters instead of intrinsic defaults.
 
+The current managed-template baseline also pins the named MCP DynamoDB resources:
+
+- session table logical ID: `McpServerSessionTable469EA0FB`
+- stream table logical ID: `McpServerStreamTableC6A2DC7E`
+- stream table physical-name suffix: `mcp-streams-v2`
+
+That stream-table reset is a one-time lab-era infrastructure correction. The table stores transient MCP stream/session
+transport state, so active sessions may reset during rollout, but durable Lesser actor data remains in Lesser's own
+table.
+
 Verify the produced release directory:
 
 ```bash
 bash scripts/verify_release_assets.sh v1.2.3 dist/release
+```
+
+Exercise the named-resource regression harness locally:
+
+```bash
+bash scripts/check_managed_template_named_resource_regression.sh v1.2.3 dist/release
 ```
 
 Verify the exact published GitHub release assets:
@@ -73,6 +89,7 @@ The workflow `.github/workflows/release.yml`:
 - builds release assets
 - verifies the release assets from the produced release directory
 - rejects managed templates with non-string CloudFormation parameter defaults before publish
+- rejects managed templates that drift the pinned MCP table logical IDs or the `mcp-streams-v2` stream-table baseline
 - rejects the release before upload if `checksums.txt` omits any published managed asset, including `lesser-body-release.json`
 - publishes a GitHub Release with the runtime zip, managed deploy templates, helper script, checksums, and metadata
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -185,3 +185,23 @@ Fix:
 
 - Deploy Lesser first (shared + stage). Then deploy lesser-body.
 - Only enable `soulEnabled=true` in Lesser after `mcp_lambda_arn` exists.
+
+## Managed deploy fails with stream-table replacement / `AWS::EarlyValidation::ResourceExistenceCheck`
+
+Symptoms:
+
+- Managed `deploy-lesser-body-from-release.sh` fails while creating a change set.
+- CloudFormation reports `AWS::EarlyValidation::ResourceExistenceCheck` for the MCP stream table.
+
+Cause:
+
+- An older managed template reused the physical stream-table name while changing the logical ID and schema boundary.
+- The corrected baseline uses the versioned physical table suffix `mcp-streams-v2` while keeping the exported SSM name
+  `mcp_stream_table_name` stable.
+
+Fix:
+
+- Upgrade to a release that includes the versioned stream-table baseline and the pinned MCP table logical IDs.
+- Expect transient MCP session/stream continuity to reset during the update; durable Lesser actor data is unaffected.
+- In lab, if you are validating a full repro/reset path, dropping and recreating the instance is acceptable, but it is
+  not required for the corrected design.

--- a/scripts/check_managed_template_named_resource_regression.sh
+++ b/scripts/check_managed_template_named_resource_regression.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $0 <version> [release-dir]" >&2
+  exit 1
+fi
+
+VERSION="$1"
+SOURCE_DIR="${2:-dist/release-test}"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if [[ ! -d "${SOURCE_DIR}" ]]; then
+  echo "release directory does not exist: ${SOURCE_DIR}" >&2
+  exit 1
+fi
+
+TMP_DIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+refresh_release_metadata() {
+  local release_dir="$1"
+  python3 - "${release_dir}" <<'PY'
+import hashlib
+import json
+import pathlib
+import sys
+
+root = pathlib.Path(sys.argv[1])
+
+def digest(path: pathlib.Path) -> tuple[str, int]:
+    data = path.read_bytes()
+    return hashlib.sha256(data).hexdigest(), path.stat().st_size
+
+deploy_path = root / "lesser-body-deploy.json"
+release_path = root / "lesser-body-release.json"
+deploy = json.loads(deploy_path.read_text())
+release = json.loads(release_path.read_text())
+
+template_files = {
+    "dev": "lesser-body-managed-dev.template.json",
+    "staging": "lesser-body-managed-staging.template.json",
+    "live": "lesser-body-managed-live.template.json",
+}
+
+for stage, filename in template_files.items():
+    sha, size = digest(root / filename)
+    deploy["templates"][stage]["sha256"] = sha
+    deploy["templates"][stage]["bytes"] = size
+    release["artifacts"]["deploy_templates"][stage]["sha256"] = sha
+    release["artifacts"]["deploy_templates"][stage]["bytes"] = size
+
+deploy_path.write_text(json.dumps(deploy, indent=2) + "\n")
+deploy_sha, deploy_size = digest(deploy_path)
+
+for artifact_key, filename in {
+    "lambda_zip": "lesser-body.zip",
+    "deploy_script": "deploy-lesser-body-from-release.sh",
+}.items():
+    sha, size = digest(root / filename)
+    release["artifacts"][artifact_key]["sha256"] = sha
+    release["artifacts"][artifact_key]["bytes"] = size
+
+release["artifacts"]["deploy_manifest"]["sha256"] = deploy_sha
+release["artifacts"]["deploy_manifest"]["bytes"] = deploy_size
+release_path.write_text(json.dumps(release, indent=2) + "\n")
+
+checksummed_assets = [
+    "lesser-body.zip",
+    "lesser-body-deploy.json",
+    "lesser-body-managed-dev.template.json",
+    "lesser-body-managed-staging.template.json",
+    "lesser-body-managed-live.template.json",
+    "deploy-lesser-body-from-release.sh",
+    "lesser-body-release.json",
+]
+
+lines = []
+for asset in checksummed_assets:
+    sha, _ = digest(root / asset)
+    lines.append(f"{sha}  {asset}\n")
+
+(root / "checksums.txt").write_text("".join(lines))
+PY
+}
+
+LOGICAL_ID_DIR="${TMP_DIR}/release-bad-stream-logical-id"
+cp -R "${SOURCE_DIR}" "${LOGICAL_ID_DIR}"
+
+python3 - "${LOGICAL_ID_DIR}/lesser-body-managed-dev.template.json" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+template = json.loads(path.read_text())
+resources = template["Resources"]
+resources["BrokenStreamTable12345678"] = resources.pop("McpServerStreamTableC6A2DC7E")
+resources["McpStreamTableParam604E9EFA"]["Properties"]["Value"] = {"Ref": "BrokenStreamTable12345678"}
+path.write_text(json.dumps(template, indent=2) + "\n")
+PY
+
+refresh_release_metadata "${LOGICAL_ID_DIR}"
+
+LOGICAL_ID_ERR="${TMP_DIR}/verify-logical-id.err"
+if bash "${ROOT_DIR}/scripts/verify_release_assets.sh" "${VERSION}" "${LOGICAL_ID_DIR}" > /dev/null 2> "${LOGICAL_ID_ERR}"; then
+  echo "verify_release_assets.sh unexpectedly accepted a managed template with a drifted stream table logical ID" >&2
+  exit 1
+fi
+
+if ! grep -Fq 'lesser-body-managed-dev.template.json: missing expected resource McpServerStreamTableC6A2DC7E' "${LOGICAL_ID_ERR}"; then
+  echo "verify_release_assets.sh did not report the expected stream-table logical-ID regression" >&2
+  cat "${LOGICAL_ID_ERR}" >&2
+  exit 1
+fi
+
+TABLE_NAME_DIR="${TMP_DIR}/release-bad-stream-table-name"
+cp -R "${SOURCE_DIR}" "${TABLE_NAME_DIR}"
+
+python3 - "${TABLE_NAME_DIR}/lesser-body-managed-dev.template.json" <<'PY'
+import json
+import pathlib
+import sys
+
+def rewrite(node):
+    if isinstance(node, str):
+        return node.replace("mcp-streams-v2", "mcp-streams-v3")
+    if isinstance(node, list):
+        return [rewrite(item) for item in node]
+    if isinstance(node, dict):
+        return {key: rewrite(value) for key, value in node.items()}
+    return node
+
+path = pathlib.Path(sys.argv[1])
+template = json.loads(path.read_text())
+table = template["Resources"]["McpServerStreamTableC6A2DC7E"]
+table["Properties"]["TableName"] = rewrite(table["Properties"]["TableName"])
+path.write_text(json.dumps(template, indent=2) + "\n")
+PY
+
+refresh_release_metadata "${TABLE_NAME_DIR}"
+
+TABLE_NAME_ERR="${TMP_DIR}/verify-table-name.err"
+if bash "${ROOT_DIR}/scripts/verify_release_assets.sh" "${VERSION}" "${TABLE_NAME_DIR}" > /dev/null 2> "${TABLE_NAME_ERR}"; then
+  echo "verify_release_assets.sh unexpectedly accepted a managed template with a drifted stream table name baseline" >&2
+  exit 1
+fi
+
+if ! grep -Fq 'lesser-body-managed-dev.template.json: McpServerStreamTableC6A2DC7E TableName must contain mcp-streams-v2' "${TABLE_NAME_ERR}"; then
+  echo "verify_release_assets.sh did not report the expected stream-table name regression" >&2
+  cat "${TABLE_NAME_ERR}" >&2
+  exit 1
+fi
+
+echo "Regression confirmed: verifier rejects MCP named-resource logical-ID and table-name drift"

--- a/scripts/verify_release_assets.sh
+++ b/scripts/verify_release_assets.sh
@@ -150,6 +150,29 @@ assert deploy["lambda"]["sha256"] == release["artifacts"]["lambda_zip"]["sha256"
 assert deploy["script"]["sha256"] == release["artifacts"]["deploy_script"]["sha256"]
 
 template_errors = []
+expected_named_tables = {
+    "McpServerSessionTable469EA0FB": {
+        "type": "AWS::DynamoDB::Table",
+        "table_name_contains": "mcp-sessions",
+    },
+    "McpServerStreamTableC6A2DC7E": {
+        "type": "AWS::DynamoDB::Table",
+        "table_name_contains": "mcp-streams-v2",
+    },
+}
+expected_export_refs = {
+    "McpSessionTableParam11A03692": {
+        "name_contains": "mcp_session_table_name",
+        "ref": "McpServerSessionTable469EA0FB",
+    },
+    "McpStreamTableParam604E9EFA": {
+        "name_contains": "mcp_stream_table_name",
+        "ref": "McpServerStreamTableC6A2DC7E",
+    },
+}
+forbidden_legacy_resources = {
+    "McpStreamTableEDC02B0A": "legacy stream table logical ID",
+}
 
 for stage in ("dev", "staging", "live"):
     stage_meta = release["artifacts"]["deploy_templates"][stage]
@@ -182,6 +205,54 @@ for stage in ("dev", "staging", "live"):
         if "Default" in param_spec and not isinstance(param_spec["Default"], str):
             template_errors.append(
                 f"{stage_path.name}: Parameters.{param_name}.Default must be a string, got {type(param_spec['Default']).__name__}"
+            )
+
+    resources = template.get("Resources", {})
+    if not isinstance(resources, dict):
+        template_errors.append(f"{stage_path.name}: template is missing Resources")
+        continue
+
+    for logical_id, label in forbidden_legacy_resources.items():
+        if logical_id in resources:
+            template_errors.append(f"{stage_path.name}: forbidden {label} {logical_id} is present")
+
+    for logical_id, spec in expected_named_tables.items():
+        resource = resources.get(logical_id)
+        if not isinstance(resource, dict):
+            template_errors.append(f"{stage_path.name}: missing expected resource {logical_id}")
+            continue
+        if resource.get("Type") != spec["type"]:
+            template_errors.append(
+                f"{stage_path.name}: {logical_id} expected type {spec['type']}, got {resource.get('Type')!r}"
+            )
+            continue
+        props = resource.get("Properties", {})
+        table_name_text = json.dumps(props.get("TableName"), sort_keys=True)
+        if spec["table_name_contains"] not in table_name_text:
+            template_errors.append(
+                f"{stage_path.name}: {logical_id} TableName must contain {spec['table_name_contains']}, got {table_name_text}"
+            )
+
+    for logical_id, spec in expected_export_refs.items():
+        resource = resources.get(logical_id)
+        if not isinstance(resource, dict):
+            template_errors.append(f"{stage_path.name}: missing expected resource {logical_id}")
+            continue
+        if resource.get("Type") != "AWS::SSM::Parameter":
+            template_errors.append(
+                f"{stage_path.name}: {logical_id} expected type AWS::SSM::Parameter, got {resource.get('Type')!r}"
+            )
+            continue
+        props = resource.get("Properties", {})
+        name_text = json.dumps(props.get("Name"), sort_keys=True)
+        if spec["name_contains"] not in name_text:
+            template_errors.append(
+                f"{stage_path.name}: {logical_id} Name must contain {spec['name_contains']}, got {name_text}"
+            )
+        expected_ref = {"Ref": spec["ref"]}
+        if props.get("Value") != expected_ref:
+            template_errors.append(
+                f"{stage_path.name}: {logical_id} Value must equal {expected_ref}, got {props.get('Value')!r}"
             )
 
 if template_errors:


### PR DESCRIPTION
## Milestone
managed MCP stream-table baseline reset — fix issue #144 by making the AppTheory-backed stream table the intentional managed baseline instead of preserving the pre-AppTheory custom table shape.

## Classification
bug-fix / operational-reliability / test-coverage / docs

## Surfaces affected
- `cdk/stacks/lesser_body_stack_shared.go`
- `cdk/stacks/lesser_body_stack_shared_test.go`
- `scripts/verify_release_assets.sh`
- `scripts/check_managed_template_named_resource_regression.sh`
- `docs/managed-deploy-contract.md`
- `docs/release.md`
- `docs/deployment.md`
- `docs/troubleshooting.md`

## Specialist walks referenced
- Tool surface: none
- MCP contract: none
- Lesser integration: preserves existing SSM export names
- Host delegation: advisory only for managed release consumers
- Framework: idiomatic AppTheory consumption; no local framework patch

## Consumer impact
- No MCP client contract change
- Managed deploy path gets a new explicit stream-table physical baseline: `...-mcp-streams-v2`
- Exported SSM name stays stable: `mcp_stream_table_name`
- Transient MCP stream/session continuity may reset during rollout; durable Lesser actor data remains intact

## Tasks
- [x] Add named MCP table fingerprint coverage in CDK tests
- [x] Version the MCP stream table physical baseline to `mcp-streams-v2`
- [x] Pin managed MCP table logical IDs for future template stability
- [x] Extend release verification to reject named-resource drift
- [x] Document the one-time stream-table baseline reset and new stability promise

## Root cause
Issue #144 surfaced a managed deploy failure on April 18, 2026 when the release assets still reused the legacy stream-table physical name while the AppTheory refactor had changed the logical ID and schema boundary. CloudFormation treated that as a replacement against an already-claimed custom name.

## Validation
- `go test ./...`
- `go vet ./...`
- `gofmt -l $(git diff --name-only main...HEAD -- '*.go')`
- `bash scripts/build.sh`
- `go test ./stacks ./cmd/release-template` (from `cdk/`)
- `CDK_DEFAULT_ACCOUNT=123456789012 CDK_DEFAULT_REGION=us-east-1 npx cdk synth -c app=lesser -c stage=dev -c baseDomain=example.com` (from `cdk/`)
- `bash scripts/build_release_assets.sh v0.2.31 <tmpdir>`
- `bash scripts/verify_release_assets.sh v0.2.31 <tmpdir>`
- `bash scripts/check_managed_template_named_resource_regression.sh v0.2.31 <tmpdir>`

## Stage rollout plan (handoff to deploy-body)
- [ ] Merged to main
- [ ] Deployed to lab / dev
- [ ] Lab soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
- `lesser`: none required; published SSM export names are unchanged
- `host`: release-note advisory for managed release consumers

## Notes
Repo-wide `gofmt -l .` and `cdk/go test ./...` are not clean baseline gates in this checkout because they walk `reference/` material and `cdk/node_modules/` template sources outside the ship target. The validation above uses the owned source packages and changed Go files instead.