### PR TITLE
fix(identity): fail closed private reachability

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -294,8 +294,8 @@ Scope key:
 | `sms_read` | Read | List inbound SMS metadata/previews from lesser-host's canonical mailbox. |
 | `voicemail_read` | Read | List inbound voice/voicemail metadata/previews from lesser-host's canonical mailbox. |
 | `identity_whoami` | Read | Return the current soul agent identity, channels, and contact preferences. |
-| `identity_lookup` | Read | Resolve a soul identity by full agent ID, managed email, ENS name, a current-instance local ID such as `medic`, a remote ActivityPub handle such as `@steward@remote.example`, or a canonical actor URL such as `https://remote.example/users/steward`; returns public identity summary only. |
-| `identity_verify` | Read | Verify that a recent communication matches a resolved soul identity using channel resolution plus notification provenance. |
+| `identity_lookup` | Read | Resolve a public soul identity by full agent ID, ENS name, a current-instance local ID such as `medic`, an explicit remote ActivityPub handle such as `@steward@remote.example`, or a canonical actor URL such as `https://remote.example/users/steward`; returns public identity summary only. |
+| `identity_verify` | Read | Verify that a recent communication matches a resolved soul identity using public ENS resolution plus authoritative message provenance. Private email/phone reachability verification fails closed until lesser-host exposes a body-facing resolver. |
 
 Notes:
 
@@ -324,15 +324,18 @@ Notes:
 - Voice is currently receive-only: use `voicemail_read` for inbound voicemail; outbound `phone_call` is intentionally disabled.
 - `identity_lookup` accepts:
   - full soul `agentId`
-  - managed email address
   - ENS name
   - current-instance local IDs such as `medic`
   - remote ActivityPub handles in `@user@domain` form
   - canonical remote actor URLs in `https://domain/users/user` form
+- Managed email and phone reverse lookup are private reachability surfaces in lesser-host. Until lesser-host exposes a
+  body-facing, instance-authenticated resolver, `identity_lookup` and `identity_verify` fail closed for private
+  email/phone identifiers with `private_reachability_unavailable` instead of probing those routes anonymously.
 - `identity_lookup` intentionally returns only public identity summary fields (`agentId`, `domain`, `localId`,
   `status`). It does not expose arbitrary agents' private `channels` or `contactPreferences`; use
   `identity_whoami` or `agent://channels` only for the authenticated agent's own channel data.
-- For bare `user@domain` inputs, `identity_lookup` first tries managed-email resolution. If that returns not found, lesser-body falls back to treating the input as a remote ActivityPub handle and resolves it through the exact qualified host search form.
+- Bare `user@domain` inputs are ambiguous with private managed email reachability and fail closed. Use the explicit
+  ActivityPub handle form `@user@domain` when the input is meant to be a public actor handle.
 - When a query is only a local ID, lesser-body resolves it against the authenticated actor's current instance domain.
   Cross-instance lookups should use an explicit domain-qualified form such as `@user@domain` or a canonical actor URL instead of relying on bare local IDs.
 - Remote ActivityPub handles and canonical actor URLs resolve through an exact domain-qualified host query instead of the fuzzy `q=<local>&domain=<domain>` path.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -144,6 +144,29 @@ Fix:
   - `LESSER_SOUL_API_BASE_URL=https://<stage>.lesser.host`
   - optionally `LESSER_HOST_INSTANCE_KEY` or `LESSER_HOST_INSTANCE_KEY_ARN` for host-backed comm tools
 
