### PR TITLE
fix(identity): use Lesser bound-self verification

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -307,7 +307,9 @@ Notes:
   separate Lesser notification queries, so their per-type cursors are not collapsed into one `nextCursor`. Non-timestamp
   `since` values remain a legacy cursor alias for compatibility, but new callers should not rely on that path.
 - Communication and identity tools also require an **OAuth JWT** bearer token for agent-context reads such as `identity_whoami`
-  and inbox-backed verification.
+  and inbox-backed verification. For self-identity checks, lesser-body passes that bearer to Lesser's
+  `GET /api/v1/souls/bound/me` endpoint and fails closed if Lesser does not confirm an active bound soul for the
+  authenticated local username.
 - Host-backed communication tools (`email_send`, `email_read`, `email_get`, `email_get_content`, `email_search`,
   `email_reply`, `email_delete`, `email_mark_read`, `email_mark_unread`, `sms_send`, `sms_read`, `voicemail_read`)
   additionally require the managed

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -127,11 +127,16 @@ Symptoms:
 
 Common causes:
 
+- The Lesser instance does not yet expose `GET /api/v1/souls/bound/me`, or the endpoint returns a fail-closed
+  `soul_not_bound` / `soul_not_available` response for the authenticated runtime agent.
 - `LESSER_SOUL_API_BASE_URL` points at the Lesser instance API (`https://api.<stageDomain>`) instead of lesser-host.
 - In a managed deployment, Lesser `TRUST_CONFIG` is missing `baseURL` and/or `instanceKeySecretARN`.
 
 Fix:
 
+- Verify the authenticated runtime-agent OAuth bearer succeeds against the Lesser bound-self endpoint:
+  `GET https://api.<stageDomain>/api/v1/souls/bound/me`. A healthy souled runtime agent returns
+  `binding_state: "bound"` with `binding.agent_username` matching the token username.
 - In managed AWS deployments, make sure `PK=INSTANCE#CONFIG, SK=TRUST_CONFIG` in `LESSER_TABLE_NAME` has:
   - `managed.baseURL`
   - `managed.instanceKeySecretARN` for host-backed communication tools

