### PR TITLE
feat(identity): support remote activitypub identity_lookup inputs

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -310,9 +310,10 @@ Notes:
   - current-instance local IDs such as `medic`
   - remote ActivityPub handles in `@user@domain` form
   - canonical remote actor URLs in `https://domain/users/user` form
-- For bare `user@domain` inputs, `identity_lookup` first tries managed-email resolution. If that returns not found, lesser-body falls back to treating the input as a remote ActivityPub handle and searches with `q=user` plus `domain=domain`.
+- For bare `user@domain` inputs, `identity_lookup` first tries managed-email resolution. If that returns not found, lesser-body falls back to treating the input as a remote ActivityPub handle and resolves it through the exact qualified host search form.
 - When a query is only a local ID, lesser-body resolves it against the authenticated actor's current instance domain.
   Cross-instance lookups should use an explicit domain-qualified form such as `@user@domain` or a canonical actor URL instead of relying on bare local IDs.
+- Remote ActivityPub handles and canonical actor URLs resolve through an exact domain-qualified host query instead of the fuzzy `q=<local>&domain=<domain>` path.
 - Remote actor URL support is intentionally narrow and deterministic. Unsupported remote URL shapes return a tool-level `invalid_request` error instead of passing the URL through unchanged to lesser-host.
 - Memory tools require an authenticated identity; the identity is derived from the JWT username claim, or set to
   `instance` for the deprecated managed-instance-key compatibility path.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -290,7 +290,7 @@ Scope key:
 | `sms_read` | Read | Read recent inbound SMS messages delivered to the instance. |
 | `voicemail_read` | Read | Read voicemail notifications and transcriptions. |
 | `identity_whoami` | Read | Return the current soul agent identity, channels, and contact preferences. |
-| `identity_lookup` | Read | Resolve a soul identity by ENS name, managed email, full agent ID, or a current-instance local ID such as `medic`. |
+| `identity_lookup` | Read | Resolve a soul identity by full agent ID, managed email, ENS name, a current-instance local ID such as `medic`, a remote ActivityPub handle such as `@steward@remote.example`, or a canonical actor URL such as `https://remote.example/users/steward`. |
 | `identity_verify` | Read | Verify that a recent communication matches a resolved soul identity using channel resolution plus notification provenance. |
 
 Notes:
@@ -308,8 +308,12 @@ Notes:
   - managed email address
   - ENS name
   - current-instance local IDs such as `medic`
+  - remote ActivityPub handles in `@user@domain` form
+  - canonical remote actor URLs in `https://domain/users/user` form
+- For bare `user@domain` inputs, `identity_lookup` first tries managed-email resolution. If that returns not found, lesser-body falls back to treating the input as a remote ActivityPub handle and searches with `q=user` plus `domain=domain`.
 - When a query is only a local ID, lesser-body resolves it against the authenticated actor's current instance domain.
-  Cross-instance lookups should use a domain-qualified form instead of relying on bare local IDs.
+  Cross-instance lookups should use an explicit domain-qualified form such as `@user@domain` or a canonical actor URL instead of relying on bare local IDs.
+- Remote actor URL support is intentionally narrow and deterministic. Unsupported remote URL shapes return a tool-level `invalid_request` error instead of passing the URL through unchanged to lesser-host.
 - Memory tools require an authenticated identity; the identity is derived from the JWT username claim, or set to
   `instance` for the deprecated managed-instance-key compatibility path.
 

--- a/internal/mcpapp/comm_contract_test.go
+++ b/internal/mcpapp/comm_contract_test.go
@@ -207,6 +207,9 @@ func TestLBM0_CommunicationToolSchemasMatchSpec(t *testing.T) {
 		if !strings.Contains(toolsByName["identity_lookup"].Description, "current-instance local ID") {
 			t.Fatalf("identity_lookup description should mention current-instance local IDs, got %q", toolsByName["identity_lookup"].Description)
 		}
+		if !strings.Contains(toolsByName["identity_lookup"].Description, "remote ActivityPub handle") {
+			t.Fatalf("identity_lookup description should mention remote ActivityPub handles, got %q", toolsByName["identity_lookup"].Description)
+		}
 		expectPropType(t, s, "query", "string")
 	}
 

