### PR TITLE
fix(mcp): split notification since from cursor

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -297,6 +297,9 @@ Notes:
 
 - Social tools require an **OAuth JWT** bearer token (not just an instance key) because they call the Lesser API on behalf
   of the authenticated agent.
+- `notifications_read.since` is a temporal RFC3339/RFC3339Nano lower bound (`createdAt > since`). Use the optional
+  `cursor` argument for pagination/backfill; `nextCursor` is returned when Lesser supplies an opaque pagination cursor.
+  Non-timestamp `since` values remain a legacy cursor alias for compatibility, but new callers should not rely on that path.
 - Communication and identity tools also require an **OAuth JWT** bearer token for agent-context reads such as `identity_whoami`
   and inbox-backed verification.
 - Outbound communication tools (`email_send`, `email_reply`, `sms_send`) additionally require the managed

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -299,7 +299,9 @@ Notes:
   of the authenticated agent.
 - `notifications_read.since` is a temporal RFC3339/RFC3339Nano lower bound (`createdAt > since`). Use the optional
   `cursor` argument for pagination/backfill; `nextCursor` is returned when Lesser supplies an opaque pagination cursor.
-  Non-timestamp `since` values remain a legacy cursor alias for compatibility, but new callers should not rely on that path.
+  Cursor pagination is strongest for untyped reads or reads with a single `types` value; multi-type reads fan out to
+  separate Lesser notification queries, so their per-type cursors are not collapsed into one `nextCursor`. Non-timestamp
+  `since` values remain a legacy cursor alias for compatibility, but new callers should not rely on that path.
 - Communication and identity tools also require an **OAuth JWT** bearer token for agent-context reads such as `identity_whoami`
   and inbox-backed verification.
 - Outbound communication tools (`email_send`, `email_reply`, `sms_send`) additionally require the managed

