### PR TITLE
fix(mcp): lean mailbox and memory surfaces

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -324,6 +324,10 @@ Notes:
 - Mailbox and memory tools use dual MCP result surfaces: `content[0].text` contains the JSON payload for text-reading
   clients, and `structuredContent` contains the same typed fields directly (for example `messages` or `events` at the
   top level) rather than nesting them under a `data` wrapper.
+- Mailbox and memory tools publish MCP annotations in `tools/list`: read-only hints for mailbox reads/search/content
+  fetches and `memory_query`, destructive hints for send/reply/delete tools, and idempotent hints for mailbox read-state
+  mutation tools. `memory_append` remains an additive write and is only idempotent when callers provide `event_id`, so
+  it is not advertised as unconditionally idempotent.
 - Mailbox read/search tools pass host-side filters through instead of client-side filtering: `channelType`,
   `direction`, `threadId`, bounded `query`, `unreadOnly`/`read`, `includeArchived`/`archived`, and
   `includeDeleted`/`deleted`.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -321,6 +321,9 @@ Notes:
   Verbose upstream mailbox payloads are omitted by default. `email_read`, `email_get`, `email_search`, `sms_read`,
   and `voicemail_read` accept optional `include_raw=true` for audit/debug use cases, which adds the upstream payload
   under `_raw` on each returned message.
+- Mailbox and memory tools use dual MCP result surfaces: `content[0].text` contains the JSON payload for text-reading
+  clients, and `structuredContent` contains the same typed fields directly (for example `messages` or `events` at the
+  top level) rather than nesting them under a `data` wrapper.
 - Mailbox read/search tools pass host-side filters through instead of client-side filtering: `channelType`,
   `direction`, `threadId`, bounded `query`, `unreadOnly`/`read`, `includeArchived`/`archived`, and
   `includeDeleted`/`deleted`.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -318,6 +318,9 @@ Notes:
 - Mailbox list/get/search results return redacted previews in `body`/`preview`; use `email_get_content` for full
   content when `content.available=true`. The `messageId` field in mailbox outputs is the opaque host `messageRef`
   accepted by get/content/state/reply calls; legacy host `messageId` appears as `hostMessageId` when present.
+  Verbose upstream mailbox payloads are omitted by default. `email_read`, `email_get`, `email_search`, `sms_read`,
+  and `voicemail_read` accept optional `include_raw=true` for audit/debug use cases, which adds the upstream payload
+  under `_raw` on each returned message.
 - Mailbox read/search tools pass host-side filters through instead of client-side filtering: `channelType`,
   `direction`, `threadId`, bounded `query`, `unreadOnly`/`read`, `includeArchived`/`archived`, and
   `includeDeleted`/`deleted`.

--- a/internal/mcpapp/comm_contract_test.go
+++ b/internal/mcpapp/comm_contract_test.go
@@ -165,6 +165,7 @@ func TestLBM0_CommunicationToolSchemasMatchSpec(t *testing.T) {
 		}
 		expectPropType(t, s, "folder", "string")
 		expectPropType(t, s, "unreadOnly", "boolean")
+		expectPropType(t, s, "include_raw", "boolean")
 		expectPropType(t, s, "read", "boolean")
 		expectPropType(t, s, "includeArchived", "boolean")
 		expectPropType(t, s, "archived", "boolean")
@@ -189,6 +190,9 @@ func TestLBM0_CommunicationToolSchemasMatchSpec(t *testing.T) {
 				t.Fatalf("%s required: want [messageId], got %#v", name, s.Required)
 			}
 			expectPropType(t, s, "messageId", "string")
+			if name == "email_get" {
+				expectPropType(t, s, "include_raw", "boolean")
+			}
 		}
 	}
 
@@ -202,6 +206,7 @@ func TestLBM0_CommunicationToolSchemasMatchSpec(t *testing.T) {
 		}
 		expectPropType(t, s, "query", "string")
 		expectPropType(t, s, "folder", "string")
+		expectPropType(t, s, "include_raw", "boolean")
 		expectPropType(t, s, "read", "boolean")
 		expectPropType(t, s, "unreadOnly", "boolean")
 		expectPropType(t, s, "includeArchived", "boolean")
@@ -272,6 +277,7 @@ func TestLBM0_CommunicationToolSchemasMatchSpec(t *testing.T) {
 				t.Fatalf("%s schema type: want object got %q", name, s.Type)
 			}
 			expectPropType(t, s, "unreadOnly", "boolean")
+			expectPropType(t, s, "include_raw", "boolean")
 			expectPropType(t, s, "read", "boolean")
 			expectPropType(t, s, "includeArchived", "boolean")
 			expectPropType(t, s, "archived", "boolean")