+## Identity lookup or verify returns `private_reachability_unavailable`
+
+Symptoms:
+
+- `identity_lookup` with a bare email-like query such as `user@example.com` returns
+  `private_reachability_unavailable`.
+- `identity_verify` with `channel=email` or `channel=phone` returns `private_reachability_unavailable`.
+- `identity_verify` with `channel=ens` succeeds or fails based on public ENS resolution plus authoritative sender
+  provenance, without fetching private `/agents/{id}/channels` data.
+
+Common cause:
+
+- lesser-host private reachability hardening makes email/phone reverse lookup and arbitrary agent channel reads
+  non-public. lesser-body fails closed instead of calling those routes anonymously.
+
+Fix:
+
+- For public actor lookup, use an ENS name, full agent ID, current-instance local ID, explicit ActivityPub handle
+  (`@user@domain`), or canonical actor URL.
+- For private email/phone reachability lookup, wait for the body-facing, instance-authenticated lesser-host resolver
+  contract. That resolver must use the managed instance key, be scoped to the managed instance/domain, and return only
+  bounded contactability fields.
+
 ## Host mailbox tools return empty results or 4xx errors
 
 Symptoms:

--- a/internal/mcpapp/identity_surfaces_test.go
+++ b/internal/mcpapp/identity_surfaces_test.go
@@ -39,6 +39,7 @@ func TestLBM1_IdentityToolsAndChannelResources(t *testing.T) {
 	var searchQueries []string
 	var searchDomains []string
 	var emailResolveQueries []string
+	var channelResolveQueries []string
 	soulbinding.SetDBFactoryForTests(func() (tablecore.DB, error) {
 		return &fakeTableTheoryDB{
 			firstFn: func(dest any, where map[string]any) error {
@@ -90,6 +91,7 @@ func TestLBM1_IdentityToolsAndChannelResources(t *testing.T) {
 				}
 			}`))
 		case r.URL.Path == "/api/v1/soul/agents/"+agentID+"/channels":
+			channelResolveQueries = append(channelResolveQueries, agentID)
 			_, _ = w.Write([]byte(`{
 				"agentId":"` + agentID + `",
 				"channels":{
@@ -176,6 +178,27 @@ func TestLBM1_IdentityToolsAndChannelResources(t *testing.T) {
 			t.Fatalf("%s: identity_lookup must not expose contactPreferences in public matches: %+v", label, match)
 		}
 	}
+	assertToolErrorPayload := func(label string, body []byte, wantCode string) map[string]any {
+		t.Helper()
+		var rpc mcpruntime.Response
+		_ = json.Unmarshal(body, &rpc)
+		if rpc.Error != nil {
+			t.Fatalf("%s rpc error: %+v", label, rpc.Error)
+		}
+		var out mcpruntime.ToolResult
+		{
+			b, _ := json.Marshal(rpc.Result)
+			_ = json.Unmarshal(b, &out)
+		}
+		if !out.IsError {
+			t.Fatalf("%s expected isError tool result, got %+v", label, out)
+		}
+		errPayload, _ := out.StructuredContent["error"].(map[string]any)
+		if errPayload["code"] != wantCode {
+			t.Fatalf("%s expected error code %q, got %+v", label, wantCode, errPayload)
+		}
+		return errPayload
+	}
 
 	// identity_whoami should resolve the authenticated local agent via the soul binding and return channels + preferences.
 	{
@@ -227,8 +250,8 @@ func TestLBM1_IdentityToolsAndChannelResources(t *testing.T) {
 		}
 	}
 
-	// identity_lookup should resolve managed email/ENS directly without stripping them to bare localIds.
-	for _, q := range []string{"agent-alice@lessersoul.ai", "agent-alice.lessersoul.eth"} {
+	// identity_lookup should resolve public ENS directly without stripping it to a bare localId.
+	for _, q := range []string{"agent-alice.lessersoul.eth"} {
 		callParams, _ := json.Marshal(map[string]any{
 			"name":      "identity_lookup",
 			"arguments": map[string]any{"query": q},
@@ -263,13 +286,40 @@ func TestLBM1_IdentityToolsAndChannelResources(t *testing.T) {
 		assertPublicLookupMatch(q, match)
 	}
 	if len(searchQueries) != 0 {
-		t.Fatalf("identity_lookup for managed identifiers should resolve directly, got search queries %+v", searchQueries)
+		t.Fatalf("identity_lookup for ENS should resolve directly, got search queries %+v", searchQueries)
 	}
 	if len(searchDomains) != 0 {
-		t.Fatalf("identity_lookup for managed identifiers should not set search domains, got %+v", searchDomains)
+		t.Fatalf("identity_lookup for ENS should not set search domains, got %+v", searchDomains)
 	}
-	if !reflect.DeepEqual(emailResolveQueries, []string{"agent-alice@lessersoul.ai"}) {
-		t.Fatalf("identity_lookup for managed identifiers should only resolve supported managed email directly, got %+v", emailResolveQueries)
+	if len(emailResolveQueries) != 0 {
+		t.Fatalf("identity_lookup for ENS should not call managed email resolution, got %+v", emailResolveQueries)
+	}
+
+	searchQueries = nil
+	searchDomains = nil
+	emailResolveQueries = nil
+
+	// identity_lookup should fail closed for private reachability identifiers until
+	// lesser-host exposes a body-facing instance-authenticated resolver.
+	for _, q := range []string{"agent-alice@lessersoul.ai", "+15550142"} {
+		callParams, _ := json.Marshal(map[string]any{
+			"name":      "identity_lookup",
+			"arguments": map[string]any{"query": q},
+		})
+		resp := invokeJSON(t, env, app, map[string][]string{
+			"authorization":  {authHeader},
+			"mcp-session-id": {sessionID},
+		}, &mcpruntime.Request{JSONRPC: "2.0", ID: 30, Method: "tools/call", Params: callParams})
+		if resp.Status != 200 {
+			t.Fatalf("identity_lookup(%q): status=%d body=%s", q, resp.Status, string(resp.Body))
+		}
+		errPayload := assertToolErrorPayload("identity_lookup("+q+")", resp.Body, "private_reachability_unavailable")
+		if errPayload["status"] != float64(501) {
+			t.Fatalf("identity_lookup(%q): expected status 501, got %+v", q, errPayload)
+		}
+	}
+	if len(searchQueries) != 0 || len(searchDomains) != 0 || len(emailResolveQueries) != 0 {
+		t.Fatalf("identity_lookup private reachability should fail before host/search calls: search=%+v domains=%+v email=%+v", searchQueries, searchDomains, emailResolveQueries)
 	}
 
 	searchQueries = nil
@@ -339,13 +389,6 @@ func TestLBM1_IdentityToolsAndChannelResources(t *testing.T) {
 			wantSearchDomain: "",
 		},
 		{
-			name:             "bare_handle_falls_back_after_email_miss",
-			query:            "steward@remote.example",
-			wantSearchQ:      "remote.example/steward",
-			wantSearchDomain: "",
-			wantEmailResolve: []string{"steward@remote.example"},
-		},
-		{
 			name:             "canonical_actor_url",
 			query:            "https://remote.example/users/steward",
 			wantSearchQ:      "remote.example/steward",
@@ -396,6 +439,30 @@ func TestLBM1_IdentityToolsAndChannelResources(t *testing.T) {
 		}
 		if !reflect.DeepEqual(emailResolveQueries, tc.wantEmailResolve) {
 			t.Fatalf("%s identity_lookup(%q): email resolves want %+v got %+v", tc.name, tc.query, tc.wantEmailResolve, emailResolveQueries)
+		}
+	}
+
+	// Bare user@domain input is ambiguous with private managed email reachability.
+	// It now fails closed instead of probing host email resolution anonymously; callers
+	// should use @user@domain for public ActivityPub handles.
+	{
+		searchQueries = nil
+		searchDomains = nil
+		emailResolveQueries = nil
+		callParams, _ := json.Marshal(map[string]any{
+			"name":      "identity_lookup",
+			"arguments": map[string]any{"query": "steward@remote.example"},
+		})
+		resp := invokeJSON(t, env, app, map[string][]string{
+			"authorization":  {authHeader},
+			"mcp-session-id": {sessionID},
+		}, &mcpruntime.Request{JSONRPC: "2.0", ID: 321, Method: "tools/call", Params: callParams})
+		if resp.Status != 200 {
+			t.Fatalf("identity_lookup(bare user@domain): status=%d body=%s", resp.Status, string(resp.Body))
+		}
+		_ = assertToolErrorPayload("identity_lookup(bare user@domain)", resp.Body, "private_reachability_unavailable")
+		if len(searchQueries) != 0 || len(searchDomains) != 0 || len(emailResolveQueries) != 0 {
+			t.Fatalf("identity_lookup bare user@domain should fail before host/search calls: search=%+v domains=%+v email=%+v", searchQueries, searchDomains, emailResolveQueries)
 		}
 	}
 
@@ -499,13 +566,21 @@ func TestLBM1_IdentityToolsAndChannelResources(t *testing.T) {
 		}
 	}
 
-	// identity_verify should resolve the identity and verify a concrete inbound message.
-	{
+	// identity_verify should fail closed for private email/phone reachability until
+	// lesser-host exposes a body-facing instance-authenticated resolver.
+	for _, tc := range []struct {
+		channel    string
+		identifier string
+	}{
+		{channel: "email", identifier: "agent-alice@lessersoul.ai"},
+		{channel: "phone", identifier: "+15550142"},
+	} {
+		channelResolveQueries = nil
 		callParams, _ := json.Marshal(map[string]any{
 			"name": "identity_verify",
 			"arguments": map[string]any{
-				"channel":    "email",
-				"identifier": "agent-alice@lessersoul.ai",
+				"channel":    tc.channel,
+				"identifier": tc.identifier,
 				"messageId":  "comm-msg-001",
 			},
 		})
@@ -514,36 +589,23 @@ func TestLBM1_IdentityToolsAndChannelResources(t *testing.T) {
 			"mcp-session-id": {sessionID},
 		}, &mcpruntime.Request{JSONRPC: "2.0", ID: 6, Method: "tools/call", Params: callParams})
 		if resp.Status != 200 {
-			t.Fatalf("identity_verify email: status=%d body=%s", resp.Status, string(resp.Body))
+			t.Fatalf("identity_verify %s: status=%d body=%s", tc.channel, resp.Status, string(resp.Body))
 		}
-
-		var rpc mcpruntime.Response
-		_ = json.Unmarshal(resp.Body, &rpc)
-		if rpc.Error != nil {
-			t.Fatalf("identity_verify email rpc error: %+v", rpc.Error)
-		}
-		var out mcpruntime.ToolResult
-		{
-			b, _ := json.Marshal(rpc.Result)
-			_ = json.Unmarshal(b, &out)
-		}
-		data, _ := out.StructuredContent["data"].(map[string]any)
-		if data["verified"] != true {
-			t.Fatalf("expected verified identity match, got %+v", data)
-		}
-		if data["matchedBy"] != "sender.agentId" {
-			t.Fatalf("expected sender provenance match, got %+v", data)
+		_ = assertToolErrorPayload("identity_verify "+tc.channel, resp.Body, "private_reachability_unavailable")
+		if len(channelResolveQueries) != 0 {
+			t.Fatalf("identity_verify %s should not fetch private /channels, got %+v", tc.channel, channelResolveQueries)
 		}
 	}
 
 	// identity_verify must not trust spoofable sender display/name/address fields
 	// without authoritative soul agent provenance on the message.
 	{
+		channelResolveQueries = nil
 		callParams, _ := json.Marshal(map[string]any{
 			"name": "identity_verify",
 			"arguments": map[string]any{
-				"channel":    "email",
-				"identifier": "agent-alice@lessersoul.ai",
+				"channel":    "ens",
+				"identifier": "agent-alice.lessersoul.eth",
 				"messageId":  "comm-msg-spoof",
 			},
 		})
@@ -572,10 +634,14 @@ func TestLBM1_IdentityToolsAndChannelResources(t *testing.T) {
 		if data["reason"] != "message_lacks_authoritative_sender_provenance" {
 			t.Fatalf("expected missing provenance reason, got %+v", data)
 		}
+		if len(channelResolveQueries) != 0 {
+			t.Fatalf("identity_verify spoofed sender should not fetch private /channels, got %+v", channelResolveQueries)
+		}
 	}
 
 	// identity_verify should also work when resolving the sender by ENS and using the same message provenance.
 	{
+		channelResolveQueries = nil
 		callParams, _ := json.Marshal(map[string]any{
 			"name": "identity_verify",
 			"arguments": map[string]any{
@@ -605,6 +671,12 @@ func TestLBM1_IdentityToolsAndChannelResources(t *testing.T) {
 		data, _ := out.StructuredContent["data"].(map[string]any)
 		if data["verified"] != true {
 			t.Fatalf("expected ENS verification to succeed, got %+v", data)
+		}
+		if data["matchedBy"] != "sender.agentId" {
+			t.Fatalf("expected sender provenance match, got %+v", data)
+		}
+		if len(channelResolveQueries) != 0 {
+			t.Fatalf("identity_verify ENS should not fetch private /channels, got %+v", channelResolveQueries)
 		}
 	}
 }

--- a/internal/mcpserver/comm_prompts.go
+++ b/internal/mcpserver/comm_prompts.go
@@ -9,7 +9,7 @@ import (
 	mcpruntime "github.com/theory-cloud/apptheory/runtime/mcp"
 )
 
-const identityLookupPromptQueryForms = "managed email, ENS name, full agentId, current-instance local ID, remote ActivityPub handle such as @steward@remote.example, or canonical actor URL such as https://remote.example/users/steward"
+const identityLookupPromptQueryForms = "ENS name, full agentId, current-instance local ID, explicit remote ActivityPub handle such as @steward@remote.example, or canonical actor URL such as https://remote.example/users/steward; private email/phone reachability lookup currently fails closed until lesser-host exposes a body-facing resolver"
 
 func promptComposeEmail(_ context.Context, args json.RawMessage) (*mcpruntime.PromptResult, error) {
 	var in struct {

--- a/internal/mcpserver/comm_tools.go
+++ b/internal/mcpserver/comm_tools.go
@@ -302,7 +302,7 @@ func identityWhoamiDef() mcpruntime.ToolDef {
 func identityLookupDef() mcpruntime.ToolDef {
 	return mcpruntime.ToolDef{
 		Name:        "identity_lookup",
-		Description: "Look up a soul identity by full agentId, managed email, ENS name, a current-instance local ID such as medic, a remote ActivityPub handle such as @steward@remote.example, or a canonical actor URL such as https://remote.example/users/steward.",
+		Description: "Look up a public soul identity by full agentId, ENS name, a current-instance local ID such as medic, an explicit remote ActivityPub handle such as @steward@remote.example, or a canonical actor URL such as https://remote.example/users/steward. Private email/phone reachability lookup fails closed until lesser-host exposes a body-facing resolver.",
 		InputSchema: json.RawMessage(`{
 			"type":"object",
 			"properties":{
@@ -316,7 +316,7 @@ func identityLookupDef() mcpruntime.ToolDef {
 func identityVerifyDef() mcpruntime.ToolDef {
 	return mcpruntime.ToolDef{
 		Name:        "identity_verify",
-		Description: "Verify that a communication came from a specific soul identity.",
+		Description: "Verify that a communication came from a specific soul identity. ENS verification uses public resolution plus authoritative message provenance; private email/phone verification fails closed until lesser-host exposes a body-facing resolver.",
 		InputSchema: json.RawMessage(`{
 			"type":"object",
 			"properties":{

--- a/internal/mcpserver/identity_tools.go
+++ b/internal/mcpserver/identity_tools.go
@@ -741,7 +741,12 @@ func resolveAgentIDByIdentifier(ctx context.Context, client *soulapi.Client, q s
 	var path string
 	switch {
 	case looksLikeEmail(q):
-		path = "/api/v1/soul/resolve/email/" + url.PathEscape(q)
+		if _, ok := emailLikeLookupDomain(q); !ok {
+			return "", unsupportedRemoteActorHandleError(q)
+		}
+		return "", privateReachabilityUnavailableError("email", "identity_lookup")
+	case looksLikePhoneIdentifier(q):
+		return "", privateReachabilityUnavailableError("phone", "identity_lookup")
 	case looksLikeENSName(q):
 		path = "/api/v1/soul/resolve/ens/" + url.PathEscape(q)
 	default:
@@ -758,6 +763,39 @@ func resolveAgentIDByIdentifier(ctx context.Context, client *soulapi.Client, q s
 	return normalizeSoulAgentID(stringFromMap(agent, "agent_id")), nil
 }
 
+func privateReachabilityUnavailableError(channel string, toolName string) *toolUserError {
+	channel = strings.ToLower(strings.TrimSpace(channel))
+	if channel == "" {
+		channel = "reachability"
+	}
+	toolName = strings.TrimSpace(toolName)
+
+	details := map[string]any{
+		"source":           "lesser_host_reachability",
+		"channel":          channel,
+		"requiredContract": "body_facing_instance_key_resolver",
+	}
+	if toolName != "" {
+		details["tool"] = toolName
+	}
+	if channel == "email" {
+		details["publicAlternatives"] = []string{
+			"ENS name",
+			"full agentId",
+			"current-instance local ID",
+			"explicit ActivityPub handle in @user@domain form",
+			"canonical actor URL",
+		}
+	}
+
+	return &toolUserError{
+		Code:    "private_reachability_unavailable",
+		Message: fmt.Sprintf("private %s reachability resolution requires a body-facing lesser-host resolver; request fails closed until that instance-authenticated contract is available", channel),
+		Status:  501,
+		Details: details,
+	}
+}
+
 func looksLikeEmail(q string) bool {
 	q = strings.TrimSpace(q)
 	if q == "" || strings.Contains(q, " ") {
@@ -765,6 +803,18 @@ func looksLikeEmail(q string) bool {
 	}
 	parts := strings.Split(q, "@")
 	return len(parts) == 2 && strings.TrimSpace(parts[0]) != "" && strings.TrimSpace(parts[1]) != ""
+}
+
+func emailLikeLookupDomain(q string) (string, bool) {
+	parts := strings.SplitN(strings.TrimSpace(q), "@", 2)
+	if len(parts) != 2 {
+		return "", false
+	}
+	return normalizeLookupDomain(parts[1])
+}
+
+func looksLikePhoneIdentifier(q string) bool {
+	return normalizeVerificationPhone(q) != ""
 }
 
 func looksLikeENSName(q string) bool {

--- a/internal/mcpserver/identity_verify_tools.go
+++ b/internal/mcpserver/identity_verify_tools.go
@@ -129,15 +129,11 @@ func resolveIdentityForVerification(ctx context.Context, client *soulapi.Client,
 		return nil, nil, errors.New("soul api client is nil")
 	}
 
-	resolvePath := "/api/v1/soul/resolve/email/" + url.PathEscape(identifier)
-	switch channel {
-	case "ens":
-		resolvePath = "/api/v1/soul/resolve/ens/" + url.PathEscape(identifier)
-	case "phone":
-		resolvePath = "/api/v1/soul/resolve/phone/" + url.PathEscape(identifier)
+	if channel == "email" || channel == "phone" {
+		return nil, nil, privateReachabilityUnavailableError(channel, "identity_verify")
 	}
 
-	resolvedAny, err := client.DoJSON(ctx, "GET", resolvePath, nil, "", nil)
+	resolvedAny, err := client.DoJSON(ctx, "GET", "/api/v1/soul/resolve/ens/"+url.PathEscape(identifier), nil, "", nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -152,15 +148,7 @@ func resolveIdentityForVerification(ctx context.Context, client *soulapi.Client,
 		return nil, nil, errors.New("unexpected resolve response")
 	}
 
-	channelsAny, err := client.DoJSON(ctx, "GET", "/api/v1/soul/agents/"+url.PathEscape(agentID)+"/channels", nil, "", nil)
-	if err != nil {
-		return nil, nil, err
-	}
-	channelsPayload, _ := channelsAny.(map[string]any)
-	if channelsPayload == nil {
-		channelsPayload = map[string]any{}
-	}
-	return agent, channelsPayload, nil
+	return agent, map[string]any{}, nil
 }
 
 func summarizeResolvedAgent(agent map[string]any) map[string]any {

--- a/internal/mcpserver/resources_prompts.go
+++ b/internal/mcpserver/resources_prompts.go
@@ -149,7 +149,7 @@ func registerPrompts(srv *Server) error {
 				Title:       "Respect preferences",
 				Description: "Choose how to contact a target agent based on their declared contact preferences.",
 				Arguments: []mcpruntime.PromptArgument{
-					{Name: "query", Description: "ENS name, agentId, or email address.", Required: true},
+					{Name: "query", Description: "ENS name, agentId, current-instance local ID, explicit @user@domain ActivityPub handle, or canonical actor URL. Private email/phone lookup currently fails closed.", Required: true},
 				},
 			},
 			Handler: promptRespectPreferences,


### PR DESCRIPTION
## Milestone
private-reachability-fail-closed — adapt lesser-body identity lookup/verify after lesser-host M10 reachability hardening.

## Classification
bug-fix / tool-surface semantic refinement / MCP-contract semantic refinement / host-delegation coordination

## Surfaces affected
- `identity_lookup` behavior for private email/phone reachability identifiers
- `identity_verify` behavior for email/phone/ENS channels
- MCP tool descriptions and prompt guidance
- `docs/mcp.md` and `docs/troubleshooting.md`

## Specialist walks referenced
- Tool surface: `identity_lookup` and `identity_verify` behavior changed; scope remains `read`, profile availability unchanged, no new dynamic registration.
- MCP contract: JSON-RPC tool error semantics refined. New fail-closed tool error code: `private_reachability_unavailable` for private reachability identifiers.
- Lesser integration: no Lesser API contract change.
- Host delegation: preserves lesser-host privacy hardening; does not ask Host to make reverse lookup public. Host handoff sent for future body-facing instance-key resolver.
- Framework: no AppTheory/TableTheory changes.

## Consumer impact
- MCP clients receive an explicit fail-closed tool error instead of an upstream Host `401`/OAuth reauth hint for private email/phone reachability.
- Public identity lookup forms remain available: full agent ID, ENS, current-instance local ID, explicit `@user@domain`, canonical actor URL.
- Bare `user@domain` now fails closed because it is ambiguous with private managed-email reachability. Use explicit `@user@domain` for ActivityPub handles.
- `identity_verify(ens)` no longer fetches private `/agents/{id}/channels`; it uses public ENS resolution plus authoritative sender provenance.

## Tasks
- [x] Stop anonymous lesser-host private reachability calls from identity lookup/verify.
- [x] Keep ENS verification working without private channel fetches.
- [x] Add regression coverage for fail-closed private reachability and no `/channels` fetch on ENS verification.
- [x] Update MCP discovery text, prompts, and operator docs.

## Validation
- [x] `git diff --check`
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `scripts/build.sh`
- [x] `(cd cdk && go test ./...)`
- [x] Targeted: `go test ./internal/mcpapp -run TestLBM1_IdentityToolsAndChannelResources -count=1 -v`

## Stage rollout plan (handoff to deploy-body)
- [ ] Merged to main
- [ ] Deployed to lab / dev
- [ ] Lab soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
- Host contract-confirmation email sent from body to Host: `delivery-78a237f01c1b043c`.
- Future Host work requested: body-facing, instance-key-authenticated, domain-scoped resolver for private email/phone reachability, returning only bounded contactability fields and 404 for not-found/cross-domain hidden denial.

## Advisor-brief authorization
Not advisor-dispatched. Aron directly authorized proceeding after Ops report retrieval/investigation.
