### PR TITLE
fix(security): harden MCP auth and managed deploy inputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
       CDK_DEFAULT_REGION: "us-east-1"
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: go.mod
           cache: true
@@ -35,7 +35,7 @@ jobs:
         run: go test ./...
 
       - name: Set up Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
           cache: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,12 +24,12 @@ jobs:
       RELEASE_VERSION: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.version || github.ref_name }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: go.mod
           cache: true
@@ -38,7 +38,7 @@ jobs:
             cdk/go.sum
 
       - name: Set up Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
 

--- a/cdk/stacks/lesser_body_deploy_template_stack.go
+++ b/cdk/stacks/lesser_body_deploy_template_stack.go
@@ -1,7 +1,6 @@
 package stacks
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/aws/aws-cdk-go/awscdk/v2"
@@ -50,28 +49,26 @@ func NewLesserBodyDeployTemplateStack(scope constructs.Construct, id string, pro
 	})
 	jwtSecretArnParamPathParam := awscdk.NewCfnParameter(stack, jsii.String("JWTSecretArnParamPath"), &awscdk.CfnParameterProps{
 		Type:        jsii.String("String"),
-		Default:     jsii.String(defaultSsmParamPath("lesser", "shared", "secrets", "jwt-secret-arn")),
-		Description: jsii.String("SSM parameter path containing the shared JWT secret ARN for the target app."),
+		Description: jsii.String("Required SSM parameter path containing the shared JWT secret ARN for the target app, for example /<app>/shared/secrets/jwt-secret-arn."),
 	})
 	jwtSecretKeyParamPathParam := awscdk.NewCfnParameter(stack, jsii.String("JWTSecretKeyArnParamPath"), &awscdk.CfnParameterProps{
 		Type:        jsii.String("String"),
-		Default:     jsii.String(defaultSsmParamPath("lesser", "shared", "kms", "encryption-key-arn")),
-		Description: jsii.String("SSM parameter path containing the shared KMS key ARN for the target app."),
+		Description: jsii.String("Required SSM parameter path containing the shared KMS key ARN for the target app, for example /<app>/shared/kms/encryption-key-arn."),
 	})
 	lesserStageDomainParamPathParam := awscdk.NewCfnParameter(stack, jsii.String("LesserStageDomainParamPath"), &awscdk.CfnParameterProps{
 		Type:        jsii.String("String"),
-		Default:     jsii.String(defaultSsmParamPath("lesser", stage, "lesser", "exports", "v1", "domain")),
-		Description: jsii.String("SSM parameter path containing the Lesser stage domain for the target app and stage."),
+		Description: jsii.String("Required SSM parameter path containing the Lesser stage domain for the target app and stage, for example /<app>/<stage>/lesser/exports/v1/domain."),
 	})
 	lesserTableParamPathParam := awscdk.NewCfnParameter(stack, jsii.String("LesserTableNameParamPath"), &awscdk.CfnParameterProps{
 		Type:        jsii.String("String"),
-		Default:     jsii.String(defaultSsmParamPath("lesser", stage, "lesser", "exports", "v1", "table_name")),
-		Description: jsii.String("SSM parameter path containing the Lesser table name for the target app and stage."),
+		Description: jsii.String("Required SSM parameter path containing the Lesser table name for the target app and stage, for example /<app>/<stage>/lesser/exports/v1/table_name."),
 	})
 	lesserHostInstanceKeyArnParam := awscdk.NewCfnParameter(stack, jsii.String("LesserHostInstanceKeyARN"), &awscdk.CfnParameterProps{
-		Type:        jsii.String("String"),
-		Default:     jsii.String(""),
-		Description: jsii.String("Optional exact Secrets Manager ARN for the managed lesser-host instance key. When provided, lesser-body injects LESSER_HOST_INSTANCE_KEY_ARN and grants direct read access to that secret."),
+		Type:                  jsii.String("String"),
+		Default:               jsii.String(""),
+		AllowedPattern:        jsii.String(`^$|^arn:[^:*]+:secretsmanager:[a-z0-9-]+:[0-9]{12}:secret:[A-Za-z0-9/_+=.@-]+$`),
+		ConstraintDescription: jsii.String("Must be empty or an exact AWS Secrets Manager secret ARN without wildcards."),
+		Description:           jsii.String("Optional exact Secrets Manager ARN for the managed lesser-host instance key. When provided, lesser-body injects LESSER_HOST_INSTANCE_KEY_ARN and grants direct read access to that secret."),
 	})
 
 	stageDomain := resolvedStageDomainFromDeployInputs(
@@ -123,8 +120,4 @@ func resolvedStageDomainFromDeployInputs(stack awscdk.Stack, stage string, baseD
 		),
 		nil,
 	)
-}
-
-func defaultSsmParamPath(parts ...string) string {
-	return fmt.Sprintf("/%s", strings.Join(parts, "/"))
 }

--- a/cdk/stacks/lesser_body_stack_shared.go
+++ b/cdk/stacks/lesser_body_stack_shared.go
@@ -178,25 +178,14 @@ func configureLesserBodyStack(stack awscdk.Stack, props *lesserBodyRuntimeProps)
 		Resource:     jsii.String("table"),
 		ResourceName: tableName,
 	})