--- a/internal/lesserapi/client.go
+++ b/internal/lesserapi/client.go
@@ -79,13 +79,18 @@ func (e *APIError) Error() string {
 }
 
 func (c *Client) DoJSON(ctx context.Context, method string, path string, query url.Values, bearerToken string, body any) (any, error) {
+	out, _, err := c.DoJSONWithHeaders(ctx, method, path, query, bearerToken, body)
+	return out, err
+}
+
+func (c *Client) DoJSONWithHeaders(ctx context.Context, method string, path string, query url.Values, bearerToken string, body any) (any, http.Header, error) {
 	if c == nil || c.baseURL == nil || c.http == nil {
-		return nil, fmt.Errorf("lesser api client not initialized")
+		return nil, nil, fmt.Errorf("lesser api client not initialized")
 	}
 	method = strings.ToUpper(strings.TrimSpace(method))
 	path = strings.TrimSpace(path)
 	if method == "" || path == "" {
-		return nil, fmt.Errorf("missing method or path")
+		return nil, nil, fmt.Errorf("missing method or path")
 	}
 
 	endpoint := *c.baseURL
@@ -98,14 +103,14 @@ func (c *Client) DoJSON(ctx context.Context, method string, path string, query u
 	if body != nil {
 		b, err := json.Marshal(body)
 		if err != nil {
-			return nil, fmt.Errorf("marshal request body: %w", err)
+			return nil, nil, fmt.Errorf("marshal request body: %w", err)
 		}
 		reader = bytes.NewReader(b)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, method, endpoint.String(), reader)
 	if err != nil {
-		return nil, fmt.Errorf("create request: %w", err)
+		return nil, nil, fmt.Errorf("create request: %w", err)
 	}
 
 	req.Header.Set("Accept", "application/json")
@@ -118,28 +123,29 @@ func (c *Client) DoJSON(ctx context.Context, method string, path string, query u
 
 	resp, err := c.http.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("request failed: %w", err)
+		return nil, nil, fmt.Errorf("request failed: %w", err)
 	}
 	defer resp.Body.Close()
+	headers := resp.Header.Clone()
 
 	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
 	if err != nil {
-		return nil, fmt.Errorf("read response: %w", err)
+		return nil, nil, fmt.Errorf("read response: %w", err)
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, &APIError{Status: resp.StatusCode, Body: respBody}
+		return nil, headers, &APIError{Status: resp.StatusCode, Body: respBody}
 	}
 
 	if len(respBody) == 0 {
-		return map[string]any{}, nil
+		return map[string]any{}, headers, nil
 	}
 
 	var out any
 	if err := json.Unmarshal(respBody, &out); err != nil {
-		return nil, fmt.Errorf("unmarshal response: %w", err)
+		return nil, nil, fmt.Errorf("unmarshal response: %w", err)
 	}
-	return out, nil
+	return out, headers, nil
 }
 
 func resolveBaseURL() (*url.URL, error) {

--- a/internal/mcpapp/social_tools_test.go
+++ b/internal/mcpapp/social_tools_test.go
@@ -685,7 +685,144 @@ func TestM5_ProfileReadRejectsNonObjectArguments(t *testing.T) {
 	}
 }
 
-func TestM5_NotificationsReadPersistsCursor(t *testing.T) {
+func TestM5_NotificationsReadTimestampSinceFiltersRecentRemoteCreates(t *testing.T) {
+	t.Setenv("MCP_SESSION_TABLE", "")
+	t.Setenv("JWT_SECRET", "test")
+	auth.ResetForTests()
+
+	var gotQueries []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/api/v1/notifications" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		gotQueries = append(gotQueries, r.URL.RawQuery)
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.RawQuery {
+		case "limit=30":
+			_, _ = w.Write([]byte(`[
+				{"id":"old-mention","type":"mention","created_at":"2026-04-04T12:00:00Z","account":{"id":"acct-old","acct":"old@example.com"},"status":{"id":"old-post","content":"old mention","visibility":"public"}},
+				{"id":"remote-create-mention-9addcb94","type":"mention","created_at":"2026-04-24T20:07:34.02332832Z","account":{"id":"https://dev.theory.greater.website/users/steward","acct":"steward@dev.theory.greater.website","display_name":"Steward"},"status":{"id":"remote-status-mention","content":"PROJECT20-1248-DEDUPE","visibility":"public"}},
+				{"id":"remote-create-reply-a33f4d5","type":"reply","created_at":"2026-04-24T20:07:40.451151151Z","account":{"id":"https://dev.theory.greater.website/users/steward","acct":"steward@dev.theory.greater.website","display_name":"Steward"},"status":{"id":"remote-status-reply","content":"PROJECT20-1248-REPLY","in_reply_to_id":"parent-1","visibility":"public"}}
+			]`))
+		case "limit=30&types%5B%5D=mention":
+			_, _ = w.Write([]byte(`[
+				{"id":"old-typed-mention","type":"mention","created_at":"2026-04-04T12:00:00Z","account":{"id":"acct-old","acct":"old@example.com"},"status":{"id":"old-post","content":"old mention","visibility":"public"}},
+				{"id":"remote-create-mention-9addcb94","type":"mention","created_at":"2026-04-24T20:07:34.02332832Z","account":{"id":"https://dev.theory.greater.website/users/steward","acct":"steward@dev.theory.greater.website","display_name":"Steward"},"status":{"id":"remote-status-mention","content":"PROJECT20-1248-DEDUPE","visibility":"public"}}
+			]`))
+		case "limit=30&types%5B%5D=reply":
+			_, _ = w.Write([]byte(`[
+				{"id":"remote-create-reply-a33f4d5","type":"reply","created_at":"2026-04-24T20:07:40.451151151Z","account":{"id":"https://dev.theory.greater.website/users/steward","acct":"steward@dev.theory.greater.website","display_name":"Steward"},"status":{"id":"remote-status-reply","content":"PROJECT20-1248-REPLY","in_reply_to_id":"parent-1","visibility":"public"}}
+			]`))
+		default:
+			t.Fatalf("unexpected notifications query: %q", r.URL.RawQuery)
+		}
+	}))
+	defer server.Close()
+
+	t.Setenv("LESSER_API_BASE_URL", server.URL)
+	lesserapi.ResetForTests()
+
+	app, err := mcpapp.New("test", "dev")
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+
+	env := testkit.New()
+	token := newTestToken(t, "test", "agent1", []string{"read"})
+	authHeader := "Bearer " + token
+
+	initResp := invokeJSON(t, env, app, map[string][]string{
+		"authorization": {authHeader},
+	}, &mcpruntime.Request{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "initialize",
+	})
+	if initResp.Status != 200 {
+		t.Fatalf("initialize: status=%d body=%s", initResp.Status, string(initResp.Body))
+	}
+	sessionID := initResp.Headers["mcp-session-id"][0]
+
+	callNotifications := func(id int, arguments map[string]any) map[string]any {
+		callParams, _ := json.Marshal(map[string]any{
+			"name":      "notifications_read",
+			"arguments": arguments,
+		})
+		resp := invokeJSON(t, env, app, map[string][]string{
+			"authorization":  {authHeader},
+			"mcp-session-id": {sessionID},
+		}, &mcpruntime.Request{
+			JSONRPC: "2.0",
+			ID:      id,
+			Method:  "tools/call",
+			Params:  callParams,
+		})
+		if resp.Status != 200 {
+			t.Fatalf("notifications_read: status=%d body=%s", resp.Status, string(resp.Body))
+		}
+
+		var rpc mcpruntime.Response
+		if err := json.Unmarshal(resp.Body, &rpc); err != nil {
+			t.Fatalf("unmarshal notifications_read: %v", err)
+		}
+		if rpc.Error != nil {
+			t.Fatalf("notifications_read rpc error: %+v", rpc.Error)
+		}
+		var out mcpruntime.ToolResult
+		b, _ := json.Marshal(rpc.Result)
+		_ = json.Unmarshal(b, &out)
+		data, _ := out.StructuredContent["data"].(map[string]any)
+		return data
+	}
+
+	data := callNotifications(2, map[string]any{
+		"limit": 30,
+		"since": "2026-04-24T20:06:00Z",
+	})
+	if data["count"] != float64(2) {
+		t.Fatalf("expected two fresh notifications after timestamp since, got %+v", data)
+	}
+	if data["nextSince"] != "2026-04-24T20:07:40.451151151Z" {
+		t.Fatalf("expected timestamp nextSince from newest notification, got %+v", data)
+	}
+	notifications, _ := data["notifications"].([]any)
+	seen := map[string]bool{}
+	for _, item := range notifications {
+		n, _ := item.(map[string]any)
+		seen[n["id"].(string)] = true
+	}
+	if !seen["remote-create-mention-9addcb94"] || !seen["remote-create-reply-a33f4d5"] || seen["old-mention"] {
+		t.Fatalf("unexpected timestamp-filtered notifications: %+v", notifications)
+	}
+
+	typed := callNotifications(3, map[string]any{
+		"limit": 30,
+		"since": "2026-04-24T20:06:00Z",
+		"types": []string{"mention", "reply"},
+	})
+	if typed["count"] != float64(2) {
+		t.Fatalf("expected fresh mention and reply after typed timestamp since, got %+v", typed)
+	}
+
+	wantQueries := []string{
+		"limit=30",
+		"limit=30&types%5B%5D=mention",
+		"limit=30&types%5B%5D=reply",
+	}
+	if len(gotQueries) != len(wantQueries) {
+		t.Fatalf("expected %d notifications queries, got %v", len(wantQueries), gotQueries)
+	}
+	for i, want := range wantQueries {
+		if gotQueries[i] != want {
+			t.Fatalf("query %d: want %q, got %q", i, want, gotQueries[i])
+		}
+		if strings.Contains(gotQueries[i], "max_id=") {
+			t.Fatalf("timestamp since must not be forwarded as max_id: %v", gotQueries)
+		}
+	}
+}
+
+func TestM5_NotificationsReadSeparatesTimestampSinceAndCursor(t *testing.T) {
 	t.Setenv("MCP_SESSION_TABLE", "")
 	t.Setenv("JWT_SECRET", "test")
 	t.Setenv("LESSER_BODY_MEMORY_STORE", "memory")
@@ -705,13 +842,14 @@ func TestM5_NotificationsReadPersistsCursor(t *testing.T) {
 				{"id":"n3","type":"mention","created_at":"2026-03-01T03:00:00Z","account":{"id":"acct-3","acct":"agent3","display_name":"Agent 3"},"status":{"id":"post-3","content":"Newest","visibility":"public"}},
 				{"id":"n2","type":"mention","created_at":"2026-03-01T02:00:00Z","account":{"id":"acct-2","acct":"agent2","display_name":"Agent 2"},"status":{"id":"post-2","content":"Older","visibility":"public"}}
 			]`))
-		case "limit=5&max_id=n3":
+		case "limit=5&max_id=notif%2320260301030000%23n3":
+			w.Header().Set("Link", `<https://example.test/api/v1/notifications?max_id=notif%2320260301020000%23n2&limit=5>; rel="next"`)
 			_, _ = w.Write([]byte(`[
-				{"id":"n4","type":"mention","created_at":"2026-03-01T04:00:00Z","account":{"id":"acct-4","acct":"agent4","display_name":"Agent 4"},"status":{"id":"post-4","content":"After cursor","visibility":"public"}}
+				{"id":"n2","type":"mention","created_at":"2026-03-01T02:00:00Z","account":{"id":"acct-2","acct":"agent2","display_name":"Agent 2"},"status":{"id":"post-2","content":"Cursor page","visibility":"public"}}
 			]`))
 		case "limit=5&max_id=n1":
 			_, _ = w.Write([]byte(`[
-				{"id":"n5","type":"mention","created_at":"2026-03-01T05:00:00Z","account":{"id":"acct-5","acct":"agent5","display_name":"Agent 5"},"status":{"id":"post-5","content":"Explicit override","visibility":"public"}}
+				{"id":"n1-old","type":"mention","created_at":"2026-03-01T01:00:00Z","account":{"id":"acct-1","acct":"agent1","display_name":"Agent 1"},"status":{"id":"post-1","content":"Legacy cursor","visibility":"public"}}
 			]`))
 		default:
 			t.Fatalf("unexpected notifications query: %q", r.URL.RawQuery)
@@ -794,38 +932,46 @@ func TestM5_NotificationsReadPersistsCursor(t *testing.T) {
 	}
 
 	first := callTool(2, "notifications_read", map[string]any{"limit": 5})
-	if first["since"] != "" {
-		t.Fatalf("expected empty since on first call, got %+v", first)
+	if first["since"] != "" || first["cursor"] != "" {
+		t.Fatalf("expected empty since/cursor on first call, got %+v", first)
+	}
+	if first["nextSince"] != "2026-03-01T03:00:00Z" {
+		t.Fatalf("expected timestamp nextSince on first call, got %+v", first)
 	}
 	if readCursor(3) != "n3" {
-		t.Fatalf("expected cursor n3 after first call")
+		t.Fatalf("expected legacy cursor n3 after first call")
 	}
 
 	second := callTool(4, "notifications_read", map[string]any{"limit": 5})
-	if second["since"] != "n3" {
-		t.Fatalf("expected stored since n3 on second call, got %+v", second)
-	}
-	if readCursor(5) != "n4" {
-		t.Fatalf("expected cursor n4 after second call")
+	if second["since"] != "" || second["cursor"] != "" {
+		t.Fatalf("expected omitted since to avoid implicit cursor, got %+v", second)
 	}
 
-	override := callTool(6, "notifications_read", map[string]any{"limit": 5, "since": "n1"})
-	if override["since"] != "n1" {
-		t.Fatalf("expected explicit since n1, got %+v", override)
-	}
-	if readCursor(7) != "n5" {
-		t.Fatalf("expected cursor n5 after explicit override")
+	cursor := callTool(5, "notifications_read", map[string]any{"limit": 5, "cursor": "notif#20260301030000#n3"})
+	if cursor["cursor"] != "notif#20260301030000#n3" || cursor["nextCursor"] != "notif#20260301020000#n2" {
+		t.Fatalf("expected explicit cursor and nextCursor, got %+v", cursor)
 	}
 
-	reset := callTool(8, "notifications_read", map[string]any{"limit": 5, "since": ""})
-	if reset["since"] != "" {
+	legacy := callTool(6, "notifications_read", map[string]any{"limit": 5, "since": "n1"})
+	if legacy["since"] != "n1" || legacy["cursor"] != "n1" {
+		t.Fatalf("expected legacy non-timestamp since to act as cursor alias, got %+v", legacy)
+	}
+
+	reset := callTool(7, "notifications_read", map[string]any{"limit": 5, "since": ""})
+	if reset["since"] != "" || reset["cursor"] != "" {
 		t.Fatalf("expected empty since on reset call, got %+v", reset)
 	}
 	if reset["count"] != float64(2) {
 		t.Fatalf("expected reset call to return full list, got %+v", reset)
 	}
 
-	wantQueries := []string{"limit=5", "limit=5&max_id=n3", "limit=5&max_id=n1", "limit=5"}
+	wantQueries := []string{
+		"limit=5",
+		"limit=5",
+		"limit=5&max_id=notif%2320260301030000%23n3",
+		"limit=5&max_id=n1",
+		"limit=5",
+	}
 	if len(gotQueries) != len(wantQueries) {
 		t.Fatalf("expected %d notifications queries, got %v", len(wantQueries), gotQueries)
 	}

--- a/internal/mcpserver/social_tools.go
+++ b/internal/mcpserver/social_tools.go
@@ -339,9 +339,10 @@ func handleConversationsRead(ctx context.Context, args json.RawMessage) (*mcprun
 
 func handleNotificationsRead(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
 	var in struct {
-		Types []string `json:"types,omitempty"`
-		Since *string  `json:"since"`
-		Limit int      `json:"limit,omitempty"`
+		Types  []string `json:"types,omitempty"`
+		Since  *string  `json:"since"`
+		Cursor string   `json:"cursor,omitempty"`
+		Limit  int      `json:"limit,omitempty"`
 	}
 	if err := json.Unmarshal(args, &in); err != nil {
 		return nil, invalidParams("invalid args: " + err.Error())
@@ -350,13 +351,14 @@ func handleNotificationsRead(ctx context.Context, args json.RawMessage) (*mcprun
 	explicitSince := in.Since != nil
 	requestedSince := trimDeref(in.Since)
 	effectiveSince := requestedSince
+	effectiveCursor := strings.TrimSpace(in.Cursor)
+	sinceTime, hasTemporalSince := parseNotificationSince(requestedSince)
 
-	if !explicitSince {
-		if storedCursor, err := readNotificationCursor(ctx); err == nil {
-			effectiveSince = storedCursor
-		}
-	} else if requestedSince == "" {
+	if explicitSince && requestedSince == "" {
 		_ = clearNotificationCursor(ctx)
+	}
+	if explicitSince && requestedSince != "" && !hasTemporalSince && effectiveCursor == "" {
+		effectiveCursor = requestedSince
 	}
 
 	token, err := requireOAuthBearer(ctx)
@@ -368,15 +370,19 @@ func handleNotificationsRead(ctx context.Context, args json.RawMessage) (*mcprun
 		return nil, err
 	}
 
-	list, err := readSocialNotifications(ctx, client, token, upstreamTypes, in.Limit, effectiveSince)
+	list, nextCursor, err := readSocialNotifications(ctx, client, token, upstreamTypes, in.Limit, effectiveCursor)
 	if err != nil {
 		return authToolResultFromError(err)
 	}
 
 	notifications := socialNotificationsFromAPI(list)
+	if hasTemporalSince {
+		notifications = filterSocialNotificationsAfter(notifications, sinceTime)
+	}
 	if len(requestedTypes) > 0 {
 		notifications = filterSocialNotificationsByType(notifications, requestedTypes)
 	}
+	sortSocialNotificationsNewestFirst(notifications)
 	if in.Limit > 0 && len(notifications) > in.Limit {
 		notifications = notifications[:in.Limit]
 	}
@@ -385,15 +391,26 @@ func handleNotificationsRead(ctx context.Context, args json.RawMessage) (*mcprun
 	if len(notifications) > 0 {
 		if newest, ok := notifications[0].(map[string]any); ok {
 			_ = writeNotificationCursor(ctx, strings.TrimSpace(firstNonEmptyStringMap(newest, "id")))
+			if hasTemporalSince || effectiveCursor == "" {
+				if createdAt, ok := notificationCreatedAt(newest); ok {
+					nextSince = createdAt.Format(time.RFC3339Nano)
+				}
+			}
 		}
-		if oldest, ok := notifications[len(notifications)-1].(map[string]any); ok {
-			nextSince = strings.TrimSpace(firstNonEmptyStringMap(oldest, "id"))
+		if nextSince == "" {
+			if oldest, ok := notifications[len(notifications)-1].(map[string]any); ok {
+				nextSince = strings.TrimSpace(firstNonEmptyStringMap(oldest, "id"))
+			}
 		}
+	} else if hasTemporalSince {
+		nextSince = sinceTime.Format(time.RFC3339Nano)
 	}
 
 	return toolJSONResult(map[string]any{
 		"since":         effectiveSince,
+		"cursor":        effectiveCursor,
 		"nextSince":     nextSince,
+		"nextCursor":    nextCursor,
 		"count":         len(notifications),
 		"types":         requestedTypes,
 		"notifications": notifications,
@@ -719,6 +736,7 @@ func notificationsReadDef() mcpruntime.ToolDef {
 			"properties":{
 				"types":{"type":"array","items":{"type":"string"}},
 				"since":{"type":"string"},
+				"cursor":{"type":"string"},
 				"limit":{"type":"integer","minimum":1,"maximum":80}
 			}
 		}`),
@@ -891,9 +909,9 @@ func normalizeRequestedNotificationTypes(in []string) ([]string, []string) {
 	return requested, upstream
 }
 
-func readSocialNotifications(ctx context.Context, client *lesserapi.Client, token string, upstreamTypes []string, limit int, since string) ([]any, error) {
+func readSocialNotifications(ctx context.Context, client *lesserapi.Client, token string, upstreamTypes []string, limit int, cursor string) ([]any, string, error) {
 	if client == nil {
-		return nil, fmt.Errorf("lesser api client not initialized")
+		return nil, "", fmt.Errorf("lesser api client not initialized")
 	}
 
 	queries := upstreamTypes
@@ -902,15 +920,15 @@ func readSocialNotifications(ctx context.Context, client *lesserapi.Client, toke
 	}
 
 	if len(queries) <= 1 {
-		return readSocialNotificationsByType(ctx, client, token, firstString(queries), limit, since)
+		return readSocialNotificationsByType(ctx, client, token, firstString(queries), limit, cursor)
 	}
 
 	combined := make([]map[string]any, 0, len(queries)*max(1, limit))
 	seenIDs := make(map[string]struct{}, len(queries)*max(1, limit))
 	for _, typ := range queries {
-		items, err := readSocialNotificationsByType(ctx, client, token, typ, limit, since)
+		items, _, err := readSocialNotificationsByType(ctx, client, token, typ, limit, cursor)
 		if err != nil {
-			return nil, err
+			return nil, "", err
 		}
 		for _, item := range items {
 			raw, ok := item.(map[string]any)
@@ -944,31 +962,31 @@ func readSocialNotifications(ctx context.Context, client *lesserapi.Client, toke
 	for _, item := range combined {
 		out = append(out, item)
 	}
-	return out, nil
+	return out, "", nil
 }
 
-func readSocialNotificationsByType(ctx context.Context, client *lesserapi.Client, token string, notificationType string, limit int, since string) ([]any, error) {
+func readSocialNotificationsByType(ctx context.Context, client *lesserapi.Client, token string, notificationType string, limit int, cursor string) ([]any, string, error) {
 	query := url.Values{}
 	if limit > 0 {
 		query.Set("limit", strconv.Itoa(limit))
 	}
-	if strings.TrimSpace(since) != "" {
-		query.Set("max_id", strings.TrimSpace(since))
+	if strings.TrimSpace(cursor) != "" {
+		query.Set("max_id", strings.TrimSpace(cursor))
 	}
 	if strings.TrimSpace(notificationType) != "" {
 		query.Add("types[]", strings.TrimSpace(notificationType))
 	}
 
-	out, err := client.DoJSON(ctx, "GET", "/api/v1/notifications", query, token, nil)
+	out, headers, err := client.DoJSONWithHeaders(ctx, "GET", "/api/v1/notifications", query, token, nil)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	list, ok := out.([]any)
 	if !ok {
-		return nil, fmt.Errorf("unexpected notifications response")
+		return nil, "", fmt.Errorf("unexpected notifications response")
 	}
-	return list, nil
+	return list, nextNotificationCursorFromHeaders(headers), nil
 }
 
 func socialNotificationsFromAPI(items []any) []any {
@@ -1002,6 +1020,39 @@ func filterSocialNotificationsByType(items []any, want []string) []any {
 		}
 	}
 	return out
+}
+
+func filterSocialNotificationsAfter(items []any, since time.Time) []any {
+	if since.IsZero() {
+		return items
+	}
+
+	out := make([]any, 0, len(items))
+	for _, item := range items {
+		notification, _ := item.(map[string]any)
+		createdAt, ok := notificationCreatedAt(notification)
+		if !ok || !createdAt.After(since) {
+			continue
+		}
+		out = append(out, notification)
+	}
+	return out
+}
+
+func sortSocialNotificationsNewestFirst(items []any) {
+	sort.SliceStable(items, func(i, j int) bool {
+		left, _ := items[i].(map[string]any)
+		right, _ := items[j].(map[string]any)
+		leftTime, leftOK := notificationCreatedAt(left)
+		rightTime, rightOK := notificationCreatedAt(right)
+		switch {
+		case leftOK && rightOK && !leftTime.Equal(rightTime):
+			return leftTime.After(rightTime)
+		case leftOK != rightOK:
+			return leftOK
+		}
+		return strings.TrimSpace(firstNonEmptyStringMap(left, "id")) > strings.TrimSpace(firstNonEmptyStringMap(right, "id"))
+	})
 }
 
 func normalizeSocialNotification(raw map[string]any) map[string]any {
@@ -1103,11 +1154,54 @@ func notificationCreatedAt(raw map[string]any) (time.Time, bool) {
 	if value == "" {
 		return time.Time{}, false
 	}
-	t, err := time.Parse(time.RFC3339, value)
+	t, err := time.Parse(time.RFC3339Nano, value)
 	if err != nil {
 		return time.Time{}, false
 	}
 	return t.UTC(), true
+}
+
+func parseNotificationSince(value string) (time.Time, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}, false
+	}
+	t, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return t.UTC(), true
+}
+
+func nextNotificationCursorFromHeaders(headers map[string][]string) string {
+	for _, link := range headers["Link"] {
+		if cursor := nextNotificationCursorFromLink(link); cursor != "" {
+			return cursor
+		}
+	}
+	return ""
+}
+
+func nextNotificationCursorFromLink(link string) string {
+	for _, part := range strings.Split(link, ",") {
+		part = strings.TrimSpace(part)
+		if !strings.Contains(part, `rel="next"`) && !strings.Contains(part, `rel=next`) {
+			continue
+		}
+		start := strings.Index(part, "<")
+		end := strings.Index(part, ">")
+		if start < 0 || end <= start {
+			continue
+		}
+		u, err := url.Parse(part[start+1 : end])
+		if err != nil {
+			continue
+		}
+		if cursor := strings.TrimSpace(u.Query().Get("max_id")); cursor != "" {
+			return cursor
+		}
+	}
+	return ""
 }
 
 func firstString(values []string) string {


### PR DESCRIPTION
## Milestone
Project 20 notification read repair — make `notifications_read.since` temporal and separate pagination cursors.

## Classification
MCP-contract / tool-surface / lesser-integration / bug-fix.

## What changed
- Treat RFC3339/RFC3339Nano `notifications_read.since` values as temporal `createdAt > since` filters.
- Stop forwarding timestamp `since` values to Lesser as `max_id`.
- Add optional `cursor` input for pagination/backfill and return `nextCursor` from Lesser `Link` headers when available.
- Preserve non-timestamp `since` as a legacy cursor alias for compatibility.
- Sort normalized notifications newest-first before limiting and compute timestamp `nextSince` for temporal reads.
- Document the `since` vs `cursor` contract in `docs/mcp.md`, including the limitation that multi-type reads do not collapse per-type cursors into a single `nextCursor`.

## Root cause
Ops used `notifications_read(since=2026-04-24T20:06:00Z)` as a timestamp filter, but lesser-body forwarded that value upstream as Lesser API `max_id`. Lesser v1.2.48 treats `max_id` as an opaque storage cursor, so RFC3339 timestamps compared lexicographically against notification SK/GSI cursor shapes could hide the fresh remote-create mention/reply rows.

## Specialist walks referenced
- Tool surface: modifies existing social read tool; scope remains `read`; profile availability remains drone + souled; no side effects added.
- MCP contract: additive `cursor` field and `nextCursor` result; semantic repair for RFC3339 `since`; legacy non-timestamp `since` retained as compatibility alias. Cursor pagination is strongest for untyped/single-type reads; multi-type reads fan out to separate Lesser queries and currently return no aggregate `nextCursor`.
- Lesser integration: continues consuming `/api/v1/notifications`; no Lesser schema or endpoint change required for the bridge. Durable follow-up remains for Lesser to expose true timestamp filtering or fully-defined notification cursor semantics.

## Consumer impact
- Timestamp callers now see fresh notifications after `since`.
- Cursor/backfill callers should move to `cursor`; legacy non-timestamp `since` still works as an alias during transition.
- Multi-type cursor pagination is intentionally limited until the contract grows per-type cursors or Lesser exposes a unified server-side filter.
- `.well-known/mcp.json` will advertise the optional `cursor` parameter after deploy.

## Validation
- `git ls-files '*.go' ':!:cdk/node_modules/**' ':!:reference/**' | xargs gofmt -l` (empty)
- `go test ./...`
- `go vet ./...`
- `scripts/build.sh`
- Targeted: `go test ./internal/mcpapp -run 'TestM5_NotificationsRead' -count=1`
- `git diff --check`

Note: raw `gofmt -l .` on current `main` still traverses committed CDK `node_modules` Go templates and reference code, so validation used the source-only tracked-file check above.

## Rollout / reprobe handoff
1. Deploy to lab/dev after merge via `deploy-body`.
2. Reprobe Ops with `notifications_read({"since":"2026-04-24T20:06:00Z","limit":30})` and typed `mention`/`reply` variants.
3. Expected result: fresh remote-create mention and reply rows appear; no timestamp `since` is sent upstream as `max_id`.
4. Keep Lesser API follow-up open for durable server-side timestamp filtering or explicit cursor semantics.

## Tasks
- [x] Add timestamp-since regression coverage for fresh remote-create mention/reply rows.
- [x] Add explicit cursor coverage and Link-header `nextCursor` extraction.
- [x] Implement temporal `since` filtering and cursor separation.
- [x] Update MCP docs.
- [x] Clarify multi-type cursor limitation.