--- a/internal/mcpapp/email_tools_test.go
+++ b/internal/mcpapp/email_tools_test.go
@@ -44,8 +44,8 @@ func TestLBM2_EmailSendAndReply_TalkToCommAPI(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
-		case r.URL.Path == "/api/v1/souls/mine":
-			_, _ = w.Write([]byte(`{"souls":[{"agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-bob"},"binding_state":"bound","binding":{"agent_username":"agent1"}}]}`))
+		case r.URL.Path == "/api/v1/souls/bound/me":
+			_, _ = w.Write([]byte(boundSelfResponse(agentID, "agent1", "test.example.com", "agent-bob")))
 		case r.URL.Path == "/api/v1/soul/agents/"+agentID:
 			_, _ = w.Write([]byte(`{"version":"1","agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-bob","status":"active"}}`))
 		case r.URL.Path == "/api/v1/soul/agents/"+agentID+"/registration":

--- a/internal/mcpapp/identity_surfaces_test.go
+++ b/internal/mcpapp/identity_surfaces_test.go
@@ -56,8 +56,8 @@ func TestLBM1_IdentityToolsAndChannelResources(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 
 		switch {
-		case r.URL.Path == "/api/v1/souls/mine":
-			_, _ = w.Write([]byte(`{"souls":[{"agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-alice"},"binding_state":"bound","binding":{"agent_username":"agent1"}}]}`))
+		case r.URL.Path == "/api/v1/souls/bound/me":
+			_, _ = w.Write([]byte(boundSelfResponse(agentID, "agent1", "test.example.com", "agent-alice")))
 		case r.URL.Path == "/api/v1/soul/search":
 			q := r.URL.Query().Get("q")
 			domain := r.URL.Query().Get("domain")
@@ -637,8 +637,8 @@ func TestLBM1_IdentityLookupBareLocalFailsWithoutTrustworthyCurrentInstanceDomai
 		w.Header().Set("Content-Type", "application/json")
 
 		switch {
-		case r.URL.Path == "/api/v1/souls/mine":
-			_, _ = w.Write([]byte(`{"souls":[{"agent":{"agent_id":"` + agentID + `","domain":"","local_id":"agent-alice"},"binding_state":"bound","binding":{"agent_username":"agent1"}}]}`))
+		case r.URL.Path == "/api/v1/souls/bound/me":
+			_, _ = w.Write([]byte(boundSelfResponse(agentID, "agent1", "", "agent-alice")))
 		case r.URL.Path == "/api/v1/soul/agents/"+agentID:
 			_, _ = w.Write([]byte(`{"version":"1","agent":{"agent_id":"` + agentID + `","domain":"","local_id":"agent-alice","status":"active"}}`))
 		case r.URL.Path == "/api/v1/soul/search":
@@ -743,8 +743,8 @@ func TestLBM1_IdentityLookupMalformedLocalIdentifierReturnsBadRequest(t *testing
 		w.Header().Set("Content-Type", "application/json")
 
 		switch {
-		case r.URL.Path == "/api/v1/souls/mine":
-			_, _ = w.Write([]byte(`{"souls":[{"agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-alice"},"binding_state":"bound","binding":{"agent_username":"agent1"}}]}`))
+		case r.URL.Path == "/api/v1/souls/bound/me":
+			_, _ = w.Write([]byte(boundSelfResponse(agentID, "agent1", "test.example.com", "agent-alice")))
 		case r.URL.Path == "/api/v1/soul/search":
 			gotSearchQuery = r.URL.Query().Get("q")
 			gotSearchDomain = r.URL.Query().Get("domain")
@@ -850,8 +850,8 @@ func TestLBM1_IdentityLookupUnsupportedRemoteActorURLReturnsBadRequest(t *testin
 		w.Header().Set("Content-Type", "application/json")
 
 		switch {
-		case r.URL.Path == "/api/v1/souls/mine":
-			_, _ = w.Write([]byte(`{"souls":[{"agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-alice"},"binding_state":"bound","binding":{"agent_username":"agent1"}}]}`))
+		case r.URL.Path == "/api/v1/souls/bound/me":
+			_, _ = w.Write([]byte(boundSelfResponse(agentID, "agent1", "test.example.com", "agent-alice")))
 		case r.URL.Path == "/api/v1/soul/search":
 			searchCalled = true
 			_, _ = w.Write([]byte(`{"version":"1","results":[],"count":0,"has_more":false}`))

--- a/internal/mcpapp/inbox_tools_test.go
+++ b/internal/mcpapp/inbox_tools_test.go
@@ -33,8 +33,8 @@ func TestLBM3_InboxToolsUseHostMailbox(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 
 		switch {
-		case r.URL.Path == "/api/v1/souls/mine":
-			_, _ = w.Write([]byte(`{"souls":[{"agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-alice"},"binding_state":"bound","binding":{"agent_username":"agent1"}}]}`))
+		case r.URL.Path == "/api/v1/souls/bound/me":
+			_, _ = w.Write([]byte(boundSelfResponse(agentID, "agent1", "test.example.com", "agent-alice")))
 		case r.URL.Path == "/api/v1/soul/agents/"+agentID:
 			_, _ = w.Write([]byte(`{"version":"1","agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-alice","status":"active"}}`))
 		case r.URL.Path == "/api/v1/soul/agents/"+agentID+"/registration":

--- a/internal/mcpapp/outbound_comm_streaming_test.go
+++ b/internal/mcpapp/outbound_comm_streaming_test.go
@@ -36,8 +36,8 @@ func TestSmsSendStreamingEmitsProgressAndFinalResult(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 
 		switch r.URL.Path {
-		case "/api/v1/souls/mine":
-			_, _ = w.Write([]byte(`{"souls":[{"agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-dana"},"binding_state":"bound","binding":{"agent_username":"agent1"}}]}`))
+		case "/api/v1/souls/bound/me":
+			_, _ = w.Write([]byte(boundSelfResponse(agentID, "agent1", "test.example.com", "agent-dana")))
 		case "/api/v1/soul/agents/" + agentID:
 			_, _ = w.Write([]byte(`{"version":"1","agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-dana","status":"active"}}`))
 		case "/api/v1/soul/agents/" + agentID + "/registration":

--- a/internal/mcpapp/outbound_comm_tools_test.go
+++ b/internal/mcpapp/outbound_comm_tools_test.go
@@ -43,8 +43,8 @@ func TestLBM6_SMSAndVoiceOutboundTools(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 
 		switch r.URL.Path {
-		case "/api/v1/souls/mine":
-			_, _ = w.Write([]byte(`{"souls":[{"agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-carol"},"binding_state":"bound","binding":{"agent_username":"agent1"}}]}`))
+		case "/api/v1/souls/bound/me":
+			_, _ = w.Write([]byte(boundSelfResponse(agentID, "agent1", "test.example.com", "agent-carol")))
 		case "/api/v1/soul/agents/" + agentID:
 			_, _ = w.Write([]byte(`{"version":"1","agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-carol","status":"active"}}`))
 		case "/api/v1/soul/agents/" + agentID + "/registration":

--- a/internal/mcpapp/tabletheory_fake_test.go
+++ b/internal/mcpapp/tabletheory_fake_test.go
@@ -3,6 +3,7 @@ package mcpapp_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"reflect"
 	"testing"
 	"time"
@@ -139,6 +140,10 @@ func installSoulBindingLookup(t testing.TB, username string, agentID string) {
 			},
 		}, nil
 	})
+}
+
+func boundSelfResponse(agentID string, username string, domain string, localID string) string {
+	return fmt.Sprintf(`{"agent":{"agent_id":%q,"domain":%q,"local_id":%q,"status":"active","lifecycle_status":"active"},"binding_state":"bound","binding":{"agent_username":%q}}`, agentID, domain, localID, username)
 }
 
 func installMissingSoulBindingLookup(t testing.TB) {

--- a/internal/mcpserver/identity_tools.go
+++ b/internal/mcpserver/identity_tools.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/equaltoai/lesser-body/internal/auth"
+	"github.com/equaltoai/lesser-body/internal/lesserapi"
 	"github.com/equaltoai/lesser-body/internal/soulapi"
 	"github.com/equaltoai/lesser-body/internal/soulbinding"
 	mcpruntime "github.com/theory-cloud/apptheory/runtime/mcp"
@@ -170,33 +171,30 @@ func verifyAuthenticatedAgentWithLesser(ctx context.Context, bearerToken string,
 		return &toolUserError{Code: "not_configured", Message: err.Error(), Status: 500}
 	}
 
-	mineAny, err := client.DoJSON(ctx, "GET", "/api/v1/souls/mine", nil, bearerToken, nil)
+	boundAny, err := client.DoJSON(ctx, "GET", "/api/v1/souls/bound/me", nil, bearerToken, nil)
 	if err != nil {
-		return err
+		return boundSelfVerificationError(err)
 	}
-	mine, ok := mineAny.(map[string]any)
+	bound, ok := boundAny.(map[string]any)
 	if !ok {
-		return fmt.Errorf("unexpected souls/mine response")
+		return fmt.Errorf("unexpected souls/bound/me response")
 	}
 
-	items, _ := mine["souls"].([]any)
-	if len(items) == 0 {
-		return &toolUserError{Code: "not_found", Message: "no soul agents found for this identity", Status: 404}
-	}
-	for _, item := range items {
-		im, _ := item.(map[string]any)
-		agent, _ := im["agent"].(map[string]any)
-		if normalizeSoulAgentID(stringFromMap(agent, "agent_id")) != agentID {
-			continue
-		}
-
-		binding, _ := im["binding"].(map[string]any)
-		if strings.ToLower(stringFromMap(im, "binding_state")) == "bound" &&
-			normalizeLocalAgentUsername(stringFromMap(binding, "agent_username")) == username {
-			return nil
-		}
+	agent, _ := bound["agent"].(map[string]any)
+	if normalizeSoulAgentID(stringFromMap(agent, "agent_id")) != agentID {
+		return boundSoulNotAuthorizedFailure()
 	}
 
+	binding, _ := bound["binding"].(map[string]any)
+	if strings.ToLower(stringFromMap(bound, "binding_state")) != "bound" ||
+		normalizeLocalAgentUsername(stringFromMap(binding, "agent_username")) != username {
+		return boundSoulNotAuthorizedFailure()
+	}
+
+	return nil
+}
+
+func boundSoulNotAuthorizedFailure() *mcpAuthFailure {
 	return &mcpAuthFailure{
 		Code:    "forbidden",
 		Message: "OAuth identity is not authorized for this bound soul",
@@ -209,6 +207,54 @@ func verifyAuthenticatedAgentWithLesser(ctx context.Context, bearerToken string,
 			"reason":          "soul_binding_not_authorized",
 		},
 	}
+}
+
+func boundSelfVerificationError(err error) error {
+	if failure := mcpAuthFailureFromError(err); failure != nil {
+		return failure
+	}
+
+	var apiErr *lesserapi.APIError
+	if !errors.As(err, &apiErr) {
+		return err
+	}
+
+	message, parsed := boundSelfAPIErrorMessage(apiErr.Body)
+	if message == "" {
+		message = "bound soul self-verification failed"
+	}
+	details := map[string]any{
+		"source":       "lesser_bound_self",
+		"upstreamCode": apiErr.Status,
+	}
+	if parsed != nil {
+		details["apiError"] = parsed
+		if reason := extractString(parsed, "error_code"); reason != "" {
+			details["reason"] = reason
+		}
+	}
+
+	return &toolUserError{
+		Code:    identityErrorCodeForStatus(apiErr.Status),
+		Message: message,
+		Status:  apiErr.Status,
+		Details: details,
+	}
+}
+
+func boundSelfAPIErrorMessage(body []byte) (string, map[string]any) {
+	message, parsed := commExtractAPIErrorMessage(body)
+	if parsed == nil {
+		return message, nil
+	}
+	if msg := firstNonEmpty(
+		extractString(parsed, "error_description"),
+		extractString(parsed, "error"),
+		extractString(parsed, "message"),
+	); msg != "" {
+		return msg, parsed
+	}
+	return message, parsed
 }
 
 func normalizeLocalAgentUsername(username string) string {

--- a/internal/mcpserver/identity_tools_test.go
+++ b/internal/mcpserver/identity_tools_test.go
@@ -2,6 +2,8 @@ package mcpserver
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -130,6 +132,38 @@ func installSoulBindingLookup(t *testing.T, username string, agentID string) {
 	})
 }
 
+func boundSelfResponse(agentID string, username string, domain string, localID string) string {
+	return fmt.Sprintf(`{"agent":{"agent_id":%q,"domain":%q,"local_id":%q,"status":"active","lifecycle_status":"active"},"binding_state":"bound","binding":{"agent_username":%q}}`, agentID, domain, localID, username)
+}
+
+func TestVerifyAuthenticatedAgentWithLesserAcceptsBoundSelfRuntimeAgent(t *testing.T) {
+	const agentID = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+	lesserapi.ResetForTests()
+	t.Cleanup(lesserapi.ResetForTests)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/api/v1/souls/mine" {
+			t.Fatalf("must not fall back to wallet inventory endpoint")
+		}
+		if r.URL.Path != "/api/v1/souls/bound/me" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer oauth-token" {
+			t.Fatalf("expected OAuth bearer passthrough, got %q", got)
+		}
+		_, _ = w.Write([]byte(boundSelfResponse(agentID, "agent1", "test.example.com", "agent-alice")))
+	}))
+	defer server.Close()
+
+	t.Setenv("LESSER_API_BASE_URL", server.URL)
+
+	if err := verifyAuthenticatedAgentWithLesser(context.Background(), "oauth-token", agentID, "Agent1"); err != nil {
+		t.Fatalf("verifyAuthenticatedAgentWithLesser: %v", err)
+	}
+}
+
 func TestVerifyAuthenticatedAgentWithLesserRequiresBoundLocalAgent(t *testing.T) {
 	const agentID = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
@@ -139,11 +173,15 @@ func TestVerifyAuthenticatedAgentWithLesserRequiresBoundLocalAgent(t *testing.T)
 	}{
 		{
 			name:     "unbound",
-			response: `{"souls":[{"agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-alice"},"binding_state":"unbound","binding":null}]}`,
+			response: `{"agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-alice"},"binding_state":"unbound","binding":{"agent_username":"agent1"}}`,
 		},
 		{
 			name:     "bound to another local agent",
-			response: `{"souls":[{"agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-alice"},"binding_state":"bound","binding":{"agent_username":"agent2"}}]}`,
+			response: `{"agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-alice"},"binding_state":"bound","binding":{"agent_username":"agent2"}}`,
+		},
+		{
+			name:     "bound to another soul agent",
+			response: `{"agent":{"agent_id":"0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","domain":"test.example.com","local_id":"agent-alice"},"binding_state":"bound","binding":{"agent_username":"agent1"}}`,
 		},
 	}
 
@@ -155,7 +193,7 @@ func TestVerifyAuthenticatedAgentWithLesserRequiresBoundLocalAgent(t *testing.T)
 
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
-				if r.URL.Path != "/api/v1/souls/mine" {
+				if r.URL.Path != "/api/v1/souls/bound/me" {
 					t.Fatalf("unexpected path: %s", r.URL.Path)
 				}
 				if got := r.Header.Get("Authorization"); got != "Bearer oauth-token" {
@@ -182,6 +220,46 @@ func TestVerifyAuthenticatedAgentWithLesserRequiresBoundLocalAgent(t *testing.T)
 				t.Fatalf("unexpected failure details: %+v", failure.Details)
 			}
 		})
+	}
+}
+
+func TestVerifyAuthenticatedAgentWithLesserDoesNotFallbackToSoulsMine(t *testing.T) {
+	const agentID = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+	lesserapi.ResetForTests()
+	t.Cleanup(lesserapi.ResetForTests)
+
+	var mineCalled bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/souls/bound/me":
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":"no bound soul for authenticated principal","error_description":"no bound soul for authenticated principal","error_code":"soul_not_bound"}`))
+		case "/api/v1/souls/mine":
+			mineCalled = true
+			_, _ = w.Write([]byte(`{"souls":[{"agent":{"agent_id":"` + agentID + `"},"binding_state":"bound","binding":{"agent_username":"agent1"}}],"count":1}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	t.Setenv("LESSER_API_BASE_URL", server.URL)
+
+	err := verifyAuthenticatedAgentWithLesser(context.Background(), "oauth-token", agentID, "Agent1")
+	if err == nil {
+		t.Fatalf("expected bound-self 404 to fail closed")
+	}
+	if mineCalled {
+		t.Fatalf("must not fall back to /api/v1/souls/mine after bound-self denial")
+	}
+	var userErr *toolUserError
+	if !errors.As(err, &userErr) {
+		t.Fatalf("expected toolUserError for bound-self denial, got %T %v", err, err)
+	}
+	if userErr.Code != "not_found" || userErr.Status != http.StatusNotFound {
+		t.Fatalf("unexpected bound-self denial: %+v", userErr)
 	}
 }
 
@@ -229,8 +307,8 @@ func TestPrepareSoulLookupSearch_CurrentInstanceLocalQueryUsesAuthenticatedDomai
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
-		case "/api/v1/souls/mine":
-			_, _ = w.Write([]byte(`{"souls":[{"agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-alice"},"binding_state":"bound","binding":{"agent_username":"agent1"}}]}`))
+		case "/api/v1/souls/bound/me":
+			_, _ = w.Write([]byte(boundSelfResponse(agentID, "agent1", "test.example.com", "agent-alice")))
 		case "/api/v1/soul/agents/" + agentID:
 			_, _ = w.Write([]byte(`{"version":"1","agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-alice","status":"active"}}`))
 		default:


### PR DESCRIPTION
## Milestone
issue-155-bound-self-verification — migrate MCP runtime-agent self-verification to Lesser's bound-self endpoint.

Closes #155.

## Classification
bug-fix / lesser-integration / tool-surface / host-delegation-adjacent

## Surfaces affected
- `internal/mcpserver/identity_tools.go`
  - `identity_whoami`
  - current-instance `identity_lookup("<local-id>")`
  - shared `whoamiChannelsPayload` dependency used by host-backed comm tools
- Host-backed comm dependency loading for:
  - `email_send`, `email_read`, `email_get`, `email_get_content`, `email_search`, `email_reply`, `email_delete`, `email_mark_read`, `email_mark_unread`
  - `sms_send`, `sms_read`, `voicemail_read`
- Operator docs for MCP and troubleshooting

## Specialist walks referenced
- Tool surface: existing tool set/scope/profile unchanged; behavior now accepts walletless bound runtime agents while preserving fail-closed self-verification.
- MCP contract: no discovery, JSON-RPC, OAuth metadata, or tool input/output schema change.
- Lesser integration: coordinated with Lesser steward by email; Lesser confirmed `/api/v1/souls/bound/me` is deployed in the target environment, accepts read/write OAuth, requires no wallet credentials, and should be treated as authoritative.
- Host delegation: no lesser-host comm API change; comm tools still delegate through lesser-host with `LESSER_HOST_INSTANCE_KEY` after self-verification succeeds.
- Framework: no AppTheory/TableTheory changes.

## Consumer impact
- Walletless souled runtime agents can pass `identity_whoami`, current-instance local identity lookup, and host-backed comm dependency loading once Lesser confirms bound self identity.
- `/api/v1/souls/mine` remains wallet-owner inventory and is no longer used for body self-verification.
- Non-200 bound-self responses fail closed; no fallback to `/api/v1/souls/mine`.

## Tasks
- [x] Switch `verifyAuthenticatedAgentWithLesser` from `/api/v1/souls/mine` to `/api/v1/souls/bound/me`.
- [x] Retain local soulbinding agent-id cross-check as defense in depth.
- [x] Fail closed on returned agent id mismatch, binding username mismatch, non-bound binding state, and bound-self non-200 responses.
- [x] Update identity and comm integration tests to stub the new Lesser endpoint.
- [x] Add regression coverage proving bound-self 404 does not fall back to `/souls/mine`.
- [x] Update operator docs.

## Validation
- `go test ./...`
- `go vet ./...`
- `test -z "$(gofmt -l $(git ls-files '*.go'))"`
- `bash scripts/build.sh`
- `(cd cdk && go test ./...)`
- Targeted before full suite:
  - `go test ./internal/mcpserver -run 'TestVerifyAuthenticatedAgentWithLesser|TestPrepareSoulLookupSearch_CurrentInstanceLocalQueryUsesAuthenticatedDomain' -v`
  - `go test ./internal/mcpapp -run 'TestLBM1_IdentityToolsAndChannelResources|TestLBM2_EmailSendAndReply_TalkToCommAPI|TestLBM3_InboxToolsUseHostMailbox|TestLBM6_SMSAndVoiceOutboundTools|TestSmsSendStreamingEmitsProgressAndFinalResult|TestLBM1_IdentityLookup' -v`

## Stage rollout plan (handoff to deploy-body)
- [ ] Merged to main
- [ ] Deployed to lab / dev
- [ ] Validate `GET /api/v1/souls/bound/me` against target runtime-agent bearer before/alongside body smoke
- [ ] Re-run Ops MCP probe for `identity_whoami`, `identity_lookup("ops")`, `email_read`, `email_send`, `sms_read`, `voicemail_read`
- [ ] Lab soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
- Lesser steward confirmed endpoint deployment and contract in reply `delivery-1221474bb042269e`.
- No further Lesser-side code changes required for this body PR.

## Advisor-brief authorization
Not applicable.