--- a/internal/mcpapp/inbox_tools_test.go
+++ b/internal/mcpapp/inbox_tools_test.go
@@ -75,6 +75,8 @@ func TestLBM3_InboxToolsUseHostMailbox(t *testing.T) {
 				}`))
 			case "sms":
 				_, _ = w.Write([]byte(`{"messages":[{"messageRef":"comm-delivery-sms","deliveryId":"comm-delivery-sms","messageId":"comm-msg-sms","threadId":"comm-thread-sms","direction":"inbound","channelType":"sms","status":"delivered","from":{"number":"+15550142"},"preview":"sms preview","content":{"available":true},"state":{"read":false,"archived":false,"deleted":false},"createdAt":"2026-03-04T12:05:00Z"}],"count":1,"hasMore":false}`))
+			case "voice":
+				_, _ = w.Write([]byte(`{"messages":[{"messageRef":"comm-delivery-voice","deliveryId":"comm-delivery-voice","messageId":"comm-msg-voice","threadId":"comm-thread-voice","direction":"inbound","channelType":"voice","status":"delivered","from":{"number":"+15550143"},"preview":"voice preview","content":{"available":true},"state":{"read":false,"archived":false,"deleted":false},"createdAt":"2026-03-04T12:10:00Z"}],"count":1,"hasMore":false}`))
 			default:
 				_, _ = w.Write([]byte(`{"messages":[],"count":0,"hasMore":false}`))
 			}
@@ -151,14 +153,43 @@ func TestLBM3_InboxToolsUseHostMailbox(t *testing.T) {
 	if msg["messageId"] != "comm-delivery-email" || msg["hostMessageId"] != "comm-msg-email" || msg["body"] != "Hello preview" || msg["bodyIsPreview"] != true {
 		t.Fatalf("unexpected email message: %+v", msg)
 	}
+	if _, ok := msg["raw"]; ok {
+		t.Fatalf("raw field should be absent by default: %+v", msg)
+	}
+	if _, ok := msg["_raw"]; ok {
+		t.Fatalf("_raw field should be absent by default: %+v", msg)
+	}
 	if emailRead["nextCursor"] != "cursor-2" || emailRead["nextSince"] != "cursor-2" {
 		t.Fatalf("expected cursor aliases, got %+v", emailRead)
+	}
+
+	emailReadRaw := callTool(20, "email_read", map[string]any{"folder": "inbox", "limit": 10, "include_raw": true})
+	rawMessages, _ := emailReadRaw["messages"].([]any)
+	rawMsg, _ := rawMessages[0].(map[string]any)
+	if _, ok := rawMsg["_raw"].(map[string]any); !ok {
+		t.Fatalf("expected include_raw=true to expose _raw, got %+v", rawMsg)
+	}
+	if _, ok := rawMsg["raw"]; ok {
+		t.Fatalf("include_raw=true should use _raw, not raw: %+v", rawMsg)
 	}
 
 	smsRead := callTool(3, "sms_read", map[string]any{"limit": 10})
 	smsMessages, _ := smsRead["messages"].([]any)
 	if len(smsMessages) != 1 {
 		t.Fatalf("expected 1 sms message, got %+v", smsMessages)
+	}
+	smsReadRaw := callTool(21, "sms_read", map[string]any{"limit": 10, "include_raw": true})
+	smsRawMessages, _ := smsReadRaw["messages"].([]any)
+	smsRawMsg, _ := smsRawMessages[0].(map[string]any)
+	if _, ok := smsRawMsg["_raw"].(map[string]any); !ok {
+		t.Fatalf("expected sms include_raw=true to expose _raw, got %+v", smsRawMsg)
+	}
+
+	voicemailReadRaw := callTool(22, "voicemail_read", map[string]any{"limit": 10, "include_raw": true})
+	voicemailRawMessages, _ := voicemailReadRaw["messages"].([]any)
+	voicemailRawMsg, _ := voicemailRawMessages[0].(map[string]any)
+	if _, ok := voicemailRawMsg["_raw"].(map[string]any); !ok {
+		t.Fatalf("expected voicemail include_raw=true to expose _raw, got %+v", voicemailRawMsg)
 	}
 
 	emailSearch := callTool(4, "email_search", map[string]any{"query": "alice", "limit": 5})
@@ -169,6 +200,11 @@ func TestLBM3_InboxToolsUseHostMailbox(t *testing.T) {
 	emailGet := callTool(5, "email_get", map[string]any{"messageId": "comm-delivery-email"})
 	if _, ok := emailGet["message"].(map[string]any); !ok {
 		t.Fatalf("expected email_get message, got %+v", emailGet)
+	}
+	emailGetRaw := callTool(23, "email_get", map[string]any{"messageId": "comm-delivery-email", "include_raw": true})
+	emailGetRawMessage, _ := emailGetRaw["message"].(map[string]any)
+	if _, ok := emailGetRawMessage["_raw"].(map[string]any); !ok {
+		t.Fatalf("expected email_get include_raw=true to expose _raw, got %+v", emailGetRawMessage)
 	}
 
 	content := callTool(6, "email_get_content", map[string]any{"messageId": "comm-delivery-email"})

--- a/internal/mcpapp/inbox_tools_test.go
+++ b/internal/mcpapp/inbox_tools_test.go
@@ -140,8 +140,10 @@ func TestLBM3_InboxToolsUseHostMailbox(t *testing.T) {
 		var out mcpruntime.ToolResult
 		b, _ := json.Marshal(rpc.Result)
 		_ = json.Unmarshal(b, &out)
-		data, _ := out.StructuredContent["data"].(map[string]any)
-		return data
+		if _, ok := out.StructuredContent["data"]; ok {
+			t.Fatalf("%s should expose flat structuredContent, got %+v", name, out.StructuredContent)
+		}
+		return out.StructuredContent
 	}
 
 	emailRead := callTool(2, "email_read", map[string]any{"folder": "inbox", "limit": 10, "unreadOnly": true})

--- a/internal/mcpapp/memory_tools_test.go
+++ b/internal/mcpapp/memory_tools_test.go
@@ -94,6 +94,12 @@ func TestM6_MemoryAppendAndQuery(t *testing.T) {
 		if len(tool.Content) != 1 || tool.Content[0].Type != "text" || tool.Content[0].Text == "" {
 			t.Fatalf("unexpected tool result: %+v", tool)
 		}
+		if _, ok := tool.StructuredContent["data"]; ok {
+			t.Fatalf("memory_append should expose flat structuredContent, got %+v", tool.StructuredContent)
+		}
+		if _, ok := tool.StructuredContent["event"].(map[string]any); !ok {
+			t.Fatalf("memory_append structuredContent should include event directly, got %+v", tool.StructuredContent)
+		}
 
 		var out struct {
 			Created bool `json:"created"`
@@ -159,6 +165,13 @@ func TestM6_MemoryAppendAndQuery(t *testing.T) {
 		{
 			b, _ := json.Marshal(rpc.Result)
 			_ = json.Unmarshal(b, &tool)
+		}
+		if _, ok := tool.StructuredContent["data"]; ok {
+			t.Fatalf("memory_query should expose flat structuredContent, got %+v", tool.StructuredContent)
+		}
+		structuredEvents, _ := tool.StructuredContent["events"].([]any)
+		if len(structuredEvents) != 2 {
+			t.Fatalf("memory_query structuredContent should include events directly, got %+v", tool.StructuredContent)
 		}
 
 		var out struct {

--- a/internal/mcpapp/social_tools_test.go
+++ b/internal/mcpapp/social_tools_test.go
@@ -986,6 +986,9 @@ func TestM5_NotificationsReadSeparatesTimestampSinceAndCursor(t *testing.T) {
 			b, _ := json.Marshal(rpc.Result)
 			_ = json.Unmarshal(b, &out)
 		}
+		if name == "memory_append" || name == "memory_query" {
+			return out.StructuredContent
+		}
 		data, _ := out.StructuredContent["data"].(map[string]any)
 		return data
 	}
@@ -1116,6 +1119,9 @@ func TestM5_NotificationDismissClearsCursorOnDismissAll(t *testing.T) {
 		{
 			b, _ := json.Marshal(rpc.Result)
 			_ = json.Unmarshal(b, &out)
+		}
+		if name == "memory_append" || name == "memory_query" {
+			return out.StructuredContent
 		}
 		data, _ := out.StructuredContent["data"].(map[string]any)
 		return data
@@ -1249,8 +1255,7 @@ func TestM5_NotificationDismissSingleKeepsCursorAndHandlesNotFound(t *testing.T)
 		if rpc.Error != nil {
 			t.Fatalf("memory_query error: %+v", rpc.Error)
 		}
-		data, _ := out.StructuredContent["data"].(map[string]any)
-		events, _ := data["events"].([]any)
+		events, _ := out.StructuredContent["events"].([]any)
 		if len(events) == 0 {
 			return ""
 		}

--- a/internal/mcpapp/tool_annotations_test.go
+++ b/internal/mcpapp/tool_annotations_test.go
@@ -1,0 +1,113 @@
+package mcpapp_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	mcpruntime "github.com/theory-cloud/apptheory/runtime/mcp"
+	"github.com/theory-cloud/apptheory/testkit"
+
+	"github.com/equaltoai/lesser-body/internal/auth"
+	"github.com/equaltoai/lesser-body/internal/mcpapp"
+)
+
+func TestMCPToolAnnotationsForMailboxAndMemory(t *testing.T) {
+	t.Setenv("MCP_SESSION_TABLE", "")
+	t.Setenv("JWT_SECRET", "test")
+	installSoulBindingLookup(t, "agent1", "0x1111111111111111111111111111111111111111111111111111111111111111")
+	auth.ResetForTests()
+
+	app, err := mcpapp.New("test", "dev")
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+	env := testkit.New()
+	token := newTestToken(t, "test", "agent1", []string{"read", "write"})
+
+	initResp := invokeJSON(t, env, app, map[string][]string{
+		"authorization": {"Bearer " + token},
+	}, &mcpruntime.Request{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "initialize",
+	})
+	if initResp.Status != 200 {
+		t.Fatalf("initialize: status=%d body=%s", initResp.Status, string(initResp.Body))
+	}
+	sessionID := initResp.Headers["mcp-session-id"][0]
+
+	listResp := invokeJSON(t, env, app, map[string][]string{
+		"authorization":  {"Bearer " + token},
+		"mcp-session-id": {sessionID},
+	}, &mcpruntime.Request{
+		JSONRPC: "2.0",
+		ID:      2,
+		Method:  "tools/list",
+	})
+	if listResp.Status != 200 {
+		t.Fatalf("tools/list: status=%d body=%s", listResp.Status, string(listResp.Body))
+	}
+
+	var rpc mcpruntime.Response
+	if err := json.Unmarshal(listResp.Body, &rpc); err != nil {
+		t.Fatalf("unmarshal tools/list: %v", err)
+	}
+	if rpc.Error != nil {
+		t.Fatalf("tools/list error: %+v", rpc.Error)
+	}
+
+	var result struct {
+		Tools []mcpruntime.ToolDef `json:"tools"`
+	}
+	{
+		b, _ := json.Marshal(rpc.Result)
+		if err := json.Unmarshal(b, &result); err != nil {
+			t.Fatalf("unmarshal tools/list result: %v", err)
+		}
+	}
+
+	toolsByName := map[string]mcpruntime.ToolDef{}
+	for _, tool := range result.Tools {
+		toolsByName[tool.Name] = tool
+	}
+
+	assertHint := func(name string, readOnly *bool, destructive *bool, idempotent *bool) {
+		t.Helper()
+		tool, ok := toolsByName[name]
+		if !ok {
+			t.Fatalf("expected tool %q in tools/list", name)
+		}
+		if tool.Annotations == nil {
+			t.Fatalf("expected annotations for %s", name)
+		}
+		if readOnly != nil {
+			if tool.Annotations.ReadOnlyHint == nil || *tool.Annotations.ReadOnlyHint != *readOnly {
+				t.Fatalf("%s readOnlyHint: got %+v want %v", name, tool.Annotations.ReadOnlyHint, *readOnly)
+			}
+		}
+		if destructive != nil {
+			if tool.Annotations.DestructiveHint == nil || *tool.Annotations.DestructiveHint != *destructive {
+				t.Fatalf("%s destructiveHint: got %+v want %v", name, tool.Annotations.DestructiveHint, *destructive)
+			}
+		}
+		if idempotent != nil {
+			if tool.Annotations.IdempotentHint == nil || *tool.Annotations.IdempotentHint != *idempotent {
+				t.Fatalf("%s idempotentHint: got %+v want %v", name, tool.Annotations.IdempotentHint, *idempotent)
+			}
+		}
+	}
+
+	truth := true
+	falsehood := false
+
+	for _, name := range []string{"email_read", "email_get", "email_get_content", "email_search", "sms_read", "voicemail_read", "memory_query"} {
+		assertHint(name, &truth, nil, nil)
+	}
+	for _, name := range []string{"email_send", "email_reply", "email_delete", "sms_send"} {
+		assertHint(name, &falsehood, &truth, nil)
+	}
+	for _, name := range []string{"email_mark_read", "email_mark_unread"} {
+		assertHint(name, &falsehood, &falsehood, &truth)
+	}
+	assertHint("memory_append", &falsehood, &falsehood, &falsehood)
+}

--- a/internal/mcpserver/comm_tools.go
+++ b/internal/mcpserver/comm_tools.go
@@ -82,6 +82,7 @@ func emailReadDef() mcpruntime.ToolDef {
 			"properties":{
 				"folder":{"type":"string","enum":["inbox","sent"]},
 				"unreadOnly":{"type":"boolean"},
+				"include_raw":{"type":"boolean","description":"Include verbose upstream mailbox data under _raw. Defaults to false."},
 				"read":{"type":"boolean","description":"Exact read-state filter. Conflicts with unreadOnly=true when read=true."},
 				"includeArchived":{"type":"boolean"},
 				"archived":{"type":"boolean","description":"Exact archive-state filter."},
@@ -103,7 +104,8 @@ func emailGetDef() mcpruntime.ToolDef {
 		InputSchema: json.RawMessage(`{
 			"type":"object",
 			"properties":{
-				"messageId":{"type":"string","description":"Opaque host messageRef returned by email_read/email_search/email_send/email_reply."}
+				"messageId":{"type":"string","description":"Opaque host messageRef returned by email_read/email_search/email_send/email_reply."},
+				"include_raw":{"type":"boolean","description":"Include verbose upstream mailbox data under _raw. Defaults to false."}
 			},
 			"required":["messageId"]
 		}`),
@@ -133,6 +135,7 @@ func emailSearchDef() mcpruntime.ToolDef {
 			"properties":{
 				"query":{"type":"string"},
 				"folder":{"type":"string","enum":["inbox","sent"]},
+				"include_raw":{"type":"boolean","description":"Include verbose upstream mailbox data under _raw. Defaults to false."},
 				"includeArchived":{"type":"boolean"},
 				"archived":{"type":"boolean","description":"Exact archive-state filter."},
 				"includeDeleted":{"type":"boolean"},
@@ -238,6 +241,7 @@ func smsReadDef() mcpruntime.ToolDef {
 			"type":"object",
 			"properties":{
 				"unreadOnly":{"type":"boolean"},
+				"include_raw":{"type":"boolean","description":"Include verbose upstream mailbox data under _raw. Defaults to false."},
 				"read":{"type":"boolean","description":"Exact read-state filter. Conflicts with unreadOnly=true when read=true."},
 				"includeArchived":{"type":"boolean"},
 				"archived":{"type":"boolean","description":"Exact archive-state filter."},
@@ -278,6 +282,7 @@ func voicemailReadDef() mcpruntime.ToolDef {
 			"type":"object",
 			"properties":{
 				"unreadOnly":{"type":"boolean"},
+				"include_raw":{"type":"boolean","description":"Include verbose upstream mailbox data under _raw. Defaults to false."},
 				"read":{"type":"boolean","description":"Exact read-state filter. Conflicts with unreadOnly=true when read=true."},
 				"includeArchived":{"type":"boolean"},
 				"archived":{"type":"boolean","description":"Exact archive-state filter."},

--- a/internal/mcpserver/comm_tools.go
+++ b/internal/mcpserver/comm_tools.go
@@ -56,6 +56,7 @@ func emailSendDef() mcpruntime.ToolDef {
 	return mcpruntime.ToolDef{
 		Name:        "email_send",
 		Description: "Send an email from the agent's address via lesser-host (no provider credentials).",
+		Annotations: destructiveToolAnnotations(),
 		InputSchema: json.RawMessage(`{
 			"type":"object",
 			"properties":{
@@ -77,6 +78,7 @@ func emailReadDef() mcpruntime.ToolDef {
 	return mcpruntime.ToolDef{
 		Name:        "email_read",
 		Description: "List recent email metadata/previews from lesser-host's canonical mailbox.",
+		Annotations: readOnlyToolAnnotations(),
 		InputSchema: json.RawMessage(`{
 			"type":"object",
 			"properties":{
@@ -101,6 +103,7 @@ func emailGetDef() mcpruntime.ToolDef {
 	return mcpruntime.ToolDef{
 		Name:        "email_get",
 		Description: "Get canonical email metadata/state by opaque host message reference.",
+		Annotations: readOnlyToolAnnotations(),
 		InputSchema: json.RawMessage(`{
 			"type":"object",
 			"properties":{
@@ -116,6 +119,7 @@ func emailGetContentDef() mcpruntime.ToolDef {
 	return mcpruntime.ToolDef{
 		Name:        "email_get_content",
 		Description: "Fetch full email content explicitly from lesser-host's canonical mailbox.",
+		Annotations: readOnlyToolAnnotations(),
 		InputSchema: json.RawMessage(`{
 			"type":"object",
 			"properties":{
@@ -130,6 +134,7 @@ func emailSearchDef() mcpruntime.ToolDef {
 	return mcpruntime.ToolDef{
 		Name:        "email_search",
 		Description: "Run a bounded lesser-host metadata/preview search over the agent's email mailbox.",
+		Annotations: readOnlyToolAnnotations(),
 		InputSchema: json.RawMessage(`{
 			"type":"object",
 			"properties":{
@@ -155,6 +160,7 @@ func emailReplyDef() mcpruntime.ToolDef {
 	return mcpruntime.ToolDef{
 		Name:        "email_reply",
 		Description: "Reply to a specific email message.",
+		Annotations: destructiveToolAnnotations(),
 		InputSchema: json.RawMessage(`{
 			"type":"object",
 			"properties":{
@@ -177,6 +183,7 @@ func emailDeleteDef() mcpruntime.ToolDef {
 	return mcpruntime.ToolDef{
 		Name:        "email_delete",
 		Description: "Delete or archive an email message in lesser-host's canonical mailbox.",
+		Annotations: destructiveToolAnnotations(),
 		InputSchema: json.RawMessage(`{
 			"type":"object",
 			"properties":{
@@ -192,6 +199,7 @@ func emailMarkReadDef() mcpruntime.ToolDef {
 	return mcpruntime.ToolDef{
 		Name:        "email_mark_read",
 		Description: "Mark an email read in lesser-host's canonical mailbox.",
+		Annotations: idempotentMutationToolAnnotations(),
 		InputSchema: json.RawMessage(`{
 			"type":"object",
 			"properties":{
@@ -206,6 +214,7 @@ func emailMarkUnreadDef() mcpruntime.ToolDef {
 	return mcpruntime.ToolDef{
 		Name:        "email_mark_unread",
 		Description: "Mark an email unread in lesser-host's canonical mailbox.",
+		Annotations: idempotentMutationToolAnnotations(),
 		InputSchema: json.RawMessage(`{
 			"type":"object",
 			"properties":{
@@ -220,6 +229,7 @@ func smsSendDef() mcpruntime.ToolDef {
 	return mcpruntime.ToolDef{
 		Name:        "sms_send",
 		Description: "Send an SMS from the agent's number via lesser-host.",
+		Annotations: destructiveToolAnnotations(),
 		InputSchema: json.RawMessage(`{
 			"type":"object",
 			"properties":{
@@ -237,6 +247,7 @@ func smsReadDef() mcpruntime.ToolDef {
 	return mcpruntime.ToolDef{
 		Name:        "sms_read",
 		Description: "Read received SMS metadata/previews from lesser-host's canonical mailbox.",
+		Annotations: readOnlyToolAnnotations(),
 		InputSchema: json.RawMessage(`{
 			"type":"object",
 			"properties":{
@@ -278,6 +289,7 @@ func voicemailReadDef() mcpruntime.ToolDef {
 	return mcpruntime.ToolDef{
 		Name:        "voicemail_read",
 		Description: "Read voicemail metadata/previews from lesser-host's canonical mailbox.",
+		Annotations: readOnlyToolAnnotations(),
 		InputSchema: json.RawMessage(`{
 			"type":"object",
 			"properties":{

--- a/internal/mcpserver/email_tools.go
+++ b/internal/mcpserver/email_tools.go
@@ -85,7 +85,7 @@ func handleEmailSendWithProgress(ctx context.Context, args json.RawMessage, emit
 	if replyRef != "" {
 		normalized["inReplyTo"] = replyRef
 	}
-	return toolJSONResult(normalized)
+	return toolJSONResult(normalized, nil)
 }
 
 func handleEmailReply(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
@@ -168,7 +168,7 @@ func handleEmailReplyWithProgress(ctx context.Context, args json.RawMessage, emi
 		}
 		out["advisory"] = advisory
 	}
-	return toolJSONResult(out)
+	return toolJSONResult(out, nil)
 }
 
 func emailReplyRecipient(notification map[string]any) string {

--- a/internal/mcpserver/identity_tools.go
+++ b/internal/mcpserver/identity_tools.go
@@ -47,7 +47,7 @@ func handleIdentityWhoami(ctx context.Context, args json.RawMessage) (*mcpruntim
 		return identityToolResultFromError(err)
 	}
 
-	return toolJSONResult(payload)
+	return toolJSONResult(payload, nil)
 }
 
 func handleIdentityLookup(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
@@ -94,7 +94,7 @@ func handleIdentityLookup(ctx context.Context, args json.RawMessage) (*mcpruntim
 		"query":   q,
 		"matches": matches,
 		"count":   len(matches),
-	})
+	}, nil)
 }
 
 func whoamiChannelsPayload(ctx context.Context) (map[string]any, error) {

--- a/internal/mcpserver/identity_verify_tools.go
+++ b/internal/mcpserver/identity_verify_tools.go
@@ -75,7 +75,7 @@ func handleIdentityVerify(ctx context.Context, args json.RawMessage) (*mcpruntim
 	}
 
 	if in.MessageID == "" {
-		return toolJSONResult(result)
+		return toolJSONResult(result, nil)
 	}
 
 	token, err := requireOAuthBearer(ctx)
@@ -94,7 +94,7 @@ func handleIdentityVerify(ctx context.Context, args json.RawMessage) (*mcpruntim
 		result["verified"] = false
 		result["messageFound"] = false
 		result["reason"] = "message_not_found"
-		return toolJSONResult(result)
+		return toolJSONResult(result, nil)
 	}
 
 	from := commFrom(notification)
@@ -113,7 +113,7 @@ func handleIdentityVerify(ctx context.Context, args json.RawMessage) (*mcpruntim
 	}
 	if match {
 		result["matchedBy"] = matchedBy
-		return toolJSONResult(result)
+		return toolJSONResult(result, nil)
 	}
 
 	if !senderHasAuthoritativeAgentID(from) {
@@ -121,7 +121,7 @@ func handleIdentityVerify(ctx context.Context, args json.RawMessage) (*mcpruntim
 	} else {
 		result["reason"] = "sender_does_not_match_resolved_identity"
 	}
-	return toolJSONResult(result)
+	return toolJSONResult(result, nil)
 }
 
 func resolveIdentityForVerification(ctx context.Context, client *soulapi.Client, channel string, identifier string) (map[string]any, map[string]any, error) {

--- a/internal/mcpserver/inbox_tools.go
+++ b/internal/mcpserver/inbox_tools.go
@@ -16,6 +16,7 @@ func handleEmailRead(ctx context.Context, args json.RawMessage) (*mcpruntime.Too
 	var in struct {
 		Folder          string `json:"folder,omitempty"`
 		UnreadOnly      bool   `json:"unreadOnly,omitempty"`
+		IncludeRaw      bool   `json:"include_raw,omitempty"`
 		IncludeArchived bool   `json:"includeArchived,omitempty"`
 		IncludeDeleted  bool   `json:"includeDeleted,omitempty"`
 		Limit           int    `json:"limit,omitempty"`
@@ -55,6 +56,7 @@ func handleEmailRead(ctx context.Context, args json.RawMessage) (*mcpruntime.Too
 		ChannelType:     "email",
 		Direction:       direction,
 		UnreadOnly:      in.UnreadOnly,
+		IncludeRaw:      in.IncludeRaw,
 		IncludeArchived: in.IncludeArchived,
 		IncludeDeleted:  in.IncludeDeleted,
 		Archived:        archived,
@@ -87,7 +89,8 @@ func handleEmailRead(ctx context.Context, args json.RawMessage) (*mcpruntime.Too
 
 func handleEmailGet(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
 	var in struct {
-		MessageID string `json:"messageId"`
+		MessageID  string `json:"messageId"`
+		IncludeRaw bool   `json:"include_raw,omitempty"`
 	}
 	if err := json.Unmarshal(args, &in); err != nil {
 		return nil, invalidParams("invalid args: " + err.Error())
@@ -96,7 +99,7 @@ func handleEmailGet(ctx context.Context, args json.RawMessage) (*mcpruntime.Tool
 	if err != nil {
 		return commMailboxToolResultFromError(err)
 	}
-	out, err := getHostMailboxMessage(ctx, deps, in.MessageID)
+	out, err := getHostMailboxMessage(ctx, deps, in.MessageID, in.IncludeRaw)
 	if err != nil {
 		return commMailboxToolResultFromError(err)
 	}
@@ -127,6 +130,7 @@ func handleEmailSearch(ctx context.Context, args json.RawMessage) (*mcpruntime.T
 		Query           string `json:"query"`
 		Folder          string `json:"folder,omitempty"`
 		UnreadOnly      bool   `json:"unreadOnly,omitempty"`
+		IncludeRaw      bool   `json:"include_raw,omitempty"`
 		IncludeArchived bool   `json:"includeArchived,omitempty"`
 		IncludeDeleted  bool   `json:"includeDeleted,omitempty"`
 		Limit           int    `json:"limit,omitempty"`
@@ -167,6 +171,7 @@ func handleEmailSearch(ctx context.Context, args json.RawMessage) (*mcpruntime.T
 		ChannelType:     "email",
 		Direction:       direction,
 		UnreadOnly:      in.UnreadOnly,
+		IncludeRaw:      in.IncludeRaw,
 		IncludeArchived: in.IncludeArchived,
 		IncludeDeleted:  in.IncludeDeleted,
 		Archived:        archived,
@@ -257,6 +262,7 @@ func handleEmailReadState(ctx context.Context, args json.RawMessage, action stri
 func handleSmsRead(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
 	var in struct {
 		UnreadOnly      bool   `json:"unreadOnly,omitempty"`
+		IncludeRaw      bool   `json:"include_raw,omitempty"`
 		IncludeArchived bool   `json:"includeArchived,omitempty"`
 		IncludeDeleted  bool   `json:"includeDeleted,omitempty"`
 		Limit           int    `json:"limit,omitempty"`
@@ -282,6 +288,7 @@ func handleSmsRead(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolR
 		ChannelType:     "sms",
 		Direction:       "inbound",
 		UnreadOnly:      in.UnreadOnly,
+		IncludeRaw:      in.IncludeRaw,
 		IncludeArchived: in.IncludeArchived,
 		IncludeDeleted:  in.IncludeDeleted,
 		Archived:        archived,
@@ -314,6 +321,7 @@ func handleSmsRead(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolR
 func handleVoicemailRead(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
 	var in struct {
 		UnreadOnly      bool   `json:"unreadOnly,omitempty"`
+		IncludeRaw      bool   `json:"include_raw,omitempty"`
 		IncludeArchived bool   `json:"includeArchived,omitempty"`
 		IncludeDeleted  bool   `json:"includeDeleted,omitempty"`
 		Limit           int    `json:"limit,omitempty"`
@@ -338,6 +346,7 @@ func handleVoicemailRead(ctx context.Context, args json.RawMessage) (*mcpruntime
 		ChannelType:     "voice",
 		Direction:       "inbound",
 		UnreadOnly:      in.UnreadOnly,
+		IncludeRaw:      in.IncludeRaw,
 		IncludeArchived: in.IncludeArchived,
 		IncludeDeleted:  in.IncludeDeleted,
 		Archived:        archived,

--- a/internal/mcpserver/inbox_tools.go
+++ b/internal/mcpserver/inbox_tools.go
@@ -84,7 +84,7 @@ func handleEmailRead(ctx context.Context, args json.RawMessage) (*mcpruntime.Too
 	}
 	out["cursor"] = strings.TrimSpace(in.Cursor)
 	out["since"] = strings.TrimSpace(in.Since)
-	return toolJSONResult(out)
+	return toolJSONResult(out, out)
 }
 
 func handleEmailGet(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
@@ -104,7 +104,7 @@ func handleEmailGet(ctx context.Context, args json.RawMessage) (*mcpruntime.Tool
 		return commMailboxToolResultFromError(err)
 	}
 	out["source"] = "lesser-host-mailbox"
-	return toolJSONResult(out)
+	return toolJSONResult(out, out)
 }
 
 func handleEmailGetContent(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
@@ -122,7 +122,7 @@ func handleEmailGetContent(ctx context.Context, args json.RawMessage) (*mcprunti
 	if err != nil {
 		return commMailboxToolResultFromError(err)
 	}
-	return toolJSONResult(out)
+	return toolJSONResult(out, out)
 }
 
 func handleEmailSearch(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
@@ -200,7 +200,7 @@ func handleEmailSearch(ctx context.Context, args json.RawMessage) (*mcpruntime.T
 		out["deleted"] = *deleted
 	}
 	out["strategy"] = "host bounded metadata/preview query"
-	return toolJSONResult(out)
+	return toolJSONResult(out, out)
 }
 
 func handleEmailDelete(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
@@ -229,7 +229,7 @@ func handleEmailDelete(ctx context.Context, args json.RawMessage) (*mcpruntime.T
 		return commMailboxToolResultFromError(err)
 	}
 	out["source"] = "lesser-host-mailbox"
-	return toolJSONResult(out)
+	return toolJSONResult(out, out)
 }
 
 func handleEmailMarkRead(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
@@ -256,7 +256,7 @@ func handleEmailReadState(ctx context.Context, args json.RawMessage, action stri
 		return commMailboxToolResultFromError(err)
 	}
 	out["source"] = "lesser-host-mailbox"
-	return toolJSONResult(out)
+	return toolJSONResult(out, out)
 }
 
 func handleSmsRead(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
@@ -315,7 +315,7 @@ func handleSmsRead(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolR
 	}
 	out["cursor"] = strings.TrimSpace(in.Cursor)
 	out["since"] = strings.TrimSpace(in.Since)
-	return toolJSONResult(out)
+	return toolJSONResult(out, out)
 }
 
 func handleVoicemailRead(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
@@ -371,7 +371,7 @@ func handleVoicemailRead(ctx context.Context, args json.RawMessage) (*mcpruntime
 	if deleted != nil {
 		out["deleted"] = *deleted
 	}
-	return toolJSONResult(out)
+	return toolJSONResult(out, out)
 }
 
 func readCommNotifications(ctx context.Context, bearerToken string, direction string, limit int, since string) ([]any, string, error) {

--- a/internal/mcpserver/mailbox_host_tools.go
+++ b/internal/mcpserver/mailbox_host_tools.go
@@ -33,6 +33,7 @@ type commMailboxListOptions struct {
 	Cursor          string
 	ThreadID        string
 	Query           string
+	IncludeRaw      bool
 	IncludeArchived bool
 	IncludeDeleted  bool
 	Archived        *bool
@@ -180,10 +181,10 @@ func listHostMailboxMessages(ctx context.Context, deps *commMailboxDependencies,
 	if err != nil {
 		return nil, err
 	}
-	return normalizeMailboxListResult(raw), nil
+	return normalizeMailboxListResult(raw, opts.IncludeRaw), nil
 }
 
-func getHostMailboxMessage(ctx context.Context, deps *commMailboxDependencies, messageRef string) (map[string]any, error) {
+func getHostMailboxMessage(ctx context.Context, deps *commMailboxDependencies, messageRef string, includeRaw bool) (map[string]any, error) {
 	messageRef = strings.TrimSpace(messageRef)
 	if messageRef == "" {
 		return nil, invalidParams("messageId is required")
@@ -193,7 +194,7 @@ func getHostMailboxMessage(ctx context.Context, deps *commMailboxDependencies, m
 		return nil, err
 	}
 	m, _ := raw.(map[string]any)
-	message := normalizeMailboxMessage(m["message"])
+	message := normalizeMailboxMessage(m["message"], includeRaw)
 	return map[string]any{"message": message}, nil
 }
 
@@ -225,7 +226,7 @@ func mutateHostMailboxMessage(ctx context.Context, deps *commMailboxDependencies
 		return nil, err
 	}
 	m, _ := raw.(map[string]any)
-	message := normalizeMailboxMessage(m["message"])
+	message := normalizeMailboxMessage(m["message"], false)
 	return map[string]any{
 		"messageId":  firstNonEmptyString(message, "messageId", "messageRef", "deliveryId"),
 		"messageRef": firstNonEmptyString(message, "messageRef", "deliveryId", "messageId"),
@@ -250,12 +251,12 @@ func replyHostMailboxMessage(ctx context.Context, deps *commMailboxDependencies,
 	return normalizeCommSendResult(raw, nil), nil
 }
 
-func normalizeMailboxListResult(raw any) map[string]any {
+func normalizeMailboxListResult(raw any, includeRaw bool) map[string]any {
 	m, _ := raw.(map[string]any)
 	messagesRaw, _ := m["messages"].([]any)
 	messages := make([]any, 0, len(messagesRaw))
 	for _, item := range messagesRaw {
-		messages = append(messages, normalizeMailboxMessage(item))
+		messages = append(messages, normalizeMailboxMessage(item, includeRaw))
 	}
 
 	out := map[string]any{
@@ -277,7 +278,7 @@ func normalizeMailboxListResult(raw any) map[string]any {
 	return out
 }
 
-func normalizeMailboxMessage(raw any) map[string]any {
+func normalizeMailboxMessage(raw any, includeRaw bool) map[string]any {
 	m, _ := raw.(map[string]any)
 	messageRef := strings.TrimSpace(stringFromMap(m, "messageRef"))
 	deliveryID := strings.TrimSpace(stringFromMap(m, "deliveryId"))
@@ -316,7 +317,9 @@ func normalizeMailboxMessage(raw any) map[string]any {
 		"createdAt":     createdAt,
 		"receivedAt":    createdAt,
 		"updatedAt":     strings.TrimSpace(stringFromMap(m, "updatedAt")),
-		"raw":           m,
+	}
+	if includeRaw {
+		out["_raw"] = m
 	}
 	if strings.EqualFold(strings.TrimSpace(fmt.Sprint(out["direction"])), "outbound") {
 		out["sentAt"] = createdAt

--- a/internal/mcpserver/memory_tools.go
+++ b/internal/mcpserver/memory_tools.go
@@ -163,6 +163,7 @@ func memoryAppendDef() mcpruntime.ToolDef {
 	return mcpruntime.ToolDef{
 		Name:        "memory_append",
 		Description: "Append a memory event to the authenticated agent's memory timeline.",
+		Annotations: additiveMutationToolAnnotations(),
 		InputSchema: json.RawMessage(`{
 			"type":"object",
 			"properties":{
@@ -181,6 +182,7 @@ func memoryQueryDef() mcpruntime.ToolDef {
 	return mcpruntime.ToolDef{
 		Name:        "memory_query",
 		Description: "Query memory events for the authenticated agent.",
+		Annotations: readOnlyToolAnnotations(),
 		InputSchema: json.RawMessage(`{
 			"type":"object",
 			"properties":{

--- a/internal/mcpserver/memory_tools.go
+++ b/internal/mcpserver/memory_tools.go
@@ -82,7 +82,11 @@ func handleMemoryAppend(ctx context.Context, args json.RawMessage) (*mcpruntime.
 		return nil, err
 	}
 
-	return toolJSONResult(res)
+	structured, err := toolStructuredContent(res)
+	if err != nil {
+		return nil, err
+	}
+	return toolJSONResult(res, structured)
 }
 
 func handleMemoryQuery(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
@@ -133,7 +137,11 @@ func handleMemoryQuery(ctx context.Context, args json.RawMessage) (*mcpruntime.T
 		return nil, err
 	}
 
-	return toolJSONResult(res)
+	structured, err := toolStructuredContent(res)
+	if err != nil {
+		return nil, err
+	}
+	return toolJSONResult(res, structured)
 }
 
 func parseRFC3339Optional(raw string) (time.Time, error) {

--- a/internal/mcpserver/outbound_comm_tools.go
+++ b/internal/mcpserver/outbound_comm_tools.go
@@ -76,7 +76,7 @@ func handleSmsSendWithProgress(ctx context.Context, args json.RawMessage, emit f
 	if replyRef != "" {
 		normalized["inReplyTo"] = replyRef
 	}
-	return toolJSONResult(normalized)
+	return toolJSONResult(normalized, nil)
 }
 
 func handlePhoneCall(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
@@ -129,7 +129,7 @@ func handlePhoneCall(ctx context.Context, args json.RawMessage) (*mcpruntime.Too
 	if replyRef != "" {
 		normalized["inReplyTo"] = replyRef
 	}
-	return toolJSONResult(normalized)
+	return toolJSONResult(normalized, nil)
 }
 
 func loadCommSendDependencies(ctx context.Context, channel string) (*commSendDependencies, *mcpruntime.ToolResult, error) {

--- a/internal/mcpserver/social_tools.go
+++ b/internal/mcpserver/social_tools.go
@@ -68,20 +68,44 @@ func registerSocialTools(r *mcpruntime.ToolRegistry) error {
 	return nil
 }
 
-func toolJSONResult(payload any) (*mcpruntime.ToolResult, error) {
+func toolJSONResult(payload any, structured map[string]any) (*mcpruntime.ToolResult, error) {
 	b, err := json.Marshal(payload)
 	if err != nil {
 		return nil, fmt.Errorf("marshal tool result: %w", err)
+	}
+	if structured == nil {
+		structured = map[string]any{
+			"data": payload,
+		}
 	}
 	return &mcpruntime.ToolResult{
 		Content: []mcpruntime.ContentBlock{{
 			Type: "text",
 			Text: string(b),
 		}},
-		StructuredContent: map[string]any{
-			"data": payload,
-		},
+		StructuredContent: structured,
 	}, nil
+}
+
+func toolStructuredContent(payload any) (map[string]any, error) {
+	if payload == nil {
+		return map[string]any{}, nil
+	}
+	if structured, ok := payload.(map[string]any); ok {
+		return structured, nil
+	}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("marshal structured tool result: %w", err)
+	}
+	var structured map[string]any
+	if err := json.Unmarshal(b, &structured); err != nil {
+		return nil, fmt.Errorf("unmarshal structured tool result: %w", err)
+	}
+	if structured == nil {
+		structured = map[string]any{}
+	}
+	return structured, nil
 }
 
 func requireOAuthBearer(ctx context.Context) (string, error) {
@@ -127,7 +151,7 @@ func handleProfileRead(ctx context.Context, args json.RawMessage) (*mcpruntime.T
 	if err != nil {
 		return authToolResultFromError(err)
 	}
-	return toolJSONResult(out)
+	return toolJSONResult(out, nil)
 }
 
 func handleTimelineRead(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
@@ -178,7 +202,7 @@ func handleTimelineRead(ctx context.Context, args json.RawMessage) (*mcpruntime.
 	if err != nil {
 		return authToolResultFromError(err)
 	}
-	return toolJSONResult(out)
+	return toolJSONResult(out, nil)
 }
 
 func handlePostSearch(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
@@ -214,7 +238,7 @@ func handlePostSearch(ctx context.Context, args json.RawMessage) (*mcpruntime.To
 	if err != nil {
 		return authToolResultFromError(err)
 	}
-	return toolJSONResult(out)
+	return toolJSONResult(out, nil)
 }
 
 func handleFollowersList(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
@@ -261,7 +285,7 @@ func handleFollowersList(ctx context.Context, args json.RawMessage) (*mcpruntime
 	if err != nil {
 		return authToolResultFromError(err)
 	}
-	return toolJSONResult(out)
+	return toolJSONResult(out, nil)
 }
 
 func handleFollowingList(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
@@ -308,7 +332,7 @@ func handleFollowingList(ctx context.Context, args json.RawMessage) (*mcpruntime
 	if err != nil {
 		return authToolResultFromError(err)
 	}
-	return toolJSONResult(out)
+	return toolJSONResult(out, nil)
 }
 
 func handleConversationsRead(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
@@ -337,7 +361,7 @@ func handleConversationsRead(ctx context.Context, args json.RawMessage) (*mcprun
 	if err != nil {
 		return authToolResultFromError(err)
 	}
-	return toolJSONResult(out)
+	return toolJSONResult(out, nil)
 }
 
 func handleNotificationsRead(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
@@ -417,7 +441,7 @@ func handleNotificationsRead(ctx context.Context, args json.RawMessage) (*mcprun
 		"count":         len(notifications),
 		"types":         requestedTypes,
 		"notifications": notifications,
-	})
+	}, nil)
 }
 
 func handleNotificationDismiss(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
@@ -462,7 +486,7 @@ func handleNotificationDismiss(ctx context.Context, args json.RawMessage) (*mcpr
 		"ok":      true,
 		"id":      in.ID,
 		"dismiss": ternaryString(in.ID == "", "all", "single"),
-	})
+	}, nil)
 }
 
 func handlePostCreate(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
@@ -504,7 +528,7 @@ func handlePostCreate(ctx context.Context, args json.RawMessage) (*mcpruntime.To
 	if err != nil {
 		return authToolResultFromError(err)
 	}
-	return toolJSONResult(out)
+	return toolJSONResult(out, nil)
 }
 
 func handlePostBoost(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
@@ -532,7 +556,7 @@ func handlePostBoost(ctx context.Context, args json.RawMessage) (*mcpruntime.Too
 	if err != nil {
 		return authToolResultFromError(err)
 	}
-	return toolJSONResult(out)
+	return toolJSONResult(out, nil)
 }
 
 func handlePostFavorite(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
@@ -560,7 +584,7 @@ func handlePostFavorite(ctx context.Context, args json.RawMessage) (*mcpruntime.
 	if err != nil {
 		return authToolResultFromError(err)
 	}
-	return toolJSONResult(out)
+	return toolJSONResult(out, nil)
 }
 
 func handleFollow(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
@@ -588,7 +612,7 @@ func handleFollow(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolRe
 	if err != nil {
 		return authToolResultFromError(err)
 	}
-	return toolJSONResult(out)
+	return toolJSONResult(out, nil)
 }
 
 func handleUnfollow(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
@@ -616,7 +640,7 @@ func handleUnfollow(ctx context.Context, args json.RawMessage) (*mcpruntime.Tool
 	if err != nil {
 		return authToolResultFromError(err)
 	}
-	return toolJSONResult(out)
+	return toolJSONResult(out, nil)
 }
 
 func handleProfileUpdate(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
@@ -660,7 +684,7 @@ func handleProfileUpdate(ctx context.Context, args json.RawMessage) (*mcpruntime
 	if err != nil {
 		return authToolResultFromError(err)
 	}
-	return toolJSONResult(out)
+	return toolJSONResult(out, nil)
 }
 
 func profileReadDef() mcpruntime.ToolDef {

--- a/internal/mcpserver/tool_annotations.go
+++ b/internal/mcpserver/tool_annotations.go
@@ -1,0 +1,36 @@
+package mcpserver
+
+import mcpruntime "github.com/theory-cloud/apptheory/runtime/mcp"
+
+func boolHint(value bool) *bool {
+	return &value
+}
+
+func readOnlyToolAnnotations() *mcpruntime.ToolAnnotations {
+	return &mcpruntime.ToolAnnotations{
+		ReadOnlyHint: boolHint(true),
+	}
+}
+
+func destructiveToolAnnotations() *mcpruntime.ToolAnnotations {
+	return &mcpruntime.ToolAnnotations{
+		ReadOnlyHint:    boolHint(false),
+		DestructiveHint: boolHint(true),
+	}
+}
+
+func idempotentMutationToolAnnotations() *mcpruntime.ToolAnnotations {
+	return &mcpruntime.ToolAnnotations{
+		ReadOnlyHint:    boolHint(false),
+		DestructiveHint: boolHint(false),
+		IdempotentHint:  boolHint(true),
+	}
+}
+
+func additiveMutationToolAnnotations() *mcpruntime.ToolAnnotations {
+	return &mcpruntime.ToolAnnotations{
+		ReadOnlyHint:    boolHint(false),
+		DestructiveHint: boolHint(false),
+		IdempotentHint:  boolHint(false),
+	}
+}


### PR DESCRIPTION
## Milestone
#161 M0 subset — establish lean, annotated mailbox and memory MCP surfaces for #158-#160.

## Classification
MCP-contract, tool-surface, host-delegation-preserving, test-coverage, docs.

## Surfaces affected
- `internal/mcpserver/`: mailbox normalisation, mailbox tool schemas, memory/mailbox result helpers, tool annotations.
- `internal/mcpapp/`: contract and regression tests for mailbox payloads, structuredContent, and annotations.
- `docs/mcp.md`: mailbox raw opt-in, flat structuredContent, and annotation notes.

## Specialist walks referenced
- Tool surface: mailbox and memory tools only; no scope/profile changes; communication tools remain souled-only and host-delegated.
- MCP contract: #158 removes default `raw`; #159 flattens `structuredContent` for mailbox/memory; #160 adds annotations to `tools/list`.
- Lesser integration: none.
- Host delegation: preserved; no host API shape change for #158-#160.
- Framework: idiomatic AppTheory v1.3.0 `ToolDef.Annotations` and `ToolResult.StructuredContent` use.

## Consumer impact
- Default mailbox responses are significantly leaner because upstream payloads are no longer duplicated under `raw`.
- `include_raw: true` restores verbose upstream data under `_raw` for audit/debug use cases.
- Mailbox and memory `structuredContent` now exposes top-level typed fields directly instead of a `data` wrapper; text content remains JSON for text-reading clients.
- Tool annotations are visible through `tools/list`.
- Note: `memory_append` is not advertised as unconditionally idempotent because `event_id` remains optional; it is only idempotent when callers provide `event_id`.

## Tasks
- [x] #158 — eliminate raw field bloat in mailbox responses.
- [x] #159 — adopt dual Content + flat StructuredContent for mailbox and memory tools.
- [x] #160 — add tool annotations to mailbox/email/SMS/voicemail and memory tools, with truthful `memory_append` semantics.

## Validation
- [x] Baseline on `main` before branching: `go test ./...`
- [x] Baseline on `main` before branching: `go vet ./...`
- [x] Baseline on `main` before branching: `gofmt -l $(git ls-files '*.go')` empty
- [x] Baseline on `main` before branching: `scripts/build.sh`
- [x] Targeted after #158: `go test ./internal/mcpapp -run 'TestLBM0_CommunicationToolSchemasMatchSpec|TestLBM3_InboxToolsUseHostMailbox'`
- [x] Targeted after #159: `go test ./internal/mcpserver ./internal/mcpapp`
- [x] Targeted after #160: `go test ./internal/mcpserver ./internal/mcpapp -run 'TestMCPToolAnnotationsForMailboxAndMemory|TestLBM0_CommunicationToolSchemasMatchSpec'`
- [x] Final: `go test ./...`
- [x] Final: `go vet ./...`
- [x] Final: `gofmt -l $(git ls-files '*.go')` empty
- [x] Final: `scripts/build.sh`
- [x] Additional: `cd cdk && go test ./...`

## Stage rollout plan (handoff to deploy-body)
- [ ] Merged to main
- [ ] Deployed to lab / dev
- [ ] Lab soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
- None required for #158-#160. #161 M0.2 host-side `fields` projection remains tracked separately in lesser-host.

## Advisor-brief authorization
Not applicable; Aron-directed GitHub issue work.