--- a/internal/mcpapp/comm_prompts_test.go
+++ b/internal/mcpapp/comm_prompts_test.go
@@ -91,7 +91,7 @@ func TestLBM4_CommunicationPromptsExistAndReferencePreferences(t *testing.T) {
 	if !strings.Contains(combined, "identity_whoami") || !strings.Contains(combined, "agent://channels/preferences") {
 		t.Fatalf("expected compose_email prompt to reference identity_whoami and agent://channels/preferences, got: %s", combined)
 	}
-	if !strings.Contains(combined, "current-instance local ID") {
+	if !strings.Contains(combined, "current-instance local ID") || !strings.Contains(combined, "remote ActivityPub handle") {
 		t.Fatalf("expected compose_email prompt to describe supported identity_lookup query forms, got: %s", combined)
 	}
 
@@ -175,7 +175,7 @@ func TestLBM4_CommunicationPromptsExistAndReferencePreferences(t *testing.T) {
 	for _, m := range prompt.Messages {
 		combined += "\n" + m.Content.Text
 	}
-	if !strings.Contains(combined, "managed email, ENS name, full agentId, or current-instance local ID") {
+	if !strings.Contains(combined, "current-instance local ID") || !strings.Contains(combined, "remote ActivityPub handle") || !strings.Contains(combined, "canonical actor URL") {
 		t.Fatalf("expected respect_preferences prompt to describe supported identity_lookup query forms, got: %s", combined)
 	}
 }

--- a/internal/mcpapp/identity_surfaces_test.go
+++ b/internal/mcpapp/identity_surfaces_test.go
@@ -38,6 +38,7 @@ func TestLBM1_IdentityToolsAndChannelResources(t *testing.T) {
 	var gotBindingSK string
 	var searchQueries []string
 	var searchDomains []string
+	var emailResolveQueries []string
 	soulbinding.SetDBFactoryForTests(func() (tablecore.DB, error) {
 		return &fakeTableTheoryDB{
 			firstFn: func(dest any, where map[string]any) error {
@@ -61,6 +62,10 @@ func TestLBM1_IdentityToolsAndChannelResources(t *testing.T) {
 			searchQueries = append(searchQueries, q)
 			searchDomains = append(searchDomains, domain)
 			if domain == "test.example.com" && (q == "agent-alice" || q == "ops.v2" || q == "ops.eth") {
+				_, _ = w.Write([]byte(`{"version":"1","results":[{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-alice"}],"count":1,"has_more":false}`))
+				return
+			}
+			if domain == "remote.example" && q == "steward" {
 				_, _ = w.Write([]byte(`{"version":"1","results":[{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-alice"}],"count":1,"has_more":false}`))
 				return
 			}
@@ -94,7 +99,12 @@ func TestLBM1_IdentityToolsAndChannelResources(t *testing.T) {
 				"updatedAt":"2026-03-09T12:00:00Z"
 			}`))
 		case r.URL.Path == "/api/v1/soul/resolve/email/agent-alice@lessersoul.ai":
+			emailResolveQueries = append(emailResolveQueries, "agent-alice@lessersoul.ai")
 			_, _ = w.Write([]byte(`{"version":"1","agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-alice","status":"active"}}`))
+		case r.URL.Path == "/api/v1/soul/resolve/email/steward@remote.example":
+			emailResolveQueries = append(emailResolveQueries, "steward@remote.example")
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":{"message":"not found"}}`))
 		case r.URL.Path == "/api/v1/soul/resolve/ens/agent-alice.lessersoul.eth":
 			_, _ = w.Write([]byte(`{"version":"1","agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-alice","status":"active"}}`))
 		case r.URL.Path == "/api/v1/soul/resolve/ens/ops.eth":
@@ -236,9 +246,13 @@ func TestLBM1_IdentityToolsAndChannelResources(t *testing.T) {
 	if len(searchDomains) != 0 {
 		t.Fatalf("identity_lookup for managed identifiers should not set search domains, got %+v", searchDomains)
 	}
+	if !reflect.DeepEqual(emailResolveQueries, []string{"agent-alice@lessersoul.ai"}) {
+		t.Fatalf("identity_lookup for managed identifiers should only resolve supported managed email directly, got %+v", emailResolveQueries)
+	}
 
 	searchQueries = nil
 	searchDomains = nil
+	emailResolveQueries = nil
 
 	// identity_lookup should normalize current-instance local IDs and carry the authenticated instance domain explicitly.
 	for _, q := range []string{"agent-alice", "@agent-alice", "ops.v2", "ops.eth"} {
@@ -282,6 +296,83 @@ func TestLBM1_IdentityToolsAndChannelResources(t *testing.T) {
 	}
 	if !reflect.DeepEqual(searchDomains, []string{"test.example.com", "test.example.com", "test.example.com", "test.example.com"}) {
 		t.Fatalf("identity_lookup should provide current-instance domain context for local queries, got %+v", searchDomains)
+	}
+	if len(emailResolveQueries) != 0 {
+		t.Fatalf("identity_lookup should not attempt managed-email resolution for current-instance local IDs, got %+v", emailResolveQueries)
+	}
+
+	// identity_lookup should normalize remote ActivityPub identifiers into the existing domain-qualified soul search contract.
+	for _, tc := range []struct {
+		name             string
+		query            string
+		wantSearchQ      string
+		wantSearchDomain string
+		wantEmailResolve []string
+	}{
+		{
+			name:             "acct_form",
+			query:            "@steward@remote.example",
+			wantSearchQ:      "steward",
+			wantSearchDomain: "remote.example",
+		},
+		{
+			name:             "bare_handle_falls_back_after_email_miss",
+			query:            "steward@remote.example",
+			wantSearchQ:      "steward",
+			wantSearchDomain: "remote.example",
+			wantEmailResolve: []string{"steward@remote.example"},
+		},
+		{
+			name:             "canonical_actor_url",
+			query:            "https://remote.example/users/steward",
+			wantSearchQ:      "steward",
+			wantSearchDomain: "remote.example",
+		},
+	} {
+		searchQueries = nil
+		searchDomains = nil
+		emailResolveQueries = nil
+
+		callParams, _ := json.Marshal(map[string]any{
+			"name":      "identity_lookup",
+			"arguments": map[string]any{"query": tc.query},
+		})
+		resp := invokeJSON(t, env, app, map[string][]string{
+			"authorization":  {authHeader},
+			"mcp-session-id": {sessionID},
+		}, &mcpruntime.Request{JSONRPC: "2.0", ID: 32, Method: "tools/call", Params: callParams})
+		if resp.Status != 200 {
+			t.Fatalf("%s identity_lookup(%q): status=%d body=%s", tc.name, tc.query, resp.Status, string(resp.Body))
+		}
+
+		var rpc mcpruntime.Response
+		_ = json.Unmarshal(resp.Body, &rpc)
+		if rpc.Error != nil {
+			t.Fatalf("%s identity_lookup(%q) rpc error: %+v", tc.name, tc.query, rpc.Error)
+		}
+		var out mcpruntime.ToolResult
+		{
+			b, _ := json.Marshal(rpc.Result)
+			_ = json.Unmarshal(b, &out)
+		}
+		data, _ := out.StructuredContent["data"].(map[string]any)
+		matches, _ := data["matches"].([]any)
+		if len(matches) != 1 {
+			t.Fatalf("%s identity_lookup(%q): expected 1 match, got %+v", tc.name, tc.query, matches)
+		}
+		match, _ := matches[0].(map[string]any)
+		if match["agentId"] != agentID {
+			t.Fatalf("%s identity_lookup(%q): agentId want %s got %v", tc.name, tc.query, agentID, match["agentId"])
+		}
+		if !reflect.DeepEqual(searchQueries, []string{tc.wantSearchQ}) {
+			t.Fatalf("%s identity_lookup(%q): search q want [%s] got %+v", tc.name, tc.query, tc.wantSearchQ, searchQueries)
+		}
+		if !reflect.DeepEqual(searchDomains, []string{tc.wantSearchDomain}) {
+			t.Fatalf("%s identity_lookup(%q): search domain want [%s] got %+v", tc.name, tc.query, tc.wantSearchDomain, searchDomains)
+		}
+		if !reflect.DeepEqual(emailResolveQueries, tc.wantEmailResolve) {
+			t.Fatalf("%s identity_lookup(%q): email resolves want %+v got %+v", tc.name, tc.query, tc.wantEmailResolve, emailResolveQueries)
+		}
 	}
 
 	// agent://channels + agent://channels/preferences should read successfully.
@@ -585,5 +676,109 @@ func TestLBM1_IdentityLookupMalformedLocalIdentifierReturnsBadRequest(t *testing
 	}
 	if gotSearchQuery != "bad/local" || gotSearchDomain != "" {
 		t.Fatalf("unexpected downstream malformed search shape: q=%q domain=%q", gotSearchQuery, gotSearchDomain)
+	}
+}
+
+func TestLBM1_IdentityLookupUnsupportedRemoteActorURLReturnsBadRequest(t *testing.T) {
+	t.Setenv("MCP_SESSION_TABLE", "")
+	t.Setenv("JWT_SECRET", "test")
+	t.Setenv("LESSER_TABLE_NAME", "test-main-table")
+	auth.ResetForTests()
+	lesserapi.ResetForTests()
+	soulbinding.ResetForTests()
+	soulapi.ResetForTests()
+	defer soulbinding.ResetForTests()
+
+	const agentID = "0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+
+	soulbinding.SetDBFactoryForTests(func() (tablecore.DB, error) {
+		return &fakeTableTheoryDB{
+			firstFn: func(dest any, where map[string]any) error {
+				return setStructFields(dest, map[string]string{
+					"AgentID":  agentID,
+					"Username": "Agent1",
+				})
+			},
+		}, nil
+	})
+
+	searchCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case r.URL.Path == "/api/v1/soul/search":
+			searchCalled = true
+			_, _ = w.Write([]byte(`{"version":"1","results":[],"count":0,"has_more":false}`))
+		case r.URL.Path == "/api/v1/soul/agents/"+agentID:
+			_, _ = w.Write([]byte(`{"version":"1","agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-alice","status":"active"}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":{"message":"not found"}}`))
+		}
+	}))
+	defer server.Close()
+
+	t.Setenv("LESSER_API_BASE_URL", server.URL)
+	t.Setenv("LESSER_SOUL_API_BASE_URL", server.URL)
+	lesserapi.ResetForTests()
+	soulapi.ResetForTests()
+	restoreTrustConfig := mcpapp.SetLoadEffectiveTrustConfigForTests(func(context.Context) (*trustconfig.Effective, error) {
+		return &trustconfig.Effective{}, nil
+	})
+	t.Cleanup(restoreTrustConfig)
+
+	app, err := mcpapp.New("test", "dev")
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+
+	env := testkit.New()
+	token := newTestToken(t, "test", "Agent1", []string{"read"})
+	authHeader := "Bearer " + token
+
+	initResp := invokeJSON(t, env, app, map[string][]string{
+		"authorization": {authHeader},
+	}, &mcpruntime.Request{JSONRPC: "2.0", ID: 1, Method: "initialize"})
+	if initResp.Status != 200 {
+		t.Fatalf("initialize: status=%d body=%s", initResp.Status, string(initResp.Body))
+	}
+	sessionID := initResp.Headers["mcp-session-id"][0]
+
+	callParams, _ := json.Marshal(map[string]any{
+		"name":      "identity_lookup",
+		"arguments": map[string]any{"query": "https://remote.example/actors/steward"},
+	})
+	resp := invokeJSON(t, env, app, map[string][]string{
+		"authorization":  {authHeader},
+		"mcp-session-id": {sessionID},
+	}, &mcpruntime.Request{JSONRPC: "2.0", ID: 2, Method: "tools/call", Params: callParams})
+	if resp.Status != 200 {
+		t.Fatalf("identity_lookup(unsupported remote actor URL): status=%d body=%s", resp.Status, string(resp.Body))
+	}
+
+	var rpc mcpruntime.Response
+	_ = json.Unmarshal(resp.Body, &rpc)
+	if rpc.Error != nil {
+		t.Fatalf("identity_lookup(unsupported remote actor URL) rpc error: %+v", rpc.Error)
+	}
+	var out mcpruntime.ToolResult
+	{
+		b, _ := json.Marshal(rpc.Result)
+		_ = json.Unmarshal(b, &out)
+	}
+	if !out.IsError {
+		t.Fatalf("expected isError tool result, got %+v", out)
+	}
+	errPayload, _ := out.StructuredContent["error"].(map[string]any)
+	if errPayload["code"] != "invalid_request" {
+		t.Fatalf("expected invalid_request, got %+v", errPayload)
+	}
+	msg, _ := errPayload["message"].(string)
+	if !strings.Contains(strings.ToLower(msg), "unsupported") || !strings.Contains(strings.ToLower(msg), "url") {
+		t.Fatalf("expected actionable unsupported URL message, got %+v", errPayload)
+	}
+	if searchCalled {
+		t.Fatalf("identity_lookup should reject unsupported remote actor URLs before search")
 	}
 }

--- a/internal/mcpapp/identity_surfaces_test.go
+++ b/internal/mcpapp/identity_surfaces_test.go
@@ -65,7 +65,7 @@ func TestLBM1_IdentityToolsAndChannelResources(t *testing.T) {
 				_, _ = w.Write([]byte(`{"version":"1","results":[{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-alice"}],"count":1,"has_more":false}`))
 				return
 			}
-			if domain == "remote.example" && q == "steward" {
+			if domain == "" && q == "remote.example/steward" {
 				_, _ = w.Write([]byte(`{"version":"1","results":[{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-alice"}],"count":1,"has_more":false}`))
 				return
 			}
@@ -301,7 +301,7 @@ func TestLBM1_IdentityToolsAndChannelResources(t *testing.T) {
 		t.Fatalf("identity_lookup should not attempt managed-email resolution for current-instance local IDs, got %+v", emailResolveQueries)
 	}
 
-	// identity_lookup should normalize remote ActivityPub identifiers into the existing domain-qualified soul search contract.
+	// identity_lookup should normalize exact remote ActivityPub identifiers into the exact qualified soul search contract.
 	for _, tc := range []struct {
 		name             string
 		query            string
@@ -312,21 +312,21 @@ func TestLBM1_IdentityToolsAndChannelResources(t *testing.T) {
 		{
 			name:             "acct_form",
 			query:            "@steward@remote.example",
-			wantSearchQ:      "steward",
-			wantSearchDomain: "remote.example",
+			wantSearchQ:      "remote.example/steward",
+			wantSearchDomain: "",
 		},
 		{
 			name:             "bare_handle_falls_back_after_email_miss",
 			query:            "steward@remote.example",
-			wantSearchQ:      "steward",
-			wantSearchDomain: "remote.example",
+			wantSearchQ:      "remote.example/steward",
+			wantSearchDomain: "",
 			wantEmailResolve: []string{"steward@remote.example"},
 		},
 		{
 			name:             "canonical_actor_url",
 			query:            "https://remote.example/users/steward",
-			wantSearchQ:      "steward",
-			wantSearchDomain: "remote.example",
+			wantSearchQ:      "remote.example/steward",
+			wantSearchDomain: "",
 		},
 	} {
 		searchQueries = nil

--- a/internal/mcpserver/comm_prompts.go
+++ b/internal/mcpserver/comm_prompts.go
@@ -9,6 +9,8 @@ import (
 	mcpruntime "github.com/theory-cloud/apptheory/runtime/mcp"
 )
 
+const identityLookupPromptQueryForms = "managed email, ENS name, full agentId, current-instance local ID, remote ActivityPub handle such as @steward@remote.example, or canonical actor URL such as https://remote.example/users/steward"
+
 func promptComposeEmail(_ context.Context, args json.RawMessage) (*mcpruntime.PromptResult, error) {
 	var in struct {
 		To      string `json:"to"`
@@ -50,7 +52,7 @@ func promptComposeEmail(_ context.Context, args json.RawMessage) (*mcpruntime.Pr
 						"You are operating an agent's communication channels via lesser-body MCP.",
 						"Before composing/sending, fetch your current preferences and boundaries:",
 						"- Call identity_whoami and/or read agent://channels/preferences.",
-						"If the recipient is a soul-holding agent, prefer to look up their preferences first using identity_lookup with a managed email, ENS name, full agentId, or a current-instance local ID such as medic.",
+						"If the recipient is a soul-holding agent, prefer to look up their preferences first using identity_lookup with a " + identityLookupPromptQueryForms + ".",
 						"Respect communication_policy boundaries (e.g., no unsolicited outbound) and first-contact expectations (e.g., disclose you are an AI agent).",
 						"Keep the email concise and avoid secrets.",
 					}, "\n"),
@@ -130,7 +132,7 @@ func promptHandleInbound(_ context.Context, args json.RawMessage) (*mcpruntime.P
 					Text: strings.Join([]string{
 						"Use the agent's declared boundaries and contact preferences as constraints.",
 						"Fetch your own channels/preferences via identity_whoami or agent://channels/preferences if needed.",
-						"When the sender is identifiable, consider using identity_lookup with their managed email, ENS name, full agentId, or current-instance local ID to fetch contactPreferences and choose the best response channel/timing.",
+						"When the sender is identifiable, consider using identity_lookup with their " + identityLookupPromptQueryForms + " to fetch contactPreferences and choose the best response channel/timing.",
 						"Never invent message contents; read them via tools/resources.",
 					}, "\n"),
 				},
@@ -154,7 +156,7 @@ func promptRespectPreferences(_ context.Context, args json.RawMessage) (*mcprunt
 
 	user := strings.Join([]string{
 		"Determine the best way to contact the target agent while respecting their preferences.",
-		"1) Call identity_lookup with a managed email, ENS name, full agentId, or current-instance local ID (for example medic) to resolve their channels and contactPreferences.",
+		"1) Call identity_lookup with a " + identityLookupPromptQueryForms + " to resolve their channels and contactPreferences.",
 		"2) Recommend the best channel (email/sms/activitypub/mcp) and timing based on availability schedule, languages, and first-contact settings.",
 		"   - Treat voice as receive-only because outbound phone_call is intentionally disabled.",
 		"3) If preferences suggest constraints (e.g., requireSoul/requireReputation), explain what is missing and what to do next.",

--- a/internal/mcpserver/comm_tools.go
+++ b/internal/mcpserver/comm_tools.go
@@ -209,7 +209,7 @@ func identityWhoamiDef() mcpruntime.ToolDef {
 func identityLookupDef() mcpruntime.ToolDef {
 	return mcpruntime.ToolDef{
 		Name:        "identity_lookup",
-		Description: "Look up a soul identity by ENS name, managed email, full agentId, or a current-instance local ID such as medic.",
+		Description: "Look up a soul identity by full agentId, managed email, ENS name, a current-instance local ID such as medic, a remote ActivityPub handle such as @steward@remote.example, or a canonical actor URL such as https://remote.example/users/steward.",
 		InputSchema: json.RawMessage(`{
 			"type":"object",
 			"properties":{

--- a/internal/mcpserver/identity_tools.go
+++ b/internal/mcpserver/identity_tools.go
@@ -290,6 +290,7 @@ func lookupAgentIDs(ctx context.Context, client *soulapi.Client, q string) ([]st
 	}
 
 	allowENSLikeLocalFallback := false
+	allowBareRemoteHandleFallback := false
 	if agentID, err := resolveAgentIDByIdentifier(ctx, client, q); err == nil && agentID != "" {
 		return []string{agentID}, nil
 	} else if err != nil {
@@ -298,9 +299,10 @@ func lookupAgentIDs(ctx context.Context, client *soulapi.Client, q string) ([]st
 			return nil, err
 		}
 		allowENSLikeLocalFallback = looksLikeENSName(q)
+		allowBareRemoteHandleFallback = looksLikeEmail(q)
 	}
 
-	search, err := prepareSoulLookupSearch(ctx, client, q, allowENSLikeLocalFallback)
+	search, err := prepareSoulLookupSearch(ctx, client, q, allowENSLikeLocalFallback, allowBareRemoteHandleFallback)
 	if err != nil {
 		return nil, err
 	}
@@ -336,8 +338,17 @@ func lookupAgentIDs(ctx context.Context, client *soulapi.Client, q string) ([]st
 	return agentIDs, nil
 }
 
-func prepareSoulLookupSearch(ctx context.Context, client *soulapi.Client, q string, allowENSLikeLocalFallback bool) (soulLookupSearch, error) {
+func prepareSoulLookupSearch(ctx context.Context, client *soulapi.Client, q string, allowENSLikeLocalFallback bool, allowBareRemoteHandleFallback bool) (soulLookupSearch, error) {
 	searchQ := normalizeSoulLookupQuery(q)
+	if remoteSearch, handled, err := normalizeCanonicalRemoteActorURL(searchQ); handled || err != nil {
+		if err != nil {
+			return soulLookupSearch{}, err
+		}
+		return remoteSearch, nil
+	}
+	if remoteSearch, ok := normalizeRemoteActivityPubHandle(searchQ, allowBareRemoteHandleFallback); ok {
+		return remoteSearch, nil
+	}
 	localID, ok := normalizeCurrentInstanceLocalLookupQuery(searchQ, allowENSLikeLocalFallback)
 	if !ok {
 		return soulLookupSearch{Query: searchQ}, nil
@@ -407,6 +418,10 @@ func normalizeCurrentInstanceLocalLookupQuery(raw string, allowENSLikeLocalFallb
 		return "", false
 	}
 
+	return normalizeLookupLocalID(raw)
+}
+
+func normalizeLookupLocalID(raw string) (string, bool) {
 	localID := strings.ToLower(strings.TrimSpace(raw))
 	localID = strings.TrimPrefix(localID, "@")
 	localID = strings.TrimSuffix(localID, "/")
@@ -421,6 +436,100 @@ func normalizeCurrentInstanceLocalLookupQuery(raw string, allowENSLikeLocalFallb
 		return "", false
 	}
 	return localID, true
+}
+
+func normalizeRemoteActivityPubHandle(raw string, allowBareRemoteHandleFallback bool) (soulLookupSearch, bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return soulLookupSearch{}, false
+	}
+
+	if strings.HasPrefix(raw, "@") {
+		parts := strings.SplitN(strings.TrimPrefix(raw, "@"), "@", 2)
+		if len(parts) != 2 {
+			return soulLookupSearch{}, false
+		}
+		localID, ok := normalizeLookupLocalID(parts[0])
+		if !ok {
+			return soulLookupSearch{}, false
+		}
+		domain, ok := normalizeLookupDomain(parts[1])
+		if !ok {
+			return soulLookupSearch{}, false
+		}
+		return soulLookupSearch{Query: localID, Domain: domain}, true
+	}
+
+	if !allowBareRemoteHandleFallback || strings.Count(raw, "@") != 1 {
+		return soulLookupSearch{}, false
+	}
+
+	parts := strings.SplitN(raw, "@", 2)
+	localID, ok := normalizeLookupLocalID(parts[0])
+	if !ok {
+		return soulLookupSearch{}, false
+	}
+	domain, ok := normalizeLookupDomain(parts[1])
+	if !ok {
+		return soulLookupSearch{}, false
+	}
+	return soulLookupSearch{Query: localID, Domain: domain}, true
+}
+
+func normalizeLookupDomain(raw string) (string, bool) {
+	raw = strings.ToLower(strings.TrimSpace(strings.TrimSuffix(raw, ".")))
+	if raw == "" || strings.ContainsAny(raw, "/@") {
+		return "", false
+	}
+
+	parsed, err := url.Parse("https://" + raw)
+	if err != nil || parsed.Hostname() == "" {
+		return "", false
+	}
+	if parsed.Hostname() != raw || parsed.Path != "" || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return "", false
+	}
+	return parsed.Hostname(), true
+}
+
+func normalizeCanonicalRemoteActorURL(raw string) (soulLookupSearch, bool, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || !strings.Contains(raw, "://") {
+		return soulLookupSearch{}, false, nil
+	}
+
+	parsed, err := url.Parse(raw)
+	if err != nil || !strings.EqualFold(parsed.Scheme, "https") {
+		return soulLookupSearch{}, true, unsupportedRemoteActorURLError(raw)
+	}
+	if parsed.RawQuery != "" || parsed.Fragment != "" {
+		return soulLookupSearch{}, true, unsupportedRemoteActorURLError(raw)
+	}
+
+	domain, ok := normalizeLookupDomain(parsed.Hostname())
+	if !ok {
+		return soulLookupSearch{}, true, unsupportedRemoteActorURLError(raw)
+	}
+
+	segments := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+	if len(segments) != 2 || segments[0] != "users" {
+		return soulLookupSearch{}, true, unsupportedRemoteActorURLError(raw)
+	}
+
+	localID, ok := normalizeLookupLocalID(segments[1])
+	if !ok {
+		return soulLookupSearch{}, true, unsupportedRemoteActorURLError(raw)
+	}
+	return soulLookupSearch{Query: localID, Domain: domain}, true, nil
+}
+
+func unsupportedRemoteActorURLError(query string) error {
+	return &toolUserError{
+		Code:    "invalid_request",
+		Message: "unsupported remote actor URL; supported form is https://<domain>/users/<localId>",
+		Status:  400,
+		Details: map[string]any{"query": strings.TrimSpace(query)},
+	}
 }
 
 func resolveAgentIDByIdentifier(ctx context.Context, client *soulapi.Client, q string) (string, error) {

--- a/internal/mcpserver/identity_tools.go
+++ b/internal/mcpserver/identity_tools.go
@@ -251,6 +251,12 @@ type soulLookupSearch struct {
 	Domain string
 }
 
+func newExactQualifiedSoulLookupSearch(domain string, localID string) soulLookupSearch {
+	domain = strings.ToLower(strings.TrimSpace(domain))
+	localID = strings.ToLower(strings.TrimSpace(localID))
+	return soulLookupSearch{Query: domain + "/" + localID}
+}
+
 func isSoulAgentID(q string) bool {
 	q = strings.TrimSpace(q)
 	if !strings.HasPrefix(q, "0x") {
@@ -457,7 +463,7 @@ func normalizeRemoteActivityPubHandle(raw string, allowBareRemoteHandleFallback 
 		if !ok {
 			return soulLookupSearch{}, false
 		}
-		return soulLookupSearch{Query: localID, Domain: domain}, true
+		return newExactQualifiedSoulLookupSearch(domain, localID), true
 	}
 
 	if !allowBareRemoteHandleFallback || strings.Count(raw, "@") != 1 {
@@ -473,7 +479,7 @@ func normalizeRemoteActivityPubHandle(raw string, allowBareRemoteHandleFallback 
 	if !ok {
 		return soulLookupSearch{}, false
 	}
-	return soulLookupSearch{Query: localID, Domain: domain}, true
+	return newExactQualifiedSoulLookupSearch(domain, localID), true
 }
 
 func normalizeLookupDomain(raw string) (string, bool) {
@@ -520,7 +526,7 @@ func normalizeCanonicalRemoteActorURL(raw string) (soulLookupSearch, bool, error
 	if !ok {
 		return soulLookupSearch{}, true, unsupportedRemoteActorURLError(raw)
 	}
-	return soulLookupSearch{Query: localID, Domain: domain}, true, nil
+	return newExactQualifiedSoulLookupSearch(domain, localID), true, nil
 }
 
 func unsupportedRemoteActorURLError(query string) error {

--- a/internal/mcpserver/identity_tools_test.go
+++ b/internal/mcpserver/identity_tools_test.go
@@ -190,7 +190,7 @@ func TestPrepareSoulLookupSearch_CurrentInstanceLocalQueryUsesAuthenticatedDomai
 		Claims:   &auth.Claims{Username: "Agent1"},
 	}, "")
 
-	search, err := prepareSoulLookupSearch(ctx, client, "medic", false)
+	search, err := prepareSoulLookupSearch(ctx, client, "medic", false, false)
 	if err != nil {
 		t.Fatalf("prepareSoulLookupSearch: %v", err)
 	}
@@ -201,7 +201,7 @@ func TestPrepareSoulLookupSearch_CurrentInstanceLocalQueryUsesAuthenticatedDomai
 		t.Fatalf("domain: want test.example.com got %q", search.Domain)
 	}
 
-	search, err = prepareSoulLookupSearch(ctx, client, "ops.v2", false)
+	search, err = prepareSoulLookupSearch(ctx, client, "ops.v2", false, false)
 	if err != nil {
 		t.Fatalf("prepareSoulLookupSearch dot_local: %v", err)
 	}
@@ -212,7 +212,7 @@ func TestPrepareSoulLookupSearch_CurrentInstanceLocalQueryUsesAuthenticatedDomai
 		t.Fatalf("dot_local domain: want test.example.com got %q", search.Domain)
 	}
 
-	search, err = prepareSoulLookupSearch(ctx, client, "ops.eth", false)
+	search, err = prepareSoulLookupSearch(ctx, client, "ops.eth", false, false)
 	if err != nil {
 		t.Fatalf("prepareSoulLookupSearch ens_like_without_fallback: %v", err)
 	}
@@ -220,7 +220,7 @@ func TestPrepareSoulLookupSearch_CurrentInstanceLocalQueryUsesAuthenticatedDomai
 		t.Fatalf("ens_like_without_fallback: want generic search query without domain, got %+v", search)
 	}
 
-	search, err = prepareSoulLookupSearch(ctx, client, "ops.eth", true)
+	search, err = prepareSoulLookupSearch(ctx, client, "ops.eth", true, false)
 	if err != nil {
 		t.Fatalf("prepareSoulLookupSearch ens_like_with_fallback: %v", err)
 	}
@@ -229,5 +229,89 @@ func TestPrepareSoulLookupSearch_CurrentInstanceLocalQueryUsesAuthenticatedDomai
 	}
 	if search.Domain != "test.example.com" {
 		t.Fatalf("ens_like_with_fallback domain: want test.example.com got %q", search.Domain)
+	}
+}
+
+func TestNormalizeRemoteActivityPubHandle(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name                    string
+		raw                     string
+		allowBareHandleFallback bool
+		want                    soulLookupSearch
+		ok                      bool
+	}{
+		{
+			name: "acct_form",
+			raw:  "@steward@remote.example",
+			want: soulLookupSearch{Query: "steward", Domain: "remote.example"},
+			ok:   true,
+		},
+		{
+			name:                    "bare_form_with_fallback",
+			raw:                     "steward@remote.example",
+			allowBareHandleFallback: true,
+			want:                    soulLookupSearch{Query: "steward", Domain: "remote.example"},
+			ok:                      true,
+		},
+		{
+			name:                    "bare_form_without_fallback",
+			raw:                     "steward@remote.example",
+			allowBareHandleFallback: false,
+			ok:                      false,
+		},
+		{
+			name: "ens_like_local_part_supported",
+			raw:  "@ops.eth@remote.example",
+			want: soulLookupSearch{Query: "ops.eth", Domain: "remote.example"},
+			ok:   true,
+		},
+		{
+			name: "invalid_domain",
+			raw:  "@steward@remote.example/path",
+			ok:   false,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, ok := normalizeRemoteActivityPubHandle(tc.raw, tc.allowBareHandleFallback)
+			if got != tc.want || ok != tc.ok {
+				t.Fatalf("normalizeRemoteActivityPubHandle(%q, %v) = (%+v, %v), want (%+v, %v)", tc.raw, tc.allowBareHandleFallback, got, ok, tc.want, tc.ok)
+			}
+		})
+	}
+}
+
+func TestNormalizeCanonicalRemoteActorURL(t *testing.T) {
+	t.Parallel()
+
+	search, handled, err := normalizeCanonicalRemoteActorURL("https://remote.example/users/steward")
+	if err != nil || !handled {
+		t.Fatalf("canonical actor url: handled=%v err=%v", handled, err)
+	}
+	if search != (soulLookupSearch{Query: "steward", Domain: "remote.example"}) {
+		t.Fatalf("canonical actor url: got %+v", search)
+	}
+
+	search, handled, err = normalizeCanonicalRemoteActorURL("https://remote.example/users/ops.eth/")
+	if err != nil || !handled {
+		t.Fatalf("canonical actor url with dotted local id: handled=%v err=%v", handled, err)
+	}
+	if search != (soulLookupSearch{Query: "ops.eth", Domain: "remote.example"}) {
+		t.Fatalf("canonical actor url with dotted local id: got %+v", search)
+	}
+
+	_, handled, err = normalizeCanonicalRemoteActorURL("https://remote.example/actors/steward")
+	if !handled || err == nil {
+		t.Fatalf("unsupported actor url should be handled with an error, got handled=%v err=%v", handled, err)
+	}
+	userErr, ok := err.(*toolUserError)
+	if !ok || userErr.Code != "invalid_request" {
+		t.Fatalf("unsupported actor url should return invalid_request tool error, got %#v", err)
 	}
 }

--- a/internal/mcpserver/identity_tools_test.go
+++ b/internal/mcpserver/identity_tools_test.go
@@ -245,14 +245,14 @@ func TestNormalizeRemoteActivityPubHandle(t *testing.T) {
 		{
 			name: "acct_form",
 			raw:  "@steward@remote.example",
-			want: soulLookupSearch{Query: "steward", Domain: "remote.example"},
+			want: soulLookupSearch{Query: "remote.example/steward"},
 			ok:   true,
 		},
 		{
 			name:                    "bare_form_with_fallback",
 			raw:                     "steward@remote.example",
 			allowBareHandleFallback: true,
-			want:                    soulLookupSearch{Query: "steward", Domain: "remote.example"},
+			want:                    soulLookupSearch{Query: "remote.example/steward"},
 			ok:                      true,
 		},
 		{
@@ -264,7 +264,7 @@ func TestNormalizeRemoteActivityPubHandle(t *testing.T) {
 		{
 			name: "ens_like_local_part_supported",
 			raw:  "@ops.eth@remote.example",
-			want: soulLookupSearch{Query: "ops.eth", Domain: "remote.example"},
+			want: soulLookupSearch{Query: "remote.example/ops.eth"},
 			ok:   true,
 		},
 		{
@@ -294,7 +294,7 @@ func TestNormalizeCanonicalRemoteActorURL(t *testing.T) {
 	if err != nil || !handled {
 		t.Fatalf("canonical actor url: handled=%v err=%v", handled, err)
 	}
-	if search != (soulLookupSearch{Query: "steward", Domain: "remote.example"}) {
+	if search != (soulLookupSearch{Query: "remote.example/steward"}) {
 		t.Fatalf("canonical actor url: got %+v", search)
 	}
 
@@ -302,7 +302,7 @@ func TestNormalizeCanonicalRemoteActorURL(t *testing.T) {
 	if err != nil || !handled {
 		t.Fatalf("canonical actor url with dotted local id: handled=%v err=%v", handled, err)
 	}
-	if search != (soulLookupSearch{Query: "ops.eth", Domain: "remote.example"}) {
+	if search != (soulLookupSearch{Query: "remote.example/ops.eth"}) {
 		t.Fatalf("canonical actor url with dotted local id: got %+v", search)
 	}
 


### PR DESCRIPTION
## Milestone
issue-146 — make `identity_lookup` accept remote ActivityPub handles and canonical actor URLs

## Classification
tool-surface / bug-fix / test-coverage / docs

## Surfaces affected
- `internal/mcpserver/identity_tools.go`
- `internal/mcpserver/identity_tools_test.go`
- `internal/mcpapp/identity_surfaces_test.go`
- `internal/mcpserver/comm_tools.go`
- `internal/mcpserver/comm_prompts.go`
- `internal/mcpapp/comm_contract_test.go`
- `internal/mcpapp/comm_prompts_test.go`
- `docs/mcp.md`

## Specialist walks referenced
- Tool surface: completed via `evolve-tool-surface`
- MCP contract: no JSON-RPC / discovery / OAuth envelope change
- Lesser integration: audited; no lesser-host contract change currently required
- Host delegation: n/a
- Framework: idiomatic

## Consumer impact
- MCP clients get additive support for remote ActivityPub identifier inputs in `identity_lookup`
- Operators: no deploy-contract change expected
- Sibling repos: no required code change currently identified

## Tasks
- [x] Implement deterministic normalization and regression coverage for remote ActivityPub handles and canonical actor URLs
- [x] Update docs, tool descriptions, and prompt guidance to match the shipped contract

## Validation
- `go test ./...`
- `go vet ./...`
- `gofmt -l .`
- `scripts/build.sh`
- Targeted: `go test ./internal/mcpapp ./internal/mcpserver -run 'IdentityLookup|identity_lookup|Prompt|Contract' -count=1`

## Stage rollout plan (handoff to deploy-body)
- [ ] Merged to main
- [ ] Deployed to lab / dev
- [ ] Lab soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
none currently required; lesser-host contract remains `(q, domain)`

## Advisor-brief authorization
Arch advisor brief reviewed from `arch@lessersoul.ai`; execution authorized in-session by Aron on 2026-04-21.

Closes #146