-	indexArn := stack.FormatArn(&awscdk.ArnComponents{
-		Service:      jsii.String("dynamodb"),
-		Resource:     jsii.String("table"),
-		ResourceName: tokenJoin("/", tableName, jsii.String("index"), jsii.String("*")),
-	})
 	handler.AddToRolePolicy(awsiam.NewPolicyStatement(&awsiam.PolicyStatementProps{
 		Actions: &[]*string{
-			jsii.String("dynamodb:BatchGetItem"),
 			jsii.String("dynamodb:Query"),
 			jsii.String("dynamodb:GetItem"),
-			jsii.String("dynamodb:Scan"),
-			jsii.String("dynamodb:ConditionCheckItem"),
-			jsii.String("dynamodb:BatchWriteItem"),
 			jsii.String("dynamodb:PutItem"),
-			jsii.String("dynamodb:UpdateItem"),
-			jsii.String("dynamodb:DeleteItem"),
 			jsii.String("dynamodb:DescribeTable"),
 		},
-		Resources: &[]*string{tableArn, indexArn},
+		Resources: &[]*string{tableArn},
 	}))
 
 	mcpLambdaArnParam := awsssm.NewCfnParameter(stack, jsii.String("McpLambdaArnParam"), &awsssm.CfnParameterProps{

--- a/cdk/stacks/lesser_body_stack_shared_test.go
+++ b/cdk/stacks/lesser_body_stack_shared_test.go
@@ -80,6 +80,9 @@ func TestManagedDeployTemplateSupportsExactLesserHostInstanceKeyARN(t *testing.T
 	if got, ok := param["Default"].(string); !ok || got != "" {
 		t.Fatalf("expected LesserHostInstanceKeyARN default empty string, got %#v", param["Default"])
 	}
+	if pattern, ok := param["AllowedPattern"].(string); !ok || !strings.Contains(pattern, "secretsmanager") || !strings.Contains(pattern, "^$|^arn:") {
+		t.Fatalf("expected exact Secrets Manager ARN allowed pattern, got %#v", param["AllowedPattern"])
+	}
 
 	lambda := firstLambdaFunction(t, mustResources(t, template))
 	props, ok := lambda["Properties"].(map[string]any)
@@ -113,6 +116,104 @@ func TestManagedDeployTemplateSupportsExactLesserHostInstanceKeyARN(t *testing.T
 	}
 	if !foundConditionalExactGrant {
 		t.Fatalf("expected an IAM secret read resource wired to LesserHostInstanceKeyARN")
+	}
+}
+
+func TestManagedDeployTemplateRequiresAppScopedLesserParameterPaths(t *testing.T) {
+	template := synthTemplate(t, "TestStack", func(app awscdk.App) {
+		_ = NewLesserBodyDeployTemplateStack(app, "TestStack", &LesserBodyDeployTemplateStackProps{
+			StackProps: awscdk.StackProps{
+				Env: &awscdk.Environment{
+					Account: jsii.String("123456789012"),
+					Region:  jsii.String("us-east-1"),
+				},
+			},
+			ServiceVersion: "test",
+			Stage:          "dev",
+		})
+	})
+
+	params, ok := template["Parameters"].(map[string]any)
+	if !ok {
+		t.Fatalf("template missing Parameters")
+	}
+	for _, name := range []string{
+		"JWTSecretArnParamPath",
+		"JWTSecretKeyArnParamPath",
+		"LesserStageDomainParamPath",
+		"LesserTableNameParamPath",
+	} {
+		param, ok := params[name].(map[string]any)
+		if !ok {
+			t.Fatalf("template missing %s parameter", name)
+		}
+		if _, ok := param["Default"]; ok {
+			t.Fatalf("%s must not default to /lesser/...; deploy helper must pass app-scoped override, got %s", name, mustJSON(t, param["Default"]))
+		}
+	}
+}
+
+func TestLesserTablePolicyUsesLeastPrivilegePrimaryTableAccess(t *testing.T) {
+	assetDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(assetDir, "bootstrap"), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write bootstrap: %v", err)
+	}
+
+	template := synthTemplate(t, "TestStack", func(app awscdk.App) {
+		stack := awscdk.NewStack(app, jsii.String("TestStack"), &awscdk.StackProps{
+			Env: &awscdk.Environment{
+				Account: jsii.String("123456789012"),
+				Region:  jsii.String("us-east-1"),
+			},
+		})
+
+		configureLesserBodyStack(stack, &lesserBodyRuntimeProps{
+			AppName:               jsii.String("theory"),
+			Stage:                 jsii.String("dev"),
+			Code:                  awslambda.Code_FromAsset(jsii.String(assetDir), nil),
+			ServiceVersion:        jsii.String("test"),
+			PublicEndpoint:        jsii.String("https://api.dev.example.com/mcp/{actor}"),
+			LesserAPIBaseURL:      jsii.String("https://api.dev.example.com"),
+			AllowedOrigins:        jsii.String("https://claude.ai"),
+			JWTSecretArnParamPath: jsii.String("/theory/shared/secrets/jwt-secret-arn"),
+			JWTSecretKeyParamPath: jsii.String("/theory/shared/kms/encryption-key-arn"),
+			LesserTableParamPath:  jsii.String("/theory/dev/lesser/exports/v1/table_name"),
+		})
+	})
+
+	var lesserTableStatement map[string]any
+	for _, statement := range allPolicyStatements(t, mustResources(t, template)) {
+		if strings.Contains(mustJSON(t, extractStatementResourcesFromMap(statement)), "/theory/dev/lesser/exports/v1/table_name") {
+			lesserTableStatement = statement
+			break
+		}
+	}
+	if lesserTableStatement == nil {
+		t.Fatalf("expected Lesser table IAM statement")
+	}
+	statementJSON := mustJSON(t, lesserTableStatement)
+	for _, want := range []string{
+		`"dynamodb:DescribeTable"`,
+		`"dynamodb:GetItem"`,
+		`"dynamodb:PutItem"`,
+		`"dynamodb:Query"`,
+	} {
+		if !strings.Contains(statementJSON, want) {
+			t.Fatalf("expected least-privilege DynamoDB action %s in %s", want, statementJSON)
+		}
+	}
+	for _, unwanted := range []string{
+		`"dynamodb:BatchGetItem"`,
+		`"dynamodb:BatchWriteItem"`,
+		`"dynamodb:ConditionCheckItem"`,
+		`"dynamodb:DeleteItem"`,
+		`"dynamodb:Scan"`,
+		`"dynamodb:UpdateItem"`,
+		`/index/`,
+	} {
+		if strings.Contains(statementJSON, unwanted) {
+			t.Fatalf("expected Lesser table policy to omit %s, got %s", unwanted, statementJSON)
+		}
 	}
 }
 

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/equaltoai/lesser-body/internal/trustconfig"
 	"github.com/golang-jwt/jwt/v5"
@@ -14,7 +15,10 @@ import (
 	oauthruntime "github.com/theory-cloud/apptheory/runtime/oauth"
 )
 
-const contextKeyPrincipal = "lesser_body_principal"
+const (
+	contextKeyPrincipal = "lesser_body_principal"
+	maxAccessTokenAge   = 24 * time.Hour
+)
 
 type PrincipalType string
 
@@ -203,6 +207,12 @@ func validateAccessToken(ctx context.Context, tokenString string) (*Claims, erro
 	}
 	claims, ok := token.Claims.(*Claims)
 	if !ok || !token.Valid {
+		return nil, &apptheory.AppError{Code: "app.unauthorized", Message: "unauthorized"}
+	}
+	if claims.IssuedAt == nil || claims.IssuedAt.Time.IsZero() {
+		return nil, &apptheory.AppError{Code: "app.unauthorized", Message: "unauthorized"}
+	}
+	if time.Since(claims.IssuedAt.Time) > maxAccessTokenAge {
 		return nil, &apptheory.AppError{Code: "app.unauthorized", Message: "unauthorized"}
 	}
 

--- a/internal/lesserapi/client.go
+++ b/internal/lesserapi/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/netip"
 	"net/url"
 	"os"
 	"strings"
@@ -173,12 +174,24 @@ func parseBaseURL(raw string) (*url.URL, error) {
 	if u.Scheme != "https" && u.Scheme != "http" {
 		return nil, fmt.Errorf("unsupported base url scheme: %s", u.Scheme)
 	}
+	if u.Scheme == "http" && !isLocalHTTPHost(u.Hostname()) {
+		return nil, fmt.Errorf("http base url is only allowed for localhost or loopback hosts")
+	}
 	if strings.TrimSpace(u.Host) == "" {
 		return nil, fmt.Errorf("base url host is empty")
 	}
 	u.RawQuery = ""
 	u.Fragment = ""
 	return u, nil
+}
+
+func isLocalHTTPHost(host string) bool {
+	host = strings.ToLower(strings.TrimSpace(host))
+	if host == "localhost" {
+		return true
+	}
+	addr, err := netip.ParseAddr(host)
+	return err == nil && addr.IsLoopback()
 }
 
 func resolveTimeout() time.Duration {

--- a/internal/lesserapi/client_test.go
+++ b/internal/lesserapi/client_test.go
@@ -14,3 +14,15 @@ func TestResolveBaseURL_FallsBackToActorTemplateEndpoint(t *testing.T) {
 		t.Fatalf("expected mcp endpoint fallback, got %q", got)
 	}
 }
+
+func TestParseBaseURL_AllowsHTTPOnlyForLoopback(t *testing.T) {
+	for _, raw := range []string{"http://localhost:8080", "http://127.0.0.1:8080", "http://[::1]:8080"} {
+		if _, err := parseBaseURL(raw); err != nil {
+			t.Fatalf("expected loopback HTTP URL %q to be accepted: %v", raw, err)
+		}
+	}
+
+	if _, err := parseBaseURL("http://api.example.com"); err == nil {
+		t.Fatalf("expected non-loopback HTTP URL to be rejected")
+	}
+}

--- a/internal/mcpapp/app_test.go
+++ b/internal/mcpapp/app_test.go
@@ -138,7 +138,7 @@ func usernameFromJWTForTests(token string) string {
 	return strings.TrimSpace(claims.Username)
 }
 
-func TestMcpAuth_AllowsOldButUnexpiredJwt(t *testing.T) {
+func TestMcpAuth_RejectsJwtOlderThan24Hours(t *testing.T) {
 	t.Setenv("MCP_SESSION_TABLE", "")
 	t.Setenv("JWT_SECRET", "test")
 	auth.ResetForTests()
@@ -160,8 +160,8 @@ func TestMcpAuth_AllowsOldButUnexpiredJwt(t *testing.T) {
 		Method:  "initialize",
 	})
 
-	if resp.Status != 200 {
-		t.Fatalf("expected 200 for old but unexpired token, got %d (%s)", resp.Status, string(resp.Body))
+	if resp.Status != 401 {
+		t.Fatalf("expected 401 for token older than 24h, got %d (%s)", resp.Status, string(resp.Body))
 	}
 }
 

--- a/internal/mcpapp/audit.go
+++ b/internal/mcpapp/audit.go
@@ -19,7 +19,7 @@ func WithAudit(next apptheory.Handler, logger *slog.Logger) apptheory.Handler {
 	}
 
 	return func(ctx *apptheory.Context) (*apptheory.Response, error) {
-		if err := authorizeTools(ctx); err != nil {
+		if err := authorizeMCPRequests(ctx); err != nil {
 			auditMcp(ctx, logger)
 			if stepUp, ok := err.(*mcpStepUpRequiredError); ok {
 				return insufficientScopeMCPResponse(ctx, stepUp.GrantedScopes, stepUp.RequiredScopes), nil
@@ -43,7 +43,7 @@ func (e *mcpStepUpRequiredError) Error() string {
 	return "insufficient scope"
 }
 
-func authorizeTools(ctx *apptheory.Context) error {
+func authorizeMCPRequests(ctx *apptheory.Context) error {
 	if ctx == nil {
 		return nil
 	}
@@ -60,7 +60,7 @@ func authorizeTools(ctx *apptheory.Context) error {
 			return nil
 		}
 		for _, req := range reqs {
-			if err := authorizeToolsRequest(ctx, req); err != nil {
+			if err := authorizeMCPRequest(ctx, req); err != nil {
 				return err
 			}
 		}
@@ -71,21 +71,16 @@ func authorizeTools(ctx *apptheory.Context) error {
 	if err != nil {
 		return nil
 	}
-	return authorizeToolsRequest(ctx, req)
+	return authorizeMCPRequest(ctx, req)
 }
 
-func authorizeToolsRequest(ctx *apptheory.Context, req *mcpruntime.Request) error {
-	if ctx == nil || req == nil || req.Method != "tools/call" {
+func authorizeMCPRequest(ctx *apptheory.Context, req *mcpruntime.Request) error {
+	if ctx == nil || req == nil {
 		return nil
 	}
 
-	var params struct {
-		Name string `json:"name"`
-	}
-	_ = json.Unmarshal(req.Params, &params)
-	toolName := strings.TrimSpace(params.Name)
-	if toolName == "" {
-		// Let the MCP runtime return Invalid params.
+	requiredScopes := requiredScopesForMCPRequest(req)
+	if len(requiredScopes) == 0 {
 		return nil
 	}
 
@@ -103,12 +98,11 @@ func authorizeToolsRequest(ctx *apptheory.Context, req *mcpruntime.Request) erro
 		return &apptheory.AppError{Code: "app.forbidden", Message: "forbidden"}
 	}
 
-	// M5 tool policy: read tools require read (or write/admin), write tools require write (or admin).
+	// M5 policy: read surfaces require read (or write/admin), write surfaces require write (or admin).
 	if hasAnyScope(p.Claims.Scopes, "admin") {
 		return nil
 	}
 
-	requiredScopes := requiredScopesForTool(toolName)
 	allowedScopes := append([]string(nil), requiredScopes...)
 	if len(requiredScopes) == 1 && requiredScopes[0] == "read" {
 		allowedScopes = append(allowedScopes, "write")
@@ -120,6 +114,46 @@ func authorizeToolsRequest(ctx *apptheory.Context, req *mcpruntime.Request) erro
 	return &mcpStepUpRequiredError{
 		GrantedScopes:  append([]string(nil), p.Claims.Scopes...),
 		RequiredScopes: requiredScopes,
+	}
+}
+
+func requiredScopesForMCPRequest(req *mcpruntime.Request) []string {
+	if req == nil {
+		return nil
+	}
+
+	switch req.Method {
+	case "tools/call":
+		var params struct {
+			Name string `json:"name"`
+		}
+		_ = json.Unmarshal(req.Params, &params)
+		toolName := strings.TrimSpace(params.Name)
+		if toolName == "" {
+			// Let the MCP runtime return Invalid params.
+			return nil
+		}
+		return requiredScopesForTool(toolName)
+	case "resources/read":
+		var params struct {
+			URI string `json:"uri"`
+		}
+		_ = json.Unmarshal(req.Params, &params)
+		if strings.TrimSpace(params.URI) == "" {
+			return nil
+		}
+		return []string{"read"}
+	case "prompts/get":
+		var params struct {
+			Name string `json:"name"`
+		}
+		_ = json.Unmarshal(req.Params, &params)
+		if strings.TrimSpace(params.Name) == "" {
+			return nil
+		}
+		return []string{"read"}
+	default:
+		return nil
 	}
 }
 

--- a/internal/mcpapp/email_tools_test.go
+++ b/internal/mcpapp/email_tools_test.go
@@ -44,6 +44,8 @@ func TestLBM2_EmailSendAndReply_TalkToCommAPI(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
+		case r.URL.Path == "/api/v1/souls/mine":
+			_, _ = w.Write([]byte(`{"souls":[{"agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-bob"}}]}`))
 		case r.URL.Path == "/api/v1/soul/agents/"+agentID:
 			_, _ = w.Write([]byte(`{"version":"1","agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-bob","status":"active"}}`))
 		case r.URL.Path == "/api/v1/soul/agents/"+agentID+"/registration":
@@ -128,8 +130,9 @@ func TestLBM2_EmailSendAndReply_TalkToCommAPI(t *testing.T) {
 		if gotBody["to"] != "alice@example.com" || gotBody["subject"] != "[bot] Hello" || gotBody["body"] != "Hi there\n\n"+expectedFooter {
 			t.Fatalf("unexpected comm api payload fields: %+v", gotBody)
 		}
-		if gotBody["idempotencyKey"] != "req-email-send-123" {
-			t.Fatalf("expected request-id-backed idempotencyKey, got %+v", gotBody)
+		idempotencyKey, _ := gotBody["idempotencyKey"].(string)
+		if idempotencyKey == "" || idempotencyKey == "req-email-send-123" {
+			t.Fatalf("expected generated idempotencyKey distinct from request id, got %+v", gotBody)
 		}
 		if gotBody["inReplyTo"] != "comm-msg-prev" {
 			t.Fatalf("expected inReplyTo=comm-msg-prev, got %+v", gotBody)
@@ -149,8 +152,8 @@ func TestLBM2_EmailSendAndReply_TalkToCommAPI(t *testing.T) {
 		if data["messageId"] != "comm-msg-001" || data["status"] != "sent" {
 			t.Fatalf("unexpected tool data: %+v", data)
 		}
-		if data["idempotencyKey"] != "req-email-send-123" {
-			t.Fatalf("expected tool data to include request idempotencyKey, got %+v", data)
+		if data["idempotencyKey"] != idempotencyKey {
+			t.Fatalf("expected tool data to include generated idempotencyKey, got %+v", data)
 		}
 		if data["inReplyTo"] != "comm-msg-prev" {
 			t.Fatalf("expected tool data to include inReplyTo, got %+v", data)

--- a/internal/mcpapp/email_tools_test.go
+++ b/internal/mcpapp/email_tools_test.go
@@ -45,7 +45,7 @@ func TestLBM2_EmailSendAndReply_TalkToCommAPI(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.URL.Path == "/api/v1/souls/mine":
-			_, _ = w.Write([]byte(`{"souls":[{"agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-bob"}}]}`))
+			_, _ = w.Write([]byte(`{"souls":[{"agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-bob"},"binding_state":"bound","binding":{"agent_username":"agent1"}}]}`))
 		case r.URL.Path == "/api/v1/soul/agents/"+agentID:
 			_, _ = w.Write([]byte(`{"version":"1","agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-bob","status":"active"}}`))
 		case r.URL.Path == "/api/v1/soul/agents/"+agentID+"/registration":

--- a/internal/mcpapp/identity_surfaces_test.go
+++ b/internal/mcpapp/identity_surfaces_test.go
@@ -56,12 +56,14 @@ func TestLBM1_IdentityToolsAndChannelResources(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 
 		switch {
+		case r.URL.Path == "/api/v1/souls/mine":
+			_, _ = w.Write([]byte(`{"souls":[{"agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-alice"}}]}`))
 		case r.URL.Path == "/api/v1/soul/search":
 			q := r.URL.Query().Get("q")
 			domain := r.URL.Query().Get("domain")
 			searchQueries = append(searchQueries, q)
 			searchDomains = append(searchDomains, domain)
-			if domain == "test.example.com" && (q == "agent-alice" || q == "ops.v2" || q == "ops.eth") {
+			if domain == "test.example.com" && (q == "agent-alice" || q == "ops.v2") {
 				_, _ = w.Write([]byte(`{"version":"1","results":[{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-alice"}],"count":1,"has_more":false}`))
 				return
 			}
@@ -121,6 +123,16 @@ func TestLBM1_IdentityToolsAndChannelResources(t *testing.T) {
 					"subject":"Hi",
 					"body":"Hello there",
 					"receivedAt":"2026-03-09T12:00:00Z"
+				},
+				{
+					"id":"n-spoof",
+					"type":"communication:inbound",
+					"channel":"email",
+					"messageId":"comm-msg-spoof",
+					"from":{"name":"agent-alice@lessersoul.ai","address":"attacker@example.net"},
+					"subject":"Spoof",
+					"body":"Pretending",
+					"receivedAt":"2026-03-09T12:01:00Z"
 				}
 			]`))
 		default:
@@ -255,7 +267,7 @@ func TestLBM1_IdentityToolsAndChannelResources(t *testing.T) {
 	emailResolveQueries = nil
 
 	// identity_lookup should normalize current-instance local IDs and carry the authenticated instance domain explicitly.
-	for _, q := range []string{"agent-alice", "@agent-alice", "ops.v2", "ops.eth"} {
+	for _, q := range []string{"agent-alice", "@agent-alice", "ops.v2"} {
 		callParams, _ := json.Marshal(map[string]any{
 			"name":      "identity_lookup",
 			"arguments": map[string]any{"query": q},
@@ -291,10 +303,10 @@ func TestLBM1_IdentityToolsAndChannelResources(t *testing.T) {
 			t.Fatalf("identity_lookup(%q): localId want agent-alice got %v", q, match["localId"])
 		}
 	}
-	if !reflect.DeepEqual(searchQueries, []string{"agent-alice", "agent-alice", "ops.v2", "ops.eth"}) {
+	if !reflect.DeepEqual(searchQueries, []string{"agent-alice", "agent-alice", "ops.v2"}) {
 		t.Fatalf("identity_lookup should normalize local ID queries before search, got %+v", searchQueries)
 	}
-	if !reflect.DeepEqual(searchDomains, []string{"test.example.com", "test.example.com", "test.example.com", "test.example.com"}) {
+	if !reflect.DeepEqual(searchDomains, []string{"test.example.com", "test.example.com", "test.example.com"}) {
 		t.Fatalf("identity_lookup should provide current-instance domain context for local queries, got %+v", searchDomains)
 	}
 	if len(emailResolveQueries) != 0 {
@@ -375,6 +387,83 @@ func TestLBM1_IdentityToolsAndChannelResources(t *testing.T) {
 		}
 	}
 
+	// ENS-like names that miss the authoritative ENS resolver must not fall back
+	// to current-instance local-id search.
+	{
+		searchQueries = nil
+		searchDomains = nil
+		callParams, _ := json.Marshal(map[string]any{
+			"name":      "identity_lookup",
+			"arguments": map[string]any{"query": "ops.eth"},
+		})
+		resp := invokeJSON(t, env, app, map[string][]string{
+			"authorization":  {authHeader},
+			"mcp-session-id": {sessionID},
+		}, &mcpruntime.Request{JSONRPC: "2.0", ID: 33, Method: "tools/call", Params: callParams})
+		if resp.Status != 200 {
+			t.Fatalf("identity_lookup(ops.eth): status=%d body=%s", resp.Status, string(resp.Body))
+		}
+		var rpc mcpruntime.Response
+		_ = json.Unmarshal(resp.Body, &rpc)
+		if rpc.Error != nil {
+			t.Fatalf("identity_lookup(ops.eth) rpc error: %+v", rpc.Error)
+		}
+		var out mcpruntime.ToolResult
+		{
+			b, _ := json.Marshal(rpc.Result)
+			_ = json.Unmarshal(b, &out)
+		}
+		if !out.IsError {
+			t.Fatalf("expected not_found tool result for unresolved ENS name, got %+v", out)
+		}
+		errPayload, _ := out.StructuredContent["error"].(map[string]any)
+		if errPayload["code"] != "not_found" {
+			t.Fatalf("expected not_found for unresolved ENS name, got %+v", errPayload)
+		}
+		if len(searchQueries) != 0 || len(searchDomains) != 0 {
+			t.Fatalf("unresolved ENS name should not use local search, got q=%+v domains=%+v", searchQueries, searchDomains)
+		}
+	}
+
+	// identity_lookup should reject internal-looking remote handle domains instead
+	// of forwarding them as generic soul search queries.
+	{
+		searchQueries = nil
+		searchDomains = nil
+		emailResolveQueries = nil
+		callParams, _ := json.Marshal(map[string]any{
+			"name":      "identity_lookup",
+			"arguments": map[string]any{"query": "steward@localhost"},
+		})
+		resp := invokeJSON(t, env, app, map[string][]string{
+			"authorization":  {authHeader},
+			"mcp-session-id": {sessionID},
+		}, &mcpruntime.Request{JSONRPC: "2.0", ID: 34, Method: "tools/call", Params: callParams})
+		if resp.Status != 200 {
+			t.Fatalf("identity_lookup(steward@localhost): status=%d body=%s", resp.Status, string(resp.Body))
+		}
+		var rpc mcpruntime.Response
+		_ = json.Unmarshal(resp.Body, &rpc)
+		if rpc.Error != nil {
+			t.Fatalf("identity_lookup(steward@localhost) rpc error: %+v", rpc.Error)
+		}
+		var out mcpruntime.ToolResult
+		{
+			b, _ := json.Marshal(rpc.Result)
+			_ = json.Unmarshal(b, &out)
+		}
+		if !out.IsError {
+			t.Fatalf("expected invalid_request tool result for internal remote handle, got %+v", out)
+		}
+		errPayload, _ := out.StructuredContent["error"].(map[string]any)
+		if errPayload["code"] != "invalid_request" {
+			t.Fatalf("expected invalid_request for internal remote handle, got %+v", errPayload)
+		}
+		if len(searchQueries) != 0 || len(searchDomains) != 0 {
+			t.Fatalf("internal remote handle should not use soul search, got q=%+v domains=%+v", searchQueries, searchDomains)
+		}
+	}
+
 	// agent://channels + agent://channels/preferences should read successfully.
 	{
 		params, _ := json.Marshal(map[string]any{"uri": "agent://channels"})
@@ -430,8 +519,46 @@ func TestLBM1_IdentityToolsAndChannelResources(t *testing.T) {
 		if data["verified"] != true {
 			t.Fatalf("expected verified identity match, got %+v", data)
 		}
-		if data["matchedBy"] != "sender.agentId" && data["matchedBy"] != "sender.email" {
+		if data["matchedBy"] != "sender.agentId" {
 			t.Fatalf("expected sender provenance match, got %+v", data)
+		}
+	}
+
+	// identity_verify must not trust spoofable sender display/name/address fields
+	// without authoritative soul agent provenance on the message.
+	{
+		callParams, _ := json.Marshal(map[string]any{
+			"name": "identity_verify",
+			"arguments": map[string]any{
+				"channel":    "email",
+				"identifier": "agent-alice@lessersoul.ai",
+				"messageId":  "comm-msg-spoof",
+			},
+		})
+		resp := invokeJSON(t, env, app, map[string][]string{
+			"authorization":  {authHeader},
+			"mcp-session-id": {sessionID},
+		}, &mcpruntime.Request{JSONRPC: "2.0", ID: 61, Method: "tools/call", Params: callParams})
+		if resp.Status != 200 {
+			t.Fatalf("identity_verify spoofed sender: status=%d body=%s", resp.Status, string(resp.Body))
+		}
+
+		var rpc mcpruntime.Response
+		_ = json.Unmarshal(resp.Body, &rpc)
+		if rpc.Error != nil {
+			t.Fatalf("identity_verify spoofed sender rpc error: %+v", rpc.Error)
+		}
+		var out mcpruntime.ToolResult
+		{
+			b, _ := json.Marshal(rpc.Result)
+			_ = json.Unmarshal(b, &out)
+		}
+		data, _ := out.StructuredContent["data"].(map[string]any)
+		if data["verified"] != false {
+			t.Fatalf("expected spoofed sender to remain unverified, got %+v", data)
+		}
+		if data["reason"] != "message_lacks_authoritative_sender_provenance" {
+			t.Fatalf("expected missing provenance reason, got %+v", data)
 		}
 	}
 
@@ -498,6 +625,8 @@ func TestLBM1_IdentityLookupBareLocalFailsWithoutTrustworthyCurrentInstanceDomai
 		w.Header().Set("Content-Type", "application/json")
 
 		switch {
+		case r.URL.Path == "/api/v1/souls/mine":
+			_, _ = w.Write([]byte(`{"souls":[{"agent":{"agent_id":"` + agentID + `","domain":"","local_id":"agent-alice"}}]}`))
 		case r.URL.Path == "/api/v1/soul/agents/"+agentID:
 			_, _ = w.Write([]byte(`{"version":"1","agent":{"agent_id":"` + agentID + `","domain":"","local_id":"agent-alice","status":"active"}}`))
 		case r.URL.Path == "/api/v1/soul/search":
@@ -602,6 +731,8 @@ func TestLBM1_IdentityLookupMalformedLocalIdentifierReturnsBadRequest(t *testing
 		w.Header().Set("Content-Type", "application/json")
 
 		switch {
+		case r.URL.Path == "/api/v1/souls/mine":
+			_, _ = w.Write([]byte(`{"souls":[{"agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-alice"}}]}`))
 		case r.URL.Path == "/api/v1/soul/search":
 			gotSearchQuery = r.URL.Query().Get("q")
 			gotSearchDomain = r.URL.Query().Get("domain")
@@ -707,6 +838,8 @@ func TestLBM1_IdentityLookupUnsupportedRemoteActorURLReturnsBadRequest(t *testin
 		w.Header().Set("Content-Type", "application/json")
 
 		switch {
+		case r.URL.Path == "/api/v1/souls/mine":
+			_, _ = w.Write([]byte(`{"souls":[{"agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-alice"}}]}`))
 		case r.URL.Path == "/api/v1/soul/search":
 			searchCalled = true
 			_, _ = w.Write([]byte(`{"version":"1","results":[],"count":0,"has_more":false}`))

--- a/internal/mcpapp/identity_surfaces_test.go
+++ b/internal/mcpapp/identity_surfaces_test.go
@@ -57,7 +57,7 @@ func TestLBM1_IdentityToolsAndChannelResources(t *testing.T) {
 
 		switch {
 		case r.URL.Path == "/api/v1/souls/mine":
-			_, _ = w.Write([]byte(`{"souls":[{"agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-alice"}}]}`))
+			_, _ = w.Write([]byte(`{"souls":[{"agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-alice"},"binding_state":"bound","binding":{"agent_username":"agent1"}}]}`))
 		case r.URL.Path == "/api/v1/soul/search":
 			q := r.URL.Query().Get("q")
 			domain := r.URL.Query().Get("domain")
@@ -626,7 +626,7 @@ func TestLBM1_IdentityLookupBareLocalFailsWithoutTrustworthyCurrentInstanceDomai
 
 		switch {
 		case r.URL.Path == "/api/v1/souls/mine":
-			_, _ = w.Write([]byte(`{"souls":[{"agent":{"agent_id":"` + agentID + `","domain":"","local_id":"agent-alice"}}]}`))
+			_, _ = w.Write([]byte(`{"souls":[{"agent":{"agent_id":"` + agentID + `","domain":"","local_id":"agent-alice"},"binding_state":"bound","binding":{"agent_username":"agent1"}}]}`))
 		case r.URL.Path == "/api/v1/soul/agents/"+agentID:
 			_, _ = w.Write([]byte(`{"version":"1","agent":{"agent_id":"` + agentID + `","domain":"","local_id":"agent-alice","status":"active"}}`))
 		case r.URL.Path == "/api/v1/soul/search":
@@ -732,7 +732,7 @@ func TestLBM1_IdentityLookupMalformedLocalIdentifierReturnsBadRequest(t *testing
 
 		switch {
 		case r.URL.Path == "/api/v1/souls/mine":
-			_, _ = w.Write([]byte(`{"souls":[{"agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-alice"}}]}`))
+			_, _ = w.Write([]byte(`{"souls":[{"agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-alice"},"binding_state":"bound","binding":{"agent_username":"agent1"}}]}`))
 		case r.URL.Path == "/api/v1/soul/search":
 			gotSearchQuery = r.URL.Query().Get("q")
 			gotSearchDomain = r.URL.Query().Get("domain")
@@ -839,7 +839,7 @@ func TestLBM1_IdentityLookupUnsupportedRemoteActorURLReturnsBadRequest(t *testin
 
 		switch {
 		case r.URL.Path == "/api/v1/souls/mine":
-			_, _ = w.Write([]byte(`{"souls":[{"agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-alice"}}]}`))
+			_, _ = w.Write([]byte(`{"souls":[{"agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-alice"},"binding_state":"bound","binding":{"agent_username":"agent1"}}]}`))
 		case r.URL.Path == "/api/v1/soul/search":
 			searchCalled = true
 			_, _ = w.Write([]byte(`{"version":"1","results":[],"count":0,"has_more":false}`))

--- a/internal/mcpapp/inbox_tools_test.go
+++ b/internal/mcpapp/inbox_tools_test.go
@@ -33,6 +33,8 @@ func TestLBM3_InboxToolsUseHostMailbox(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 
 		switch {
+		case r.URL.Path == "/api/v1/souls/mine":
+			_, _ = w.Write([]byte(`{"souls":[{"agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-alice"}}]}`))
 		case r.URL.Path == "/api/v1/soul/agents/"+agentID:
 			_, _ = w.Write([]byte(`{"version":"1","agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-alice","status":"active"}}`))
 		case r.URL.Path == "/api/v1/soul/agents/"+agentID+"/registration":

--- a/internal/mcpapp/inbox_tools_test.go
+++ b/internal/mcpapp/inbox_tools_test.go
@@ -34,7 +34,7 @@ func TestLBM3_InboxToolsUseHostMailbox(t *testing.T) {
 
 		switch {
 		case r.URL.Path == "/api/v1/souls/mine":
-			_, _ = w.Write([]byte(`{"souls":[{"agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-alice"}}]}`))
+			_, _ = w.Write([]byte(`{"souls":[{"agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-alice"},"binding_state":"bound","binding":{"agent_username":"agent1"}}]}`))
 		case r.URL.Path == "/api/v1/soul/agents/"+agentID:
 			_, _ = w.Write([]byte(`{"version":"1","agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-alice","status":"active"}}`))
 		case r.URL.Path == "/api/v1/soul/agents/"+agentID+"/registration":

--- a/internal/mcpapp/outbound_comm_streaming_test.go
+++ b/internal/mcpapp/outbound_comm_streaming_test.go
@@ -37,7 +37,7 @@ func TestSmsSendStreamingEmitsProgressAndFinalResult(t *testing.T) {
 
 		switch r.URL.Path {
 		case "/api/v1/souls/mine":
-			_, _ = w.Write([]byte(`{"souls":[{"agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-dana"}}]}`))
+			_, _ = w.Write([]byte(`{"souls":[{"agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-dana"},"binding_state":"bound","binding":{"agent_username":"agent1"}}]}`))
 		case "/api/v1/soul/agents/" + agentID:
 			_, _ = w.Write([]byte(`{"version":"1","agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-dana","status":"active"}}`))
 		case "/api/v1/soul/agents/" + agentID + "/registration":

--- a/internal/mcpapp/outbound_comm_streaming_test.go
+++ b/internal/mcpapp/outbound_comm_streaming_test.go
@@ -36,6 +36,8 @@ func TestSmsSendStreamingEmitsProgressAndFinalResult(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 
 		switch r.URL.Path {
+		case "/api/v1/souls/mine":
+			_, _ = w.Write([]byte(`{"souls":[{"agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-dana"}}]}`))
 		case "/api/v1/soul/agents/" + agentID:
 			_, _ = w.Write([]byte(`{"version":"1","agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-dana","status":"active"}}`))
 		case "/api/v1/soul/agents/" + agentID + "/registration":

--- a/internal/mcpapp/outbound_comm_tools_test.go
+++ b/internal/mcpapp/outbound_comm_tools_test.go
@@ -44,7 +44,7 @@ func TestLBM6_SMSAndVoiceOutboundTools(t *testing.T) {
 
 		switch r.URL.Path {
 		case "/api/v1/souls/mine":
-			_, _ = w.Write([]byte(`{"souls":[{"agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-carol"}}]}`))
+			_, _ = w.Write([]byte(`{"souls":[{"agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-carol"},"binding_state":"bound","binding":{"agent_username":"agent1"}}]}`))
 		case "/api/v1/soul/agents/" + agentID:
 			_, _ = w.Write([]byte(`{"version":"1","agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-carol","status":"active"}}`))
 		case "/api/v1/soul/agents/" + agentID + "/registration":

--- a/internal/mcpapp/outbound_comm_tools_test.go
+++ b/internal/mcpapp/outbound_comm_tools_test.go
@@ -43,6 +43,8 @@ func TestLBM6_SMSAndVoiceOutboundTools(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 
 		switch r.URL.Path {
+		case "/api/v1/souls/mine":
+			_, _ = w.Write([]byte(`{"souls":[{"agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-carol"}}]}`))
 		case "/api/v1/soul/agents/" + agentID:
 			_, _ = w.Write([]byte(`{"version":"1","agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-carol","status":"active"}}`))
 		case "/api/v1/soul/agents/" + agentID + "/registration":
@@ -138,7 +140,7 @@ func TestLBM6_SMSAndVoiceOutboundTools(t *testing.T) {
 		}
 	})
 
-	t.Run("sms send uses request id as fallback idempotency key", func(t *testing.T) {
+	t.Run("sms send generates fallback idempotency key", func(t *testing.T) {
 		gotAuth = ""
 		gotBody = nil
 
@@ -157,8 +159,9 @@ func TestLBM6_SMSAndVoiceOutboundTools(t *testing.T) {
 		if resp.Status != 200 {
 			t.Fatalf("sms_send fallback idempotency: status=%d body=%s", resp.Status, string(resp.Body))
 		}
-		if gotBody["idempotencyKey"] != "req-sms-send-123" {
-			t.Fatalf("expected sms fallback idempotencyKey=req-sms-send-123, got %+v", gotBody)
+		idempotencyKey, _ := gotBody["idempotencyKey"].(string)
+		if idempotencyKey == "" || idempotencyKey == "req-sms-send-123" {
+			t.Fatalf("expected generated sms fallback idempotencyKey distinct from request id, got %+v", gotBody)
 		}
 		if _, ok := gotBody["inReplyTo"]; ok {
 			t.Fatalf("expected no inReplyTo for non-reply sms, got %+v", gotBody)
@@ -175,7 +178,7 @@ func TestLBM6_SMSAndVoiceOutboundTools(t *testing.T) {
 			_ = json.Unmarshal(b, &out)
 		}
 		data, _ := out.StructuredContent["data"].(map[string]any)
-		if data["idempotencyKey"] != "req-sms-send-123" {
+		if data["idempotencyKey"] != idempotencyKey {
 			t.Fatalf("expected sms fallback result idempotencyKey, got %+v", data)
 		}
 	})

--- a/internal/mcpapp/resources_prompts_test.go
+++ b/internal/mcpapp/resources_prompts_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	mcpruntime "github.com/theory-cloud/apptheory/runtime/mcp"
@@ -218,5 +219,59 @@ func TestM9_ResourcesAndPrompts(t *testing.T) {
 		if rpc.Error != nil {
 			t.Fatalf("prompts/get error: %+v", rpc.Error)
 		}
+	}
+}
+
+func TestMCPAuth_ResourcesReadAndPromptsGetRequireReadScope(t *testing.T) {
+	t.Setenv("MCP_SESSION_TABLE", "")
+	t.Setenv("JWT_SECRET", "test")
+	auth.ResetForTests()
+
+	token := newTestToken(t, "test", "agent1", nil)
+	authHeader := "Bearer " + token
+
+	app, err := mcpapp.New("test", "dev")
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+	env := testkit.New()
+
+	initResp := invokeJSON(t, env, app, map[string][]string{
+		"authorization": {authHeader},
+	}, &mcpruntime.Request{JSONRPC: "2.0", ID: 1, Method: "initialize"})
+	if initResp.Status != 200 {
+		t.Fatalf("initialize: status=%d body=%s", initResp.Status, string(initResp.Body))
+	}
+	sessionID := initResp.Headers["mcp-session-id"][0]
+
+	for _, tc := range []struct {
+		name   string
+		method string
+		params map[string]any
+	}{
+		{
+			name:   "resource_read",
+			method: "resources/read",
+			params: map[string]any{"uri": "agent://profile"},
+		},
+		{
+			name:   "prompt_get",
+			method: "prompts/get",
+			params: map[string]any{"name": "compose_post"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			params, _ := json.Marshal(tc.params)
+			resp := invokeJSON(t, env, app, map[string][]string{
+				"authorization":  {authHeader},
+				"mcp-session-id": {sessionID},
+			}, &mcpruntime.Request{JSONRPC: "2.0", ID: 2, Method: tc.method, Params: params})
+			if resp.Status != 403 {
+				t.Fatalf("%s: expected 403, got %d (%s)", tc.method, resp.Status, string(resp.Body))
+			}
+			if got := firstHeader(resp.Headers, "www-authenticate"); !strings.Contains(got, "insufficient_scope") || !strings.Contains(got, `scope="read"`) {
+				t.Fatalf("%s: expected insufficient_scope read challenge, got %q", tc.method, got)
+			}
+		})
 	}
 }

--- a/internal/mcpapp/social_tools_test.go
+++ b/internal/mcpapp/social_tools_test.go
@@ -822,6 +822,80 @@ func TestM5_NotificationsReadTimestampSinceFiltersRecentRemoteCreates(t *testing
 	}
 }
 
+func TestM5_NotificationsReadBoundsLimitAndRejectsUnknownTypes(t *testing.T) {
+	t.Setenv("MCP_SESSION_TABLE", "")
+	t.Setenv("JWT_SECRET", "test")
+	auth.ResetForTests()
+
+	var gotQueries []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/api/v1/notifications" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		gotQueries = append(gotQueries, r.URL.RawQuery)
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.RawQuery != "limit=80" {
+			t.Fatalf("expected capped limit query, got %q", r.URL.RawQuery)
+		}
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer server.Close()
+
+	t.Setenv("LESSER_API_BASE_URL", server.URL)
+	lesserapi.ResetForTests()
+
+	app, err := mcpapp.New("test", "dev")
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+
+	env := testkit.New()
+	token := newTestToken(t, "test", "agent1", []string{"read"})
+	authHeader := "Bearer " + token
+
+	initResp := invokeJSON(t, env, app, map[string][]string{
+		"authorization": {authHeader},
+	}, &mcpruntime.Request{JSONRPC: "2.0", ID: 1, Method: "initialize"})
+	if initResp.Status != 200 {
+		t.Fatalf("initialize: status=%d body=%s", initResp.Status, string(initResp.Body))
+	}
+	sessionID := initResp.Headers["mcp-session-id"][0]
+
+	call := func(id int, arguments map[string]any) *mcpruntime.Response {
+		callParams, _ := json.Marshal(map[string]any{
+			"name":      "notifications_read",
+			"arguments": arguments,
+		})
+		resp := invokeJSON(t, env, app, map[string][]string{
+			"authorization":  {authHeader},
+			"mcp-session-id": {sessionID},
+		}, &mcpruntime.Request{JSONRPC: "2.0", ID: id, Method: "tools/call", Params: callParams})
+		if resp.Status != 200 {
+			t.Fatalf("notifications_read: status=%d body=%s", resp.Status, string(resp.Body))
+		}
+		var rpc mcpruntime.Response
+		if err := json.Unmarshal(resp.Body, &rpc); err != nil {
+			t.Fatalf("unmarshal notifications_read: %v", err)
+		}
+		return &rpc
+	}
+
+	if rpc := call(2, map[string]any{"limit": 500}); rpc.Error != nil {
+		t.Fatalf("expected capped limit request to succeed, got %+v", rpc.Error)
+	}
+	if len(gotQueries) != 1 {
+		t.Fatalf("expected one upstream request, got %v", gotQueries)
+	}
+
+	rpc := call(3, map[string]any{"limit": 5, "types": []string{"mention", "not-a-real-type"}})
+	if rpc.Error == nil {
+		t.Fatalf("expected unknown notification type to fail before upstream fanout")
+	}
+	if len(gotQueries) != 1 {
+		t.Fatalf("invalid type should not fan out upstream, got %v", gotQueries)
+	}
+}
+
 func TestM5_NotificationsReadSeparatesTimestampSinceAndCursor(t *testing.T) {
 	t.Setenv("MCP_SESSION_TABLE", "")
 	t.Setenv("JWT_SECRET", "test")
@@ -916,21 +990,6 @@ func TestM5_NotificationsReadSeparatesTimestampSinceAndCursor(t *testing.T) {
 		return data
 	}
 
-	readCursor := func(id int) string {
-		data := callTool(id, "memory_query", map[string]any{
-			"query": "notification_cursor:",
-			"limit": 1,
-			"order": "desc",
-		})
-		events, _ := data["events"].([]any)
-		if len(events) == 0 {
-			return ""
-		}
-		event, _ := events[0].(map[string]any)
-		content, _ := event["content"].(string)
-		return strings.TrimSpace(strings.TrimPrefix(content, "notification_cursor:"))
-	}
-
 	first := callTool(2, "notifications_read", map[string]any{"limit": 5})
 	if first["since"] != "" || first["cursor"] != "" {
 		t.Fatalf("expected empty since/cursor on first call, got %+v", first)
@@ -938,26 +997,23 @@ func TestM5_NotificationsReadSeparatesTimestampSinceAndCursor(t *testing.T) {
 	if first["nextSince"] != "2026-03-01T03:00:00Z" {
 		t.Fatalf("expected timestamp nextSince on first call, got %+v", first)
 	}
-	if readCursor(3) != "n3" {
-		t.Fatalf("expected legacy cursor n3 after first call")
-	}
 
-	second := callTool(4, "notifications_read", map[string]any{"limit": 5})
+	second := callTool(3, "notifications_read", map[string]any{"limit": 5})
 	if second["since"] != "" || second["cursor"] != "" {
 		t.Fatalf("expected omitted since to avoid implicit cursor, got %+v", second)
 	}
 
-	cursor := callTool(5, "notifications_read", map[string]any{"limit": 5, "cursor": "notif#20260301030000#n3"})
+	cursor := callTool(4, "notifications_read", map[string]any{"limit": 5, "cursor": "notif#20260301030000#n3"})
 	if cursor["cursor"] != "notif#20260301030000#n3" || cursor["nextCursor"] != "notif#20260301020000#n2" {
 		t.Fatalf("expected explicit cursor and nextCursor, got %+v", cursor)
 	}
 
-	legacy := callTool(6, "notifications_read", map[string]any{"limit": 5, "since": "n1"})
+	legacy := callTool(5, "notifications_read", map[string]any{"limit": 5, "since": "n1"})
 	if legacy["since"] != "n1" || legacy["cursor"] != "n1" {
 		t.Fatalf("expected legacy non-timestamp since to act as cursor alias, got %+v", legacy)
 	}
 
-	reset := callTool(7, "notifications_read", map[string]any{"limit": 5, "since": ""})
+	reset := callTool(6, "notifications_read", map[string]any{"limit": 5, "since": ""})
 	if reset["since"] != "" || reset["cursor"] != "" {
 		t.Fatalf("expected empty since on reset call, got %+v", reset)
 	}
@@ -1080,20 +1136,20 @@ func TestM5_NotificationDismissClearsCursorOnDismissAll(t *testing.T) {
 		return strings.TrimSpace(strings.TrimPrefix(content, "notification_cursor:"))
 	}
 
-	_ = callTool(2, "notifications_read", map[string]any{"limit": 5})
-	if readCursor(3) != "n7" {
-		t.Fatalf("expected cursor n7 after seed read")
-	}
+	_ = callTool(2, "memory_append", map[string]any{
+		"content":  "notification_cursor:n7",
+		"event_id": "01JMY4Y6A00000000000000007",
+	})
 
-	out := callTool(4, "notification_dismiss", map[string]any{})
+	out := callTool(3, "notification_dismiss", map[string]any{})
 	if out["ok"] != true || out["dismiss"] != "all" {
 		t.Fatalf("unexpected dismiss-all response: %+v", out)
 	}
-	if readCursor(5) != "" {
+	if readCursor(4) != "" {
 		t.Fatalf("expected dismiss-all to clear cursor")
 	}
 
-	wantRequests := []string{"GET /api/v1/notifications", "POST /api/v1/notifications/clear"}
+	wantRequests := []string{"POST /api/v1/notifications/clear"}
 	if len(gotRequests) != len(wantRequests) {
 		t.Fatalf("expected requests %v, got %v", wantRequests, gotRequests)
 	}
@@ -1203,12 +1259,15 @@ func TestM5_NotificationDismissSingleKeepsCursorAndHandlesNotFound(t *testing.T)
 		return strings.TrimSpace(strings.TrimPrefix(content, "notification_cursor:"))
 	}
 
-	rpc, _ := callTool(2, "notifications_read", map[string]any{"limit": 5})
+	rpc, _ := callTool(2, "memory_append", map[string]any{
+		"content":  "notification_cursor:n9",
+		"event_id": "01JMY4Y6A00000000000000009",
+	})
 	if rpc.Error != nil {
-		t.Fatalf("notifications_read error: %+v", rpc.Error)
+		t.Fatalf("memory_append error: %+v", rpc.Error)
 	}
 	if readCursor(3) != "n9" {
-		t.Fatalf("expected cursor n9 after seed read")
+		t.Fatalf("expected cursor n9 after seed append")
 	}
 
 	rpc, out := callTool(4, "notification_dismiss", map[string]any{"id": "n9"})

--- a/internal/mcpserver/identity_resources.go
+++ b/internal/mcpserver/identity_resources.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/equaltoai/lesser-body/internal/soulapi"
 	mcpruntime "github.com/theory-cloud/apptheory/runtime/mcp"
 )
 
@@ -55,6 +56,32 @@ func identityErrorPayload(err error) map[string]any {
 		}
 		if len(userErr.Details) > 0 {
 			payload["details"] = userErr.Details
+		}
+		return payload
+	}
+
+	if failure := soulAuthFailureFromError(err); failure != nil {
+		return failure.payload()
+	}
+
+	var apiErr *soulapi.APIError
+	if errors.As(err, &apiErr) {
+		code := identityErrorCodeForStatus(apiErr.Status)
+		message, parsed := commExtractAPIErrorMessage(apiErr.Body)
+		payload := map[string]any{
+			"code":    code,
+			"message": message,
+			"status":  apiErr.Status,
+		}
+		details := map[string]any{}
+		if parsed != nil {
+			details["apiError"] = parsed
+		}
+		if retryAfter := apiErr.RetryAfterSeconds(); retryAfter > 0 {
+			details["retryAfterSeconds"] = retryAfter
+		}
+		if len(details) > 0 {
+			payload["details"] = details
 		}
 		return payload
 	}

--- a/internal/mcpserver/identity_tools.go
+++ b/internal/mcpserver/identity_tools.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"net/netip"
 	"net/url"
 	"regexp"
 	"strings"
@@ -133,7 +135,70 @@ func authenticatedAgentID(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", &toolUserError{Code: "upstream_error", Message: err.Error(), Status: 500}
 	}
-	return normalizeSoulAgentID(agentID), nil
+	agentID = normalizeSoulAgentID(agentID)
+	if agentID == "" {
+		return "", nil
+	}
+
+	bearerToken := strings.TrimSpace(auth.BearerTokenFromToolContext(ctx))
+	if bearerToken == "" {
+		return "", oauthBearerRequiredFailure("missing_bearer_token")
+	}
+	if err := verifyAuthenticatedAgentWithLesser(ctx, bearerToken, agentID); err != nil {
+		return "", err
+	}
+
+	return agentID, nil
+}
+
+func verifyAuthenticatedAgentWithLesser(ctx context.Context, bearerToken string, agentID string) error {
+	agentID = normalizeSoulAgentID(agentID)
+	bearerToken = strings.TrimSpace(bearerToken)
+	if agentID == "" {
+		return newLocalAuthFailure("missing bound soul identity", "missing_bound_soul")
+	}
+	if bearerToken == "" {
+		return oauthBearerRequiredFailure("missing_bearer_token")
+	}
+
+	client, err := lesser(ctx)
+	if err != nil {
+		return &toolUserError{Code: "not_configured", Message: err.Error(), Status: 500}
+	}
+
+	mineAny, err := client.DoJSON(ctx, "GET", "/api/v1/souls/mine", nil, bearerToken, nil)
+	if err != nil {
+		return err
+	}
+	mine, ok := mineAny.(map[string]any)
+	if !ok {
+		return fmt.Errorf("unexpected souls/mine response")
+	}
+
+	items, _ := mine["souls"].([]any)
+	if len(items) == 0 {
+		return &toolUserError{Code: "not_found", Message: "no soul agents found for this identity", Status: 404}
+	}
+	for _, item := range items {
+		im, _ := item.(map[string]any)
+		agent, _ := im["agent"].(map[string]any)
+		if normalizeSoulAgentID(stringFromMap(agent, "agent_id")) == agentID {
+			return nil
+		}
+	}
+
+	return &mcpAuthFailure{
+		Code:    "forbidden",
+		Message: "OAuth identity is not authorized for this bound soul",
+		Status:  403,
+		Details: map[string]any{
+			"source":          "lesser_oauth_passthrough",
+			"reauthorize":     true,
+			"authAction":      "reauthorize",
+			"refreshRequired": false,
+			"reason":          "soul_binding_not_authorized",
+		},
+	}
 }
 
 func agentChannelsPayload(ctx context.Context, client *soulapi.Client, agentID string) (map[string]any, error) {
@@ -295,7 +360,6 @@ func lookupAgentIDs(ctx context.Context, client *soulapi.Client, q string) ([]st
 		return nil, errors.New("soul api client is nil")
 	}
 
-	allowENSLikeLocalFallback := false
 	allowBareRemoteHandleFallback := false
 	if agentID, err := resolveAgentIDByIdentifier(ctx, client, q); err == nil && agentID != "" {
 		return []string{agentID}, nil
@@ -304,11 +368,13 @@ func lookupAgentIDs(ctx context.Context, client *soulapi.Client, q string) ([]st
 		if !errors.As(err, &apiErr) || apiErr.Status != 404 {
 			return nil, err
 		}
-		allowENSLikeLocalFallback = looksLikeENSName(q)
+		if looksLikeENSName(q) {
+			return nil, nil
+		}
 		allowBareRemoteHandleFallback = looksLikeEmail(q)
 	}
 
-	search, err := prepareSoulLookupSearch(ctx, client, q, allowENSLikeLocalFallback, allowBareRemoteHandleFallback)
+	search, err := prepareSoulLookupSearch(ctx, client, q, false, allowBareRemoteHandleFallback)
 	if err != nil {
 		return nil, err
 	}
@@ -352,7 +418,10 @@ func prepareSoulLookupSearch(ctx context.Context, client *soulapi.Client, q stri
 		}
 		return remoteSearch, nil
 	}
-	if remoteSearch, ok := normalizeRemoteActivityPubHandle(searchQ, allowBareRemoteHandleFallback); ok {
+	if remoteSearch, handled, err := normalizeRemoteActivityPubHandle(searchQ, allowBareRemoteHandleFallback); handled || err != nil {
+		if err != nil {
+			return soulLookupSearch{}, err
+		}
 		return remoteSearch, nil
 	}
 	localID, ok := normalizeCurrentInstanceLocalLookupQuery(searchQ, allowENSLikeLocalFallback)
@@ -444,47 +513,56 @@ func normalizeLookupLocalID(raw string) (string, bool) {
 	return localID, true
 }
 
-func normalizeRemoteActivityPubHandle(raw string, allowBareRemoteHandleFallback bool) (soulLookupSearch, bool) {
+func normalizeRemoteActivityPubHandle(raw string, allowBareRemoteHandleFallback bool) (soulLookupSearch, bool, error) {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
-		return soulLookupSearch{}, false
+		return soulLookupSearch{}, false, nil
 	}
 
 	if strings.HasPrefix(raw, "@") {
 		parts := strings.SplitN(strings.TrimPrefix(raw, "@"), "@", 2)
 		if len(parts) != 2 {
-			return soulLookupSearch{}, false
+			return soulLookupSearch{}, false, nil
 		}
 		localID, ok := normalizeLookupLocalID(parts[0])
 		if !ok {
-			return soulLookupSearch{}, false
+			return soulLookupSearch{}, true, unsupportedRemoteActorHandleError(raw)
 		}
 		domain, ok := normalizeLookupDomain(parts[1])
 		if !ok {
-			return soulLookupSearch{}, false
+			return soulLookupSearch{}, true, unsupportedRemoteActorHandleError(raw)
 		}
-		return newExactQualifiedSoulLookupSearch(domain, localID), true
+		return newExactQualifiedSoulLookupSearch(domain, localID), true, nil
 	}
 
 	if !allowBareRemoteHandleFallback || strings.Count(raw, "@") != 1 {
-		return soulLookupSearch{}, false
+		return soulLookupSearch{}, false, nil
 	}
 
 	parts := strings.SplitN(raw, "@", 2)
 	localID, ok := normalizeLookupLocalID(parts[0])
 	if !ok {
-		return soulLookupSearch{}, false
+		return soulLookupSearch{}, true, unsupportedRemoteActorHandleError(raw)
 	}
 	domain, ok := normalizeLookupDomain(parts[1])
 	if !ok {
-		return soulLookupSearch{}, false
+		return soulLookupSearch{}, true, unsupportedRemoteActorHandleError(raw)
 	}
-	return newExactQualifiedSoulLookupSearch(domain, localID), true
+	return newExactQualifiedSoulLookupSearch(domain, localID), true, nil
 }
 
 func normalizeLookupDomain(raw string) (string, bool) {
 	raw = strings.ToLower(strings.TrimSpace(strings.TrimSuffix(raw, ".")))
-	if raw == "" || strings.ContainsAny(raw, "/@") {
+	if raw == "" || strings.ContainsAny(raw, "/@*") {
+		return "", false
+	}
+	if raw == "localhost" || strings.HasSuffix(raw, ".localhost") || strings.HasSuffix(raw, ".local") || strings.HasSuffix(raw, ".internal") {
+		return "", false
+	}
+	if !strings.Contains(raw, ".") {
+		return "", false
+	}
+	if _, err := netip.ParseAddr(raw); err == nil {
 		return "", false
 	}
 
@@ -493,6 +571,29 @@ func normalizeLookupDomain(raw string) (string, bool) {
 		return "", false
 	}
 	if parsed.Hostname() != raw || parsed.Path != "" || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return "", false
+	}
+	labels := strings.Split(parsed.Hostname(), ".")
+	for _, label := range labels {
+		if label == "" || len(label) > 63 || strings.HasPrefix(label, "-") || strings.HasSuffix(label, "-") {
+			return "", false
+		}
+		for _, r := range label {
+			if ('a' <= r && r <= 'z') || ('0' <= r && r <= '9') || r == '-' {
+				continue
+			}
+			return "", false
+		}
+	}
+	tld := labels[len(labels)-1]
+	allDigits := true
+	for _, r := range tld {
+		if r < '0' || r > '9' {
+			allDigits = false
+			break
+		}
+	}
+	if allDigits {
 		return "", false
 	}
 	return parsed.Hostname(), true
@@ -533,6 +634,15 @@ func unsupportedRemoteActorURLError(query string) error {
 	return &toolUserError{
 		Code:    "invalid_request",
 		Message: "unsupported remote actor URL; supported form is https://<domain>/users/<localId>",
+		Status:  400,
+		Details: map[string]any{"query": strings.TrimSpace(query)},
+	}
+}
+
+func unsupportedRemoteActorHandleError(query string) error {
+	return &toolUserError{
+		Code:    "invalid_request",
+		Message: "unsupported remote actor handle; supported form is @<localId>@<public-domain>",
 		Status:  400,
 		Details: map[string]any{"query": strings.TrimSpace(query)},
 	}

--- a/internal/mcpserver/identity_tools.go
+++ b/internal/mcpserver/identity_tools.go
@@ -144,21 +144,25 @@ func authenticatedAgentID(ctx context.Context) (string, error) {
 	if bearerToken == "" {
 		return "", oauthBearerRequiredFailure("missing_bearer_token")
 	}
-	if err := verifyAuthenticatedAgentWithLesser(ctx, bearerToken, agentID); err != nil {
+	if err := verifyAuthenticatedAgentWithLesser(ctx, bearerToken, agentID, username); err != nil {
 		return "", err
 	}
 
 	return agentID, nil
 }
 
-func verifyAuthenticatedAgentWithLesser(ctx context.Context, bearerToken string, agentID string) error {
+func verifyAuthenticatedAgentWithLesser(ctx context.Context, bearerToken string, agentID string, username string) error {
 	agentID = normalizeSoulAgentID(agentID)
 	bearerToken = strings.TrimSpace(bearerToken)
+	username = normalizeLocalAgentUsername(username)
 	if agentID == "" {
 		return newLocalAuthFailure("missing bound soul identity", "missing_bound_soul")
 	}
 	if bearerToken == "" {
 		return oauthBearerRequiredFailure("missing_bearer_token")
+	}
+	if username == "" {
+		return newLocalAuthFailure("missing authenticated agent identity", "missing_authenticated_identity")
 	}
 
 	client, err := lesser(ctx)
@@ -182,7 +186,13 @@ func verifyAuthenticatedAgentWithLesser(ctx context.Context, bearerToken string,
 	for _, item := range items {
 		im, _ := item.(map[string]any)
 		agent, _ := im["agent"].(map[string]any)
-		if normalizeSoulAgentID(stringFromMap(agent, "agent_id")) == agentID {
+		if normalizeSoulAgentID(stringFromMap(agent, "agent_id")) != agentID {
+			continue
+		}
+
+		binding, _ := im["binding"].(map[string]any)
+		if strings.ToLower(stringFromMap(im, "binding_state")) == "bound" &&
+			normalizeLocalAgentUsername(stringFromMap(binding, "agent_username")) == username {
 			return nil
 		}
 	}
@@ -199,6 +209,10 @@ func verifyAuthenticatedAgentWithLesser(ctx context.Context, bearerToken string,
 			"reason":          "soul_binding_not_authorized",
 		},
 	}
+}
+
+func normalizeLocalAgentUsername(username string) string {
+	return strings.ToLower(strings.TrimSpace(username))
 }
 
 func agentChannelsPayload(ctx context.Context, client *soulapi.Client, agentID string) (map[string]any, error) {

--- a/internal/mcpserver/identity_tools_test.go
+++ b/internal/mcpserver/identity_tools_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/equaltoai/lesser-body/internal/auth"
+	"github.com/equaltoai/lesser-body/internal/lesserapi"
 	"github.com/equaltoai/lesser-body/internal/soulapi"
 	"github.com/equaltoai/lesser-body/internal/soulbinding"
 	tablecore "github.com/theory-cloud/tabletheory/pkg/core"
@@ -129,6 +130,61 @@ func installSoulBindingLookup(t *testing.T, username string, agentID string) {
 	})
 }
 
+func TestVerifyAuthenticatedAgentWithLesserRequiresBoundLocalAgent(t *testing.T) {
+	const agentID = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+	tests := []struct {
+		name     string
+		response string
+	}{
+		{
+			name:     "unbound",
+			response: `{"souls":[{"agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-alice"},"binding_state":"unbound","binding":null}]}`,
+		},
+		{
+			name:     "bound to another local agent",
+			response: `{"souls":[{"agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-alice"},"binding_state":"bound","binding":{"agent_username":"agent2"}}]}`,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			lesserapi.ResetForTests()
+			t.Cleanup(lesserapi.ResetForTests)
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				if r.URL.Path != "/api/v1/souls/mine" {
+					t.Fatalf("unexpected path: %s", r.URL.Path)
+				}
+				if got := r.Header.Get("Authorization"); got != "Bearer oauth-token" {
+					t.Fatalf("expected OAuth bearer passthrough, got %q", got)
+				}
+				_, _ = w.Write([]byte(tc.response))
+			}))
+			defer server.Close()
+
+			t.Setenv("LESSER_API_BASE_URL", server.URL)
+
+			err := verifyAuthenticatedAgentWithLesser(context.Background(), "oauth-token", agentID, "Agent1")
+			if err == nil {
+				t.Fatalf("expected stale local binding to be rejected")
+			}
+			failure := mcpAuthFailureFromError(err)
+			if failure == nil {
+				t.Fatalf("expected MCP auth failure, got %T %v", err, err)
+			}
+			if failure.Code != "forbidden" || failure.Status != http.StatusForbidden {
+				t.Fatalf("unexpected failure: %+v", failure)
+			}
+			if failure.Details["reason"] != "soul_binding_not_authorized" {
+				t.Fatalf("unexpected failure details: %+v", failure.Details)
+			}
+		})
+	}
+}
+
 func TestNormalizeCurrentInstanceLocalLookupQuery(t *testing.T) {
 	t.Parallel()
 
@@ -165,6 +221,8 @@ func TestPrepareSoulLookupSearch_CurrentInstanceLocalQueryUsesAuthenticatedDomai
 	const agentID = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
 	installSoulBindingLookup(t, "Agent1", agentID)
+	lesserapi.ResetForTests()
+	t.Cleanup(lesserapi.ResetForTests)
 	soulapi.ResetForTests()
 	t.Cleanup(soulapi.ResetForTests)
 
@@ -172,7 +230,7 @@ func TestPrepareSoulLookupSearch_CurrentInstanceLocalQueryUsesAuthenticatedDomai
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
 		case "/api/v1/souls/mine":
-			_, _ = w.Write([]byte(`{"souls":[{"agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-alice"}}]}`))
+			_, _ = w.Write([]byte(`{"souls":[{"agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-alice"},"binding_state":"bound","binding":{"agent_username":"agent1"}}]}`))
 		case "/api/v1/soul/agents/" + agentID:
 			_, _ = w.Write([]byte(`{"version":"1","agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-alice","status":"active"}}`))
 		default:

--- a/internal/mcpserver/identity_tools_test.go
+++ b/internal/mcpserver/identity_tools_test.go
@@ -170,14 +170,19 @@ func TestPrepareSoulLookupSearch_CurrentInstanceLocalQueryUsesAuthenticatedDomai
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		if r.URL.Path != "/api/v1/soul/agents/"+agentID {
+		switch r.URL.Path {
+		case "/api/v1/souls/mine":
+			_, _ = w.Write([]byte(`{"souls":[{"agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-alice"}}]}`))
+		case "/api/v1/soul/agents/" + agentID:
+			_, _ = w.Write([]byte(`{"version":"1","agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-alice","status":"active"}}`))
+		default:
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
-		_, _ = w.Write([]byte(`{"version":"1","agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-alice","status":"active"}}`))
 	}))
 	defer server.Close()
 
 	t.Setenv("LESSER_SOUL_API_BASE_URL", server.URL)
+	t.Setenv("LESSER_API_BASE_URL", server.URL)
 
 	client, err := soulapi.Default()
 	if err != nil {
@@ -188,7 +193,7 @@ func TestPrepareSoulLookupSearch_CurrentInstanceLocalQueryUsesAuthenticatedDomai
 		Type:     auth.PrincipalTypeOAuthToken,
 		Identity: "Agent1",
 		Claims:   &auth.Claims{Username: "Agent1"},
-	}, "")
+	}, "test-token")
 
 	search, err := prepareSoulLookupSearch(ctx, client, "medic", false, false)
 	if err != nil {
@@ -241,6 +246,7 @@ func TestNormalizeRemoteActivityPubHandle(t *testing.T) {
 		allowBareHandleFallback bool
 		want                    soulLookupSearch
 		ok                      bool
+		wantErr                 bool
 	}{
 		{
 			name: "acct_form",
@@ -268,9 +274,10 @@ func TestNormalizeRemoteActivityPubHandle(t *testing.T) {
 			ok:   true,
 		},
 		{
-			name: "invalid_domain",
-			raw:  "@steward@remote.example/path",
-			ok:   false,
+			name:    "invalid_domain",
+			raw:     "@steward@remote.example/path",
+			ok:      true,
+			wantErr: true,
 		},
 	}
 
@@ -279,9 +286,9 @@ func TestNormalizeRemoteActivityPubHandle(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, ok := normalizeRemoteActivityPubHandle(tc.raw, tc.allowBareHandleFallback)
-			if got != tc.want || ok != tc.ok {
-				t.Fatalf("normalizeRemoteActivityPubHandle(%q, %v) = (%+v, %v), want (%+v, %v)", tc.raw, tc.allowBareHandleFallback, got, ok, tc.want, tc.ok)
+			got, ok, err := normalizeRemoteActivityPubHandle(tc.raw, tc.allowBareHandleFallback)
+			if got != tc.want || ok != tc.ok || (err != nil) != tc.wantErr {
+				t.Fatalf("normalizeRemoteActivityPubHandle(%q, %v) = (%+v, %v, %v), want (%+v, %v, err=%v)", tc.raw, tc.allowBareHandleFallback, got, ok, err, tc.want, tc.ok, tc.wantErr)
 			}
 		})
 	}

--- a/internal/mcpserver/identity_verify_tools.go
+++ b/internal/mcpserver/identity_verify_tools.go
@@ -116,7 +116,11 @@ func handleIdentityVerify(ctx context.Context, args json.RawMessage) (*mcpruntim
 		return toolJSONResult(result)
 	}
 
-	result["reason"] = "sender_does_not_match_resolved_identity"
+	if !senderHasAuthoritativeAgentID(from) {
+		result["reason"] = "message_lacks_authoritative_sender_provenance"
+	} else {
+		result["reason"] = "sender_does_not_match_resolved_identity"
+	}
 	return toolJSONResult(result)
 }
 
@@ -247,20 +251,12 @@ func senderVerificationMarkers(from map[string]any) verificationMarkers {
 	for _, key := range []string{"soulAgentId", "soul_agent_id", "agentId", "agent_id"} {
 		out.addAgentID(stringFromMap(from, key))
 	}
-	for _, key := range []string{"address", "email", "identifier", "name"} {
-		value := stringFromMap(from, key)
-		out.addEmail(value)
-		out.addPhone(value)
-		out.addENS(value)
-	}
-	for _, key := range []string{"number", "phone"} {
-		out.addPhone(stringFromMap(from, key))
-	}
-	for _, key := range []string{"ens"} {
-		out.addENS(stringFromMap(from, key))
-	}
 
 	return out
+}
+
+func senderHasAuthoritativeAgentID(from map[string]any) bool {
+	return len(senderVerificationMarkers(from).agentIDs) > 0
 }
 
 func newVerificationMarkers() verificationMarkers {

--- a/internal/mcpserver/mailbox_host_tools.go
+++ b/internal/mcpserver/mailbox_host_tools.go
@@ -10,7 +10,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/equaltoai/lesser-body/internal/auth"
 	"github.com/equaltoai/lesser-body/internal/soulapi"
 	mcpruntime "github.com/theory-cloud/apptheory/runtime/mcp"
 )
@@ -484,9 +483,6 @@ func outboundIdempotencyKey(ctx context.Context, explicit string) string {
 	explicit = strings.TrimSpace(explicit)
 	if explicit != "" {
 		return explicit
-	}
-	if requestID := auth.RequestIDFromToolContext(ctx); requestID != "" {
-		return requestID
 	}
 	return resolveOutboundCommIdempotencyKey(ctx, "")
 }

--- a/internal/mcpserver/outbound_comm_tools.go
+++ b/internal/mcpserver/outbound_comm_tools.go
@@ -216,9 +216,6 @@ func resolveOutboundCommIdempotencyKey(ctx context.Context, value string) string
 	if value != "" {
 		return value
 	}
-	if requestID := auth.RequestIDFromToolContext(ctx); requestID != "" {
-		return requestID
-	}
 	return uuid.NewString()
 }
 
@@ -294,16 +291,15 @@ func ensureBotDisclosurePrefix(value string) string {
 func hasBotDisclosurePrefix(value string) bool {
 	value = strings.TrimSpace(value)
 	for value != "" {
-		lower := strings.ToLower(value)
 		switch {
-		case strings.HasPrefix(lower, "re:"):
+		case len(value) >= 3 && strings.EqualFold(value[:3], "re:"):
 			value = strings.TrimSpace(value[3:])
-		case strings.HasPrefix(lower, "fw:"):
+		case len(value) >= 3 && strings.EqualFold(value[:3], "fw:"):
 			value = strings.TrimSpace(value[3:])
-		case strings.HasPrefix(lower, "fwd:"):
+		case len(value) >= 4 && strings.EqualFold(value[:4], "fwd:"):
 			value = strings.TrimSpace(value[4:])
 		default:
-			return strings.HasPrefix(strings.ToLower(value), strings.ToLower(botDisclosurePrefix))
+			return len(value) >= len(botDisclosurePrefix) && strings.EqualFold(value[:len(botDisclosurePrefix)], botDisclosurePrefix)
 		}
 	}
 	return false

--- a/internal/mcpserver/social_tools.go
+++ b/internal/mcpserver/social_tools.go
@@ -24,6 +24,9 @@ import (
 const (
 	notificationCursorMemoryPrefix = "notification_cursor:"
 	notificationCursorMemoryTag    = "notification_cursor"
+	notificationReadDefaultLimit   = 30
+	notificationReadMaxLimit       = 80
+	notificationReadMaxTypes       = 8
 )
 
 var notificationCursorEventIDs = struct {
@@ -347,16 +350,17 @@ func handleNotificationsRead(ctx context.Context, args json.RawMessage) (*mcprun
 	if err := json.Unmarshal(args, &in); err != nil {
 		return nil, invalidParams("invalid args: " + err.Error())
 	}
-	requestedTypes, upstreamTypes := normalizeRequestedNotificationTypes(in.Types)
+	requestedTypes, upstreamTypes, err := normalizeRequestedNotificationTypes(in.Types)
+	if err != nil {
+		return nil, err
+	}
+	limit := boundedNotificationReadLimit(in.Limit)
 	explicitSince := in.Since != nil
 	requestedSince := trimDeref(in.Since)
 	effectiveSince := requestedSince
 	effectiveCursor := strings.TrimSpace(in.Cursor)
 	sinceTime, hasTemporalSince := parseNotificationSince(requestedSince)
 
-	if explicitSince && requestedSince == "" {
-		_ = clearNotificationCursor(ctx)
-	}
 	if explicitSince && requestedSince != "" && !hasTemporalSince && effectiveCursor == "" {
 		effectiveCursor = requestedSince
 	}
@@ -370,7 +374,7 @@ func handleNotificationsRead(ctx context.Context, args json.RawMessage) (*mcprun
 		return nil, err
 	}
 
-	list, nextCursor, err := readSocialNotifications(ctx, client, token, upstreamTypes, in.Limit, effectiveCursor)
+	list, nextCursor, err := readSocialNotifications(ctx, client, token, upstreamTypes, limit, effectiveCursor)
 	if err != nil {
 		return authToolResultFromError(err)
 	}
@@ -383,14 +387,13 @@ func handleNotificationsRead(ctx context.Context, args json.RawMessage) (*mcprun
 		notifications = filterSocialNotificationsByType(notifications, requestedTypes)
 	}
 	sortSocialNotificationsNewestFirst(notifications)
-	if in.Limit > 0 && len(notifications) > in.Limit {
-		notifications = notifications[:in.Limit]
+	if len(notifications) > limit {
+		notifications = notifications[:limit]
 	}
 
 	nextSince := ""
 	if len(notifications) > 0 {
 		if newest, ok := notifications[0].(map[string]any); ok {
-			_ = writeNotificationCursor(ctx, strings.TrimSpace(firstNonEmptyStringMap(newest, "id")))
 			if hasTemporalSince || effectiveCursor == "" {
 				if createdAt, ok := notificationCreatedAt(newest); ok {
 					nextSince = createdAt.Format(time.RFC3339Nano)
@@ -878,9 +881,9 @@ func ternaryString(cond bool, yes string, no string) string {
 	return no
 }
 
-func normalizeRequestedNotificationTypes(in []string) ([]string, []string) {
+func normalizeRequestedNotificationTypes(in []string) ([]string, []string, error) {
 	if len(in) == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	requested := make([]string, 0, len(in))
@@ -896,7 +899,13 @@ func normalizeRequestedNotificationTypes(in []string) ([]string, []string) {
 		case "favorite":
 			typ = "favourite"
 		}
+		if !allowedNotificationType(typ) {
+			return nil, nil, invalidParams("unsupported notification type: " + typ)
+		}
 		if _, ok := seenRequested[typ]; !ok {
+			if len(requested) >= notificationReadMaxTypes {
+				return nil, nil, invalidParams("too many notification types requested")
+			}
 			seenRequested[typ] = struct{}{}
 			requested = append(requested, typ)
 		}
@@ -906,7 +915,27 @@ func normalizeRequestedNotificationTypes(in []string) ([]string, []string) {
 		}
 	}
 
-	return requested, upstream
+	return requested, upstream, nil
+}
+
+func allowedNotificationType(typ string) bool {
+	switch strings.TrimSpace(typ) {
+	case "mention", "reply", "favourite", "reblog", "follow", "follow_request", "poll", "status", "update", "admin.sign_up", "admin.report":
+		return true
+	default:
+		return false
+	}
+}
+
+func boundedNotificationReadLimit(limit int) int {
+	switch {
+	case limit <= 0:
+		return notificationReadDefaultLimit
+	case limit > notificationReadMaxLimit:
+		return notificationReadMaxLimit
+	default:
+		return limit
+	}
 }
 
 func readSocialNotifications(ctx context.Context, client *lesserapi.Client, token string, upstreamTypes []string, limit int, cursor string) ([]any, string, error) {
@@ -923,8 +952,9 @@ func readSocialNotifications(ctx context.Context, client *lesserapi.Client, toke
 		return readSocialNotificationsByType(ctx, client, token, firstString(queries), limit, cursor)
 	}
 
-	combined := make([]map[string]any, 0, len(queries)*max(1, limit))
-	seenIDs := make(map[string]struct{}, len(queries)*max(1, limit))
+	capacityHint := len(queries) * max(1, boundedNotificationReadLimit(limit))
+	combined := make([]map[string]any, 0, capacityHint)
+	seenIDs := make(map[string]struct{}, capacityHint)
 	for _, typ := range queries {
 		items, _, err := readSocialNotificationsByType(ctx, client, token, typ, limit, cursor)
 		if err != nil {

--- a/internal/soulapi/client.go
+++ b/internal/soulapi/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/netip"
 	"net/url"
 	"os"
 	"strconv"
@@ -210,12 +211,24 @@ func parseBaseURL(raw string) (*url.URL, error) {
 	if u.Scheme != "https" && u.Scheme != "http" {
 		return nil, fmt.Errorf("unsupported base url scheme: %s", u.Scheme)
 	}
+	if u.Scheme == "http" && !isLocalHTTPHost(u.Hostname()) {
+		return nil, fmt.Errorf("http base url is only allowed for localhost or loopback hosts")
+	}
 	if strings.TrimSpace(u.Host) == "" {
 		return nil, fmt.Errorf("base url host is empty")
 	}
 	u.RawQuery = ""
 	u.Fragment = ""
 	return u, nil
+}
+
+func isLocalHTTPHost(host string) bool {
+	host = strings.ToLower(strings.TrimSpace(host))
+	if host == "localhost" {
+		return true
+	}
+	addr, err := netip.ParseAddr(host)
+	return err == nil && addr.IsLoopback()
 }
 
 func resolveTimeout() time.Duration {

--- a/internal/soulapi/client_test.go
+++ b/internal/soulapi/client_test.go
@@ -101,3 +101,15 @@ func TestResolveBaseURL_FailsClosedForManagedDeployWithoutTrustBaseURL(t *testin
 		t.Fatalf("expected managed trust config error")
 	}
 }
+
+func TestParseBaseURL_AllowsHTTPOnlyForLoopback(t *testing.T) {
+	for _, raw := range []string{"http://localhost:8080", "http://127.0.0.1:8080", "http://[::1]:8080"} {
+		if _, err := parseBaseURL(raw); err != nil {
+			t.Fatalf("expected loopback HTTP URL %q to be accepted: %v", raw, err)
+		}
+	}
+
+	if _, err := parseBaseURL("http://api.example.com"); err == nil {
+		t.Fatalf("expected non-loopback HTTP URL to be rejected")
+	}
+}

--- a/scripts/canary_host_mailbox_mcp.py
+++ b/scripts/canary_host_mailbox_mcp.py
@@ -50,6 +50,33 @@ def log(message: str) -> None:
     print(message, flush=True)
 
 
+def redacted_payload_summary(value: Any) -> str:
+    try:
+        raw = json.dumps(value, sort_keys=True, separators=(",", ":"))
+    except (TypeError, ValueError):
+        raw = str(value)
+    digest = hashlib.sha256(raw.encode("utf-8", errors="replace")).hexdigest()[:12]
+    return f"len={len(raw)} sha256_12={digest}"
+
+
+def sanitized_error_payload(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {"payload": redacted_payload_summary(value)}
+
+    safe: dict[str, Any] = {}
+    for key in ("code", "status", "message"):
+        if key not in value:
+            continue
+        item = value.get(key)
+        if isinstance(item, str):
+            safe[key] = item[:160]
+        elif isinstance(item, (int, float, bool)) or item is None:
+            safe[key] = item
+    if not safe:
+        safe["payload"] = redacted_payload_summary(value)
+    return safe
+
+
 def post_rpc(method: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
     global next_id, session_id
     payload: dict[str, Any] = {"jsonrpc": "2.0", "id": next_id, "method": method}
@@ -77,17 +104,19 @@ def post_rpc(method: str, params: dict[str, Any] | None = None) -> dict[str, Any
             if not session_id:
                 session_id = resp.headers.get("mcp-session-id", "").strip()
     except urllib.error.HTTPError as exc:
-        body = exc.read().decode("utf-8", errors="replace")
-        raise CanaryError(f"{method} HTTP {exc.code}: {body[:500]}") from exc
+        body = exc.read()
+        digest = hashlib.sha256(body).hexdigest()[:12]
+        raise CanaryError(f"{method} HTTP {exc.code}: body_len={len(body)} body_sha256_12={digest}") from exc
     except urllib.error.URLError as exc:
         raise CanaryError(f"{method} request failed: {exc}") from exc
 
     try:
         data = json.loads(body)
     except json.JSONDecodeError as exc:
-        raise CanaryError(f"{method} returned non-JSON body: {body[:500]}") from exc
+        digest = hashlib.sha256(body.encode("utf-8", errors="replace")).hexdigest()[:12]
+        raise CanaryError(f"{method} returned non-JSON body: len={len(body)} sha256_12={digest}") from exc
     if data.get("error"):
-        raise CanaryError(f"{method} RPC error: {json.dumps(data['error'], sort_keys=True)}")
+        raise CanaryError(f"{method} RPC error: {json.dumps(sanitized_error_payload(data['error']), sort_keys=True)}")
     return data.get("result", {})
 
 
@@ -103,7 +132,7 @@ def tool_call(name: str, arguments: dict[str, Any], *, expect_error: bool = Fals
         return error_payload
     if is_error:
         error_payload = structured.get("error") or result
-        raise CanaryError(f"{name} tool error: {json.dumps(error_payload, sort_keys=True)[:500]}")
+        raise CanaryError(f"{name} tool error: {json.dumps(sanitized_error_payload(error_payload), sort_keys=True)}")
     data = structured.get("data")
     if not isinstance(data, dict):
         raise CanaryError(f"{name} missing structuredContent.data")

--- a/scripts/deploy-lesser-body-from-release.sh
+++ b/scripts/deploy-lesser-body-from-release.sh
@@ -159,13 +159,14 @@ if [[ -n "${BASE_DOMAIN}" ]]; then
   parameter_overrides+=("BaseDomain=${BASE_DOMAIN}")
 fi
 if [[ -n "${LESSER_HOST_INSTANCE_KEY_ARN}" ]]; then
-  case "${LESSER_HOST_INSTANCE_KEY_ARN}" in
-    arn:*) ;;
-    *)
-      echo "--lesser-host-instance-key-arn must start with arn:" >&2
-      exit 1
-      ;;
-  esac
+  if [[ "${LESSER_HOST_INSTANCE_KEY_ARN}" == *"*"* || "${LESSER_HOST_INSTANCE_KEY_ARN}" == *"?"* ]]; then
+    echo "--lesser-host-instance-key-arn must be an exact Secrets Manager secret ARN without wildcards" >&2
+    exit 1
+  fi
+  if [[ ! "${LESSER_HOST_INSTANCE_KEY_ARN}" =~ ^arn:[^:*]+:secretsmanager:[a-z0-9-]+:[0-9]{12}:secret:[A-Za-z0-9/_+=.@-]+$ ]]; then
+    echo "--lesser-host-instance-key-arn must be an exact Secrets Manager secret ARN" >&2
+    exit 1
+  fi
   parameter_overrides+=("LesserHostInstanceKeyARN=${LESSER_HOST_INSTANCE_KEY_ARN}")
 fi
 


### PR DESCRIPTION
## Milestone
Codex Security hardening — address the first high-priority set of findings from `.theory/codex-security-findings-2026-04-28T21-16-10.754Z.csv`.

## Classification
security / scope-profile / MCP-contract / lesser-integration / host-delegation / operational-reliability

## Surfaces affected
- MCP auth middleware (`tools/call`, `resources/read`, `prompts/get` scope gates)
- OAuth JWT freshness validation
- Identity whoami / communication dependency resolution
- `identity_verify` message provenance matching
- `notifications_read` read-scope side effects and fanout bounds
- Lesser/soul API bearer forwarding transport policy
- Host-backed comm idempotency fallback behavior
- Managed deploy CloudFormation parameters and IAM grants
- GitHub Actions pinning
- Canary log sanitization

## Specialist walks referenced
- Tool surface: read-side behavior tightened; no new dynamic tools or scope loosening
- MCP contract: discovery/list methods remain available; resource/prompt reads now enforce the documented read scope
- Lesser integration: bound soul revalidation uses Lesser `/api/v1/souls/mine` with the caller OAuth bearer before server-key host comm use
- Host delegation: outbound comm still delegates to lesser-host; generated fallback idempotency no longer reuses request IDs
- Framework: no local AppTheory/TableTheory patches

## Consumer impact
- Read-scoped clients continue to call resource and prompt reads successfully.
- Tokens with no read/write/admin scope are now rejected for `resources/read` and `prompts/get` with `insufficient_scope`.
- Soul-bound comm/whoami paths now fail closed if Lesser no longer authorizes the caller for the locally bound soul.
- `notifications_read` no longer persists or clears cursor memory; callers should use explicit `cursor`/`since` values from responses.
- Managed deploy templates require app-scoped SSM parameter paths instead of silently defaulting to `/lesser/...`.

## Tasks
- [x] Restore JWT 24h `iat` max-age enforcement
- [x] Add read-scope gates for `resources/read` and `prompts/get`
- [x] Revalidate local soul bindings with Lesser before whoami / host comm use
- [x] Require authoritative sender agent provenance for `identity_verify`
- [x] Make `notifications_read` side-effect free and bound limit/type fanout
- [x] Reject remote `http://` API base URLs before forwarding bearer credentials
- [x] Stop using request IDs as comm idempotency fallbacks
- [x] Pin GitHub Actions by commit SHA
- [x] Constrain managed deploy SSM/secret/IAM inputs
- [x] Sanitize canary error output

## Validation
- `go test ./...`
- `go vet ./...`
- `gofmt -l .` (clean, excluding generated `cdk/cdk.out`)
- `cd cdk && go test ./...`
- `cd cdk && go vet ./...`
- `scripts/build.sh`
- `cd cdk && CDK_DEFAULT_ACCOUNT=000000000000 CDK_DEFAULT_REGION=us-east-1 ./node_modules/.bin/cdk synth -c app=lesser -c stage=dev -c baseDomain=example.com`
- `scripts/verify_release_assets.sh v0.0.0-test <tmpdir>`
- `scripts/check_managed_template_default_regression.sh v0.0.0-test <tmpdir>`
- `scripts/check_release_asset_checksum_regression.sh v0.0.0-test <tmpdir>`

## Stage rollout plan (handoff to deploy-body)
- [ ] Merged to main
- [ ] Deployed to lab / dev
- [ ] Lab soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
- Lesser: `/api/v1/souls/mine` is now fail-closed in body whoami/comm identity resolution; confirm this is stable for all OAuth clients before live rollout.
- Host: managed deploy template parameter requirements and exact instance-key ARN validation affect managed provisioning inputs; host provisioning should keep passing app-derived overrides.

## Deploy
No deploy performed from this branch.