### PR TITLE
fix(mcp): finish M0 baseline read surfaces

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -60,6 +60,7 @@ Protocol + tool catalog: `docs/mcp.md`
 - Security posture: `docs/security.md`
 - Troubleshoot: `docs/troubleshooting.md`
 - Release artifacts: `docs/release.md`
+- Project 21 M0 baseline probe: `docs/m0-baseline-probe.md`
 
 ### Developers
 

--- a/docs/m0-baseline-probe.md
+++ b/docs/m0-baseline-probe.md
@@ -1,0 +1,62 @@
+# Project 21 M0 baseline MCP usability probe
+
+Run this after the M0 baseline fixes are deployed to the target dev/lab body endpoint. Deployment itself stays in the
+`deploy-body` workflow; this probe is the Ops closure gate for issue #166.
+
+## Required inputs
+
+```bash
+export MCP_ENDPOINT='https://api.<stage-domain>/mcp/<actor>'
+export MCP_BEARER_TOKEN='<OAuth token for that actor>'
+# or: export MCP_AUTHORIZATION='Bearer <OAuth token>'
+```
+
+Recommended identity/message fixtures:
+
+```bash
+export PROBE_LOCAL_ID='agent-local-id'
+export PROBE_ENS='agent.lessersoul.eth'
+export PROBE_REMOTE_AP_HANDLE='@user@remote.example'
+export PROBE_ACTOR_URL='https://remote.example/users/user'
+export PROBE_EMAIL='sender@example.com'
+export PROBE_PHONE='+15550142'
+export PROBE_MESSAGE_REF='comm-delivery-...'
+export PROBE_NOTIFICATION_SINCE='2026-05-10T00:00:00Z'
+```
+
+Optional safe self-email probe:
+
+```bash
+export PROBE_SAFE_SEND_EMAIL=true
+export PROBE_SELF_EMAIL_TO='self@example.com'
+```
+
+## Command
+
+```bash
+scripts/m0_baseline_mcp_probe.py | tee m0-baseline-probe.jsonl
+```
+
+The script prints one line per probe with pass/fail/skip, elapsed time, HTTP response size, and compact metadata. It
+prints a final `SUMMARY` JSON object suitable for attaching to the Project 21 issue or deploy notes.
+
+## Required evidence
+
+The report must include:
+
+- pass/fail/skip per probe;
+- elapsed time per probe;
+- approximate payload size for large read paths;
+- `notifications_read.diagnostics` timing/size fields when present;
+- whether default output omitted raw/debug payloads;
+- whether failures appear to be Lesser API latency, body shaping/serialization, or MCP transport timeout.
+
+## Closure expectations
+
+M0 is not closed until Ops reports repeatable baseline usability in the deployed environment:
+
+- `notifications_read({"since":"", "limit":30})` no longer times out;
+- Host mailbox messageRef verification works where authoritative sender provenance exists;
+- email/SMS/voicemail filtered pagination is sane;
+- identity lookup/verify and timestamp-since notification reads do not regress;
+- no baseline read-tool output is truncated under realistic mailbox/notification state.

--- a/docs/m0-baseline-probe.md
+++ b/docs/m0-baseline-probe.md
@@ -40,6 +40,13 @@ scripts/m0_baseline_mcp_probe.py | tee m0-baseline-probe.jsonl
 The script prints one line per probe with pass/fail/skip, elapsed time, HTTP response size, and compact metadata. It
 prints a final `SUMMARY` JSON object suitable for attaching to the Project 21 issue or deploy notes.
 
+The probe treats semantic failure payloads as failures, not successful MCP transport:
+
+- message-scoped `identity_verify` must return `messageFound:true` and `verified:true`;
+- `notifications_read` default calls must include diagnostics and must not expose `raw` or `_raw` notification payloads;
+- `email_read`, `sms_read`, and `voicemail_read` must not return an empty page with `hasMore:true`, and any
+  `hasMore:true` page must include `nextCursor`.
+
 ## Required evidence
 
 The report must include:
@@ -47,8 +54,8 @@ The report must include:
 - pass/fail/skip per probe;
 - elapsed time per probe;
 - approximate payload size for large read paths;
-- `notifications_read.diagnostics` timing/size fields when present;
-- whether default output omitted raw/debug payloads;
+- `notifications_read.diagnostics` timing/size fields;
+- whether default notification output omitted raw/debug payloads;
 - whether failures appear to be Lesser API latency, body shaping/serialization, or MCP transport timeout.
 
 ## Closure expectations

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -301,11 +301,22 @@ Notes:
 
 - Social tools require an **OAuth JWT** bearer token (not just an instance key) because they call the Lesser API on behalf
   of the authenticated agent.
+- M0 baseline read-tool policy: daily agent read paths must have compact, bounded defaults. List/read tools should return
+  operational metadata (ids, timestamps, actor/from/to, subject/type, preview/status/state, and cursor metadata) rather
+  than full upstream product payloads. Raw/debug payloads are opt-in only via `include_raw=true` where currently
+  supported, and full content remains on explicit get/content tools rather than default list responses.
 - `notifications_read.since` is a temporal RFC3339/RFC3339Nano lower bound (`createdAt > since`). Use the optional
   `cursor` argument for pagination/backfill; `nextCursor` is returned when Lesser supplies an opaque pagination cursor.
   Cursor pagination is strongest for untyped reads or reads with a single `types` value; multi-type reads fan out to
   separate Lesser notification queries, so their per-type cursors are not collapsed into one `nextCursor`. Non-timestamp
   `since` values remain a legacy cursor alias for compatibility, but new callers should not rely on that path.
+- `notifications_read` omits full upstream `raw` notification objects by default and accepts optional
+  `include_raw=true`, which returns `_raw` on each notification for expensive audit/debug use. Default notifications
+  contain compact `actor`, bounded `targetPost`, optional bounded `communication` summaries, cursor/since metadata, and
+  best-effort `diagnostics` timing/size fields for Ops probes.
+- `conversations_read` defaults to `limit=20` (maximum `80`) and returns compact conversation summaries: id, unread
+  state, updated timestamp, compact participants, and bounded `lastPost`. It accepts optional `include_raw=true`, which
+  returns `_raw` for audit/debug use.
 - Communication and identity tools also require an **OAuth JWT** bearer token for agent-context reads such as `identity_whoami`
   and inbox-backed verification. For self-identity checks, lesser-body passes that bearer to Lesser's
   `GET /api/v1/souls/bound/me` endpoint and fails closed if Lesser does not confirm an active bound soul for the
@@ -324,6 +335,9 @@ Notes:
 - Mailbox and memory tools use dual MCP result surfaces: `content[0].text` contains the JSON payload for text-reading
   clients, and `structuredContent` contains the same typed fields directly (for example `messages` or `events` at the
   top level) rather than nesting them under a `data` wrapper.
+- `timeline_read` remains bounded by caller `limit`/cursor and upstream-shaped in M0 because current baseline evidence
+  points to mailbox and notification bloat, not timeline unusability. If Ops probes show timeline truncation/timeout,
+  timeline compacting should be scoped as a follow-up MCP-contract change rather than silently changed inside M0.
 - Mailbox and memory tools publish MCP annotations in `tools/list`: read-only hints for mailbox reads/search/content
   fetches and `memory_query`, destructive hints for send/reply/delete tools, and idempotent hints for mailbox read-state
   mutation tools. `memory_append` remains an additive write and is only idempotent when callers provide `event_id`, so
@@ -341,6 +355,10 @@ Notes:
 - Managed email and phone reverse lookup are private reachability surfaces in lesser-host. Until lesser-host exposes a
   body-facing, instance-authenticated resolver, `identity_lookup` and `identity_verify` fail closed for private
   email/phone identifiers with `private_reachability_unavailable` instead of probing those routes anonymously.
+- `identity_verify(..., messageId=<host messageRef>)` uses lesser-host mailbox metadata as the canonical provenance
+  source for `comm-delivery-*` message refs. ENS verification resolves ENS publicly and compares the resolved agent ID
+  to `message.from.soulAgentId`; email/phone message-scoped verification requires both a sender address/number match
+  and authoritative `message.from.soulAgentId`. Sender display/address fields alone are not trusted.
 - `identity_lookup` intentionally returns only public identity summary fields (`agentId`, `domain`, `localId`,
   `status`). It does not expose arbitrary agents' private `channels` or `contactPreferences`; use
   `identity_whoami` or `agent://channels` only for the authenticated agent's own channel data.

--- a/internal/mcpapp/identity_surfaces_test.go
+++ b/internal/mcpapp/identity_surfaces_test.go
@@ -25,6 +25,7 @@ func TestLBM1_IdentityToolsAndChannelResources(t *testing.T) {
 	t.Setenv("MCP_SESSION_TABLE", "")
 	t.Setenv("JWT_SECRET", "test")
 	t.Setenv("LESSER_TABLE_NAME", "test-main-table")
+	t.Setenv("LESSER_HOST_INSTANCE_KEY", "instance-key-123")
 	auth.ResetForTests()
 	lesserapi.ResetForTests()
 	soulbinding.ResetForTests()
@@ -114,6 +115,78 @@ func TestLBM1_IdentityToolsAndChannelResources(t *testing.T) {
 		case r.URL.Path == "/api/v1/soul/resolve/ens/ops.eth":
 			w.WriteHeader(http.StatusNotFound)
 			_, _ = w.Write([]byte(`{"error":{"message":"not found"}}`))
+		case r.URL.Path == "/api/v1/soul/comm/mailbox/"+agentID+"/messages/comm-delivery-email":
+			if got := r.Header.Get("Authorization"); got != "Bearer instance-key-123" {
+				t.Fatalf("expected host instance bearer for mailbox lookup, got %q", got)
+			}
+			_, _ = w.Write([]byte(`{
+				"message":{
+					"messageRef":"comm-delivery-email",
+					"deliveryId":"comm-delivery-email",
+					"channelType":"email",
+					"direction":"inbound",
+					"from":{"address":"agent-alice@lessersoul.ai","soulAgentId":"` + agentID + `"},
+					"to":[{"address":"agent1@test.example.com"}],
+					"subject":"Host email",
+					"preview":"Hello from host",
+					"createdAt":"2026-05-10T12:00:00Z"
+				}
+			}`))
+		case r.URL.Path == "/api/v1/soul/comm/mailbox/"+agentID+"/messages/comm-delivery-phone":
+			_, _ = w.Write([]byte(`{
+				"message":{
+					"messageRef":"comm-delivery-phone",
+					"deliveryId":"comm-delivery-phone",
+					"channelType":"sms",
+					"direction":"inbound",
+					"from":{"number":"+15550142","soulAgentId":"` + agentID + `"},
+					"to":{"number":"+15550199"},
+					"preview":"SMS from host",
+					"createdAt":"2026-05-10T12:01:00Z"
+				}
+			}`))
+		case r.URL.Path == "/api/v1/soul/comm/mailbox/"+agentID+"/messages/comm-delivery-ens":
+			_, _ = w.Write([]byte(`{
+				"message":{
+					"messageRef":"comm-delivery-ens",
+					"deliveryId":"comm-delivery-ens",
+					"channelType":"email",
+					"direction":"inbound",
+					"from":{"address":"agent-alice@lessersoul.ai","soulAgentId":"` + agentID + `"},
+					"subject":"ENS host email",
+					"preview":"ENS verified",
+					"createdAt":"2026-05-10T12:02:00Z"
+				}
+			}`))
+		case r.URL.Path == "/api/v1/soul/comm/mailbox/"+agentID+"/messages/comm-delivery-spoof":
+			_, _ = w.Write([]byte(`{
+				"message":{
+					"messageRef":"comm-delivery-spoof",
+					"deliveryId":"comm-delivery-spoof",
+					"channelType":"email",
+					"direction":"inbound",
+					"from":{"name":"agent-alice@lessersoul.ai","address":"agent-alice@lessersoul.ai"},
+					"subject":"Spoof",
+					"preview":"No authoritative sender provenance",
+					"createdAt":"2026-05-10T12:03:00Z"
+				}
+			}`))
+		case r.URL.Path == "/api/v1/soul/comm/mailbox/"+agentID+"/messages/comm-delivery-wrong-agent":
+			_, _ = w.Write([]byte(`{
+				"message":{
+					"messageRef":"comm-delivery-wrong-agent",
+					"deliveryId":"comm-delivery-wrong-agent",
+					"channelType":"email",
+					"direction":"inbound",
+					"from":{"address":"agent-alice@lessersoul.ai","soulAgentId":"0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},
+					"subject":"Wrong agent",
+					"preview":"Wrong provenance",
+					"createdAt":"2026-05-10T12:04:00Z"
+				}
+			}`))
+		case strings.HasPrefix(r.URL.Path, "/api/v1/soul/comm/mailbox/"+agentID+"/messages/"):
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":{"message":"message not found"}}`))
 		case r.URL.Path == "/api/v1/notifications":
 			_, _ = w.Write([]byte(`[
 				{
@@ -581,7 +654,6 @@ func TestLBM1_IdentityToolsAndChannelResources(t *testing.T) {
 			"arguments": map[string]any{
 				"channel":    tc.channel,
 				"identifier": tc.identifier,
-				"messageId":  "comm-msg-001",
 			},
 		})
 		resp := invokeJSON(t, env, app, map[string][]string{
@@ -594,6 +666,88 @@ func TestLBM1_IdentityToolsAndChannelResources(t *testing.T) {
 		_ = assertToolErrorPayload("identity_verify "+tc.channel, resp.Body, "private_reachability_unavailable")
 		if len(channelResolveQueries) != 0 {
 			t.Fatalf("identity_verify %s should not fetch private /channels, got %+v", tc.channel, channelResolveQueries)
+		}
+	}
+
+	callIdentityVerify := func(id int, channel string, identifier string, messageID string) map[string]any {
+		t.Helper()
+		args := map[string]any{
+			"channel":    channel,
+			"identifier": identifier,
+		}
+		if messageID != "" {
+			args["messageId"] = messageID
+		}
+		callParams, _ := json.Marshal(map[string]any{
+			"name":      "identity_verify",
+			"arguments": args,
+		})
+		resp := invokeJSON(t, env, app, map[string][]string{
+			"authorization":  {authHeader},
+			"mcp-session-id": {sessionID},
+		}, &mcpruntime.Request{JSONRPC: "2.0", ID: id, Method: "tools/call", Params: callParams})
+		if resp.Status != 200 {
+			t.Fatalf("identity_verify(%s,%s,%s): status=%d body=%s", channel, identifier, messageID, resp.Status, string(resp.Body))
+		}
+
+		var rpc mcpruntime.Response
+		_ = json.Unmarshal(resp.Body, &rpc)
+		if rpc.Error != nil {
+			t.Fatalf("identity_verify(%s,%s,%s) rpc error: %+v", channel, identifier, messageID, rpc.Error)
+		}
+		var out mcpruntime.ToolResult
+		{
+			b, _ := json.Marshal(rpc.Result)
+			_ = json.Unmarshal(b, &out)
+		}
+		data, _ := out.StructuredContent["data"].(map[string]any)
+		if data == nil {
+			t.Fatalf("identity_verify(%s,%s,%s): expected structured data, got %+v", channel, identifier, messageID, out.StructuredContent)
+		}
+		return data
+	}
+
+	// Host mailbox messageRefs are the canonical provenance source for message-scoped identity_verify.
+	{
+		emailResolveQueries = nil
+		data := callIdentityVerify(60, "email", "agent-alice@lessersoul.ai", "comm-delivery-email")
+		if data["verified"] != true {
+			t.Fatalf("expected host email message verification to succeed, got %+v", data)
+		}
+		if data["matchedBy"] != "message.from.email+sender.soulAgentId" {
+			t.Fatalf("expected email sender provenance match, got %+v", data)
+		}
+		message, _ := data["message"].(map[string]any)
+		if message["source"] != "lesser-host-mailbox" || message["messageRef"] != "comm-delivery-email" {
+			t.Fatalf("expected host mailbox message summary, got %+v", message)
+		}
+		if len(emailResolveQueries) != 0 {
+			t.Fatalf("message-scoped email verify must not call private reachability resolver, got %+v", emailResolveQueries)
+		}
+
+		data = callIdentityVerify(61, "phone", "+1 (555) 0142", "comm-delivery-phone")
+		if data["verified"] != true || data["matchedBy"] != "message.from.phone+sender.soulAgentId" {
+			t.Fatalf("expected host phone message verification to succeed, got %+v", data)
+		}
+
+		data = callIdentityVerify(62, "ens", "agent-alice.lessersoul.eth", "comm-delivery-ens")
+		if data["verified"] != true || data["matchedBy"] != "sender.agentId" {
+			t.Fatalf("expected host ENS message verification to succeed, got %+v", data)
+		}
+
+		data = callIdentityVerify(63, "email", "agent-alice@lessersoul.ai", "comm-delivery-spoof")
+		if data["verified"] != false || data["reason"] != "message_lacks_authoritative_sender_provenance" {
+			t.Fatalf("expected spoofed host sender to fail missing provenance, got %+v", data)
+		}
+
+		data = callIdentityVerify(64, "ens", "agent-alice.lessersoul.eth", "comm-delivery-wrong-agent")
+		if data["verified"] != false || data["reason"] != "sender_does_not_match_resolved_identity" {
+			t.Fatalf("expected wrong host sender agent to fail mismatch, got %+v", data)
+		}
+
+		data = callIdentityVerify(65, "ens", "agent-alice.lessersoul.eth", "comm-delivery-missing")
+		if data["verified"] != false || data["messageFound"] != false || data["reason"] != "message_not_found" {
+			t.Fatalf("expected missing host message to be explicit, got %+v", data)
 		}
 	}
 

--- a/internal/mcpapp/social_tools_test.go
+++ b/internal/mcpapp/social_tools_test.go
@@ -69,9 +69,11 @@ func TestM5_ToolsListContainsCoreTools(t *testing.T) {
 		_ = json.Unmarshal(b, &result)
 	}
 
+	toolsByName := map[string]mcpruntime.ToolDef{}
 	have := map[string]bool{}
 	for _, tool := range result.Tools {
 		have[tool.Name] = true
+		toolsByName[tool.Name] = tool
 	}
 
 	for _, name := range []string{
@@ -93,6 +95,16 @@ func TestM5_ToolsListContainsCoreTools(t *testing.T) {
 		if !have[name] {
 			t.Fatalf("expected tool %q in tools/list", name)
 		}
+	}
+
+	var notificationSchema struct {
+		Properties map[string]map[string]any `json:"properties"`
+	}
+	if err := json.Unmarshal(toolsByName["notifications_read"].InputSchema, &notificationSchema); err != nil {
+		t.Fatalf("unmarshal notifications_read schema: %v", err)
+	}
+	if propType, _ := notificationSchema.Properties["include_raw"]["type"].(string); propType != "boolean" {
+		t.Fatalf("notifications_read include_raw should be boolean, got %+v", notificationSchema.Properties["include_raw"])
 	}
 }
 
@@ -616,6 +628,126 @@ func TestM5_NotificationsReadReturnsStructuredNotifications(t *testing.T) {
 	favourite, _ := notifications[0].(map[string]any)
 	if favourite["type"] != "favourite" {
 		t.Fatalf("expected favourite notification type, got %+v", favourite)
+	}
+}
+
+func TestM5_NotificationsReadOmitsRawByDefaultAndExposesDiagnostics(t *testing.T) {
+	t.Setenv("MCP_SESSION_TABLE", "")
+	t.Setenv("JWT_SECRET", "test")
+	auth.ResetForTests()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/api/v1/notifications" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[
+			{
+				"id":"n-mail",
+				"type":"communication:inbound",
+				"created_at":"2026-05-10T12:00:00Z",
+				"channel":"email",
+				"messageId":"comm-delivery-email",
+				"from":{"name":"Sender","address":"sender@example.com","soulAgentId":"0xabc"},
+				"to":[{"address":"agent@example.com"}],
+				"subject":"Hello",
+				"body":"` + strings.Repeat("long-body ", 80) + `",
+				"status":{"id":"post-1","content":"` + strings.Repeat("long-post ", 120) + `","visibility":"public"},
+				"debugPayload":{"large":"` + strings.Repeat("x", 4096) + `"}
+			}
+		]`))
+	}))
+	defer server.Close()
+
+	t.Setenv("LESSER_API_BASE_URL", server.URL)
+	lesserapi.ResetForTests()
+
+	app, err := mcpapp.New("test", "dev")
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+
+	env := testkit.New()
+	token := newTestToken(t, "test", "agent1", []string{"read"})
+	authHeader := "Bearer " + token
+
+	initResp := invokeJSON(t, env, app, map[string][]string{"authorization": {authHeader}}, &mcpruntime.Request{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "initialize",
+	})
+	if initResp.Status != 200 {
+		t.Fatalf("initialize: status=%d body=%s", initResp.Status, string(initResp.Body))
+	}
+	sessionID := initResp.Headers["mcp-session-id"][0]
+
+	call := func(id int, args map[string]any) map[string]any {
+		t.Helper()
+		callParams, _ := json.Marshal(map[string]any{"name": "notifications_read", "arguments": args})
+		resp := invokeJSON(t, env, app, map[string][]string{
+			"authorization":  {authHeader},
+			"mcp-session-id": {sessionID},
+		}, &mcpruntime.Request{JSONRPC: "2.0", ID: id, Method: "tools/call", Params: callParams})
+		if resp.Status != 200 {
+			t.Fatalf("notifications_read: status=%d body=%s", resp.Status, string(resp.Body))
+		}
+
+		var rpc mcpruntime.Response
+		if err := json.Unmarshal(resp.Body, &rpc); err != nil {
+			t.Fatalf("unmarshal notifications_read: %v", err)
+		}
+		if rpc.Error != nil {
+			t.Fatalf("notifications_read rpc error: %+v", rpc.Error)
+		}
+		var out mcpruntime.ToolResult
+		b, _ := json.Marshal(rpc.Result)
+		_ = json.Unmarshal(b, &out)
+		data, _ := out.StructuredContent["data"].(map[string]any)
+		if data == nil {
+			t.Fatalf("expected structured data, got %+v", out.StructuredContent)
+		}
+		return data
+	}
+
+	defaultData := call(2, map[string]any{"limit": 20})
+	notifications, _ := defaultData["notifications"].([]any)
+	if len(notifications) != 1 {
+		t.Fatalf("expected one notification, got %+v", defaultData)
+	}
+	notification, _ := notifications[0].(map[string]any)
+	if _, ok := notification["raw"]; ok {
+		t.Fatalf("raw field should be absent by default: %+v", notification)
+	}
+	if _, ok := notification["_raw"]; ok {
+		t.Fatalf("_raw field should be absent by default: %+v", notification)
+	}
+	comm, _ := notification["communication"].(map[string]any)
+	if comm["messageId"] != "comm-delivery-email" || comm["channel"] != "email" {
+		t.Fatalf("expected compact communication summary, got %+v", comm)
+	}
+	if preview, _ := comm["preview"].(string); len([]rune(preview)) > 240 {
+		t.Fatalf("expected bounded communication preview, got %d runes", len([]rune(preview)))
+	}
+	post, _ := notification["targetPost"].(map[string]any)
+	if content, _ := post["content"].(string); len([]rune(content)) > 500 {
+		t.Fatalf("expected bounded targetPost content, got %d runes", len([]rune(content)))
+	}
+	diagnostics, _ := defaultData["diagnostics"].(map[string]any)
+	if diagnostics["upstreamCount"] != float64(1) || diagnostics["normalizedCount"] != float64(1) {
+		t.Fatalf("expected notification diagnostics counts, got %+v", diagnostics)
+	}
+	if diagnostics["responseBytes"] == float64(0) || diagnostics["mcpPayloadBytes"] == float64(0) {
+		t.Fatalf("expected response size diagnostics, got %+v", diagnostics)
+	}
+
+	rawData := call(3, map[string]any{"limit": 20, "include_raw": true})
+	rawNotifications, _ := rawData["notifications"].([]any)
+	rawNotification, _ := rawNotifications[0].(map[string]any)
+	if _, ok := rawNotification["_raw"].(map[string]any); !ok {
+		t.Fatalf("expected include_raw=true to expose _raw, got %+v", rawNotification)
+	}
+	if _, ok := rawNotification["raw"]; ok {
+		t.Fatalf("include_raw=true should use _raw, not raw: %+v", rawNotification)
 	}
 }
 

--- a/internal/mcpapp/social_tools_test.go
+++ b/internal/mcpapp/social_tools_test.go
@@ -106,6 +106,15 @@ func TestM5_ToolsListContainsCoreTools(t *testing.T) {
 	if propType, _ := notificationSchema.Properties["include_raw"]["type"].(string); propType != "boolean" {
 		t.Fatalf("notifications_read include_raw should be boolean, got %+v", notificationSchema.Properties["include_raw"])
 	}
+	var conversationSchema struct {
+		Properties map[string]map[string]any `json:"properties"`
+	}
+	if err := json.Unmarshal(toolsByName["conversations_read"].InputSchema, &conversationSchema); err != nil {
+		t.Fatalf("unmarshal conversations_read schema: %v", err)
+	}
+	if propType, _ := conversationSchema.Properties["include_raw"]["type"].(string); propType != "boolean" {
+		t.Fatalf("conversations_read include_raw should be boolean, got %+v", conversationSchema.Properties["include_raw"])
+	}
 }
 
 func TestM5_ToolsProxyToLesserAPI(t *testing.T) {
@@ -496,6 +505,114 @@ func TestM5_ToolsProxyToLesserAPI(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestM5_ConversationsReadUsesCompactBoundedDefaults(t *testing.T) {
+	t.Setenv("MCP_SESSION_TABLE", "")
+	t.Setenv("JWT_SECRET", "test")
+	auth.ResetForTests()
+
+	var gotQueries []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/api/v1/conversations" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		gotQueries = append(gotQueries, r.URL.RawQuery)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[
+			{
+				"id":"conv-1",
+				"unread":true,
+				"updated_at":"2026-05-10T13:00:00Z",
+				"accounts":[{"id":"acct-1","username":"alice","acct":"alice@example.com","display_name":"Alice","note":"` + strings.Repeat("bio ", 200) + `"}],
+				"last_status":{"id":"post-1","content":"` + strings.Repeat("conversation-content ", 80) + `","created_at":"2026-05-10T12:59:00Z","visibility":"direct"},
+				"debugPayload":{"large":"` + strings.Repeat("x", 4096) + `"}
+			}
+		]`))
+	}))
+	defer server.Close()
+
+	t.Setenv("LESSER_API_BASE_URL", server.URL)
+	lesserapi.ResetForTests()
+
+	app, err := mcpapp.New("test", "dev")
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+	env := testkit.New()
+	token := newTestToken(t, "test", "agent1", []string{"read"})
+	authHeader := "Bearer " + token
+
+	initResp := invokeJSON(t, env, app, map[string][]string{"authorization": {authHeader}}, &mcpruntime.Request{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "initialize",
+	})
+	if initResp.Status != 200 {
+		t.Fatalf("initialize: status=%d body=%s", initResp.Status, string(initResp.Body))
+	}
+	sessionID := initResp.Headers["mcp-session-id"][0]
+
+	call := func(id int, args map[string]any) map[string]any {
+		t.Helper()
+		callParams, _ := json.Marshal(map[string]any{"name": "conversations_read", "arguments": args})
+		resp := invokeJSON(t, env, app, map[string][]string{
+			"authorization":  {authHeader},
+			"mcp-session-id": {sessionID},
+		}, &mcpruntime.Request{JSONRPC: "2.0", ID: id, Method: "tools/call", Params: callParams})
+		if resp.Status != 200 {
+			t.Fatalf("conversations_read: status=%d body=%s", resp.Status, string(resp.Body))
+		}
+		var rpc mcpruntime.Response
+		if err := json.Unmarshal(resp.Body, &rpc); err != nil {
+			t.Fatalf("unmarshal conversations_read: %v", err)
+		}
+		if rpc.Error != nil {
+			t.Fatalf("conversations_read rpc error: %+v", rpc.Error)
+		}
+		var out mcpruntime.ToolResult
+		b, _ := json.Marshal(rpc.Result)
+		_ = json.Unmarshal(b, &out)
+		data, _ := out.StructuredContent["data"].(map[string]any)
+		if data == nil {
+			t.Fatalf("expected structured data, got %+v", out.StructuredContent)
+		}
+		return data
+	}
+
+	defaultData := call(2, map[string]any{})
+	if gotQueries[0] != "limit=20" {
+		t.Fatalf("expected bounded default limit query, got %q", gotQueries[0])
+	}
+	conversations, _ := defaultData["conversations"].([]any)
+	if len(conversations) != 1 {
+		t.Fatalf("expected one conversation, got %+v", defaultData)
+	}
+	conversation, _ := conversations[0].(map[string]any)
+	if _, ok := conversation["raw"]; ok {
+		t.Fatalf("raw field should be absent by default: %+v", conversation)
+	}
+	if _, ok := conversation["_raw"]; ok {
+		t.Fatalf("_raw field should be absent by default: %+v", conversation)
+	}
+	participants, _ := conversation["participants"].([]any)
+	if len(participants) != 1 {
+		t.Fatalf("expected compact participants, got %+v", conversation)
+	}
+	lastPost, _ := conversation["lastPost"].(map[string]any)
+	if content, _ := lastPost["content"].(string); len([]rune(content)) > 500 {
+		t.Fatalf("expected bounded lastPost content, got %d runes", len([]rune(content)))
+	}
+
+	rawData := call(3, map[string]any{"limit": 200, "include_raw": true})
+	if gotQueries[1] != "limit=80" {
+		t.Fatalf("expected max bounded limit query, got %q", gotQueries[1])
+	}
+	rawConversations, _ := rawData["conversations"].([]any)
+	rawConversation, _ := rawConversations[0].(map[string]any)
+	if _, ok := rawConversation["_raw"].(map[string]any); !ok {
+		t.Fatalf("expected include_raw=true to expose _raw, got %+v", rawConversation)
 	}
 }
 

--- a/internal/mcpserver/identity_verify_tools.go
+++ b/internal/mcpserver/identity_verify_tools.go
@@ -48,6 +48,10 @@ func handleIdentityVerify(ctx context.Context, args json.RawMessage) (*mcpruntim
 	if resolvedIdentifier == "" {
 		return toolErrorResult("invalid_request", "identifier format is invalid for the selected channel", 400, nil)
 	}
+	if in.MessageID != "" {
+		return handleMessageScopedIdentityVerify(ctx, client, in.Channel, resolvedIdentifier, in.MessageID)
+	}
+
 	agent, channelsPayload, err := resolveIdentityForVerification(ctx, client, in.Channel, resolvedIdentifier)
 	if err != nil {
 		return identityToolResultFromError(err)
@@ -74,43 +78,74 @@ func handleIdentityVerify(ctx context.Context, args json.RawMessage) (*mcpruntim
 		}(),
 	}
 
-	if in.MessageID == "" {
-		return toolJSONResult(result, nil)
-	}
+	return toolJSONResult(result, nil)
+}
 
+func handleMessageScopedIdentityVerify(ctx context.Context, client *soulapi.Client, channel string, identifier string, messageID string) (*mcpruntime.ToolResult, error) {
 	token, err := requireOAuthBearer(ctx)
 	if err != nil {
 		return authToolResultFromError(err)
 	}
 
-	notification, err := findCommunicationNotification(ctx, token, in.MessageID)
+	message, source, err := findCommunicationMessage(ctx, token, messageID)
 	if err != nil {
-		return identityVerifyNotificationResultFromError(err)
+		return identityVerifyMessageResultFromError(err)
 	}
 
-	result["verificationScope"] = "message"
-	result["messageId"] = in.MessageID
-	if notification == nil {
+	result := map[string]any{
+		"channel":           channel,
+		"identifier":        identifier,
+		"verificationScope": "message",
+		"identityResolved":  false,
+		"verified":          false,
+		"messageId":         messageID,
+	}
+
+	if message == nil {
 		result["verified"] = false
 		result["messageFound"] = false
 		result["reason"] = "message_not_found"
 		return toolJSONResult(result, nil)
 	}
 
-	from := commFrom(notification)
-	match, matchedBy := verifySenderAgainstResolvedIdentity(agentID, in.Channel, resolvedIdentifier, channelsPayload, from)
+	from := commFrom(message)
 	result["messageFound"] = true
-	result["verified"] = match
-	result["message"] = map[string]any{
-		"messageId":      firstNonEmpty(in.MessageID, commMessageID(notification)),
-		"notificationId": strings.TrimSpace(stringFromMap(notification, "id")),
-		"channel":        notificationChannel(notification),
-		"from":           from,
-		"to":             commTo(notification),
-		"subject":        commSubject(notification),
-		"body":           commBody(notification),
-		"receivedAt":     commReceivedAt(notification),
+	result["message"] = communicationMessageSummary(message, messageID, source)
+
+	if channel == "email" || channel == "phone" {
+		agentID := firstSenderAgentID(from)
+		if agentID == "" {
+			result["reason"] = "message_lacks_authoritative_sender_provenance"
+			return toolJSONResult(result, nil)
+		}
+		if !senderIdentifierMatches(channel, identifier, from) {
+			result["reason"] = "sender_does_not_match_resolved_identity"
+			result["agent"] = map[string]any{"agentId": agentID}
+			result["identityResolved"] = true
+			return toolJSONResult(result, nil)
+		}
+		result["verified"] = true
+		result["identityResolved"] = true
+		result["agent"] = map[string]any{"agentId": agentID}
+		result["matchedBy"] = "message.from." + channel + "+sender.soulAgentId"
+		return toolJSONResult(result, nil)
 	}
+
+	agent, channelsPayload, err := resolveIdentityForVerification(ctx, client, channel, identifier)
+	if err != nil {
+		return identityToolResultFromError(err)
+	}
+	agentID := normalizeSoulAgentID(stringFromMap(agent, "agent_id"))
+	if agentID == "" {
+		return toolErrorResult("upstream_error", "resolved identity missing agent_id", 502, nil)
+	}
+
+	match, matchedBy := verifySenderAgainstResolvedIdentity(agentID, channel, identifier, channelsPayload, from)
+	result["identityResolved"] = true
+	result["verified"] = match
+	result["agent"] = summarizeResolvedAgent(agent)
+	result["channels"] = mapOrEmpty(channelsPayload, "channels")
+	result["contactPreferences"] = mapOrEmpty(channelsPayload, "contactPreferences")
 	if match {
 		result["matchedBy"] = matchedBy
 		return toolJSONResult(result, nil)
@@ -122,6 +157,31 @@ func handleIdentityVerify(ctx context.Context, args json.RawMessage) (*mcpruntim
 		result["reason"] = "sender_does_not_match_resolved_identity"
 	}
 	return toolJSONResult(result, nil)
+}
+
+func communicationMessageSummary(message map[string]any, requestedMessageID string, source string) map[string]any {
+	if message == nil {
+		return map[string]any{}
+	}
+	out := map[string]any{
+		"messageId":  firstNonEmpty(requestedMessageID, commMessageID(message), firstNonEmptyStringMap(message, "messageId", "messageRef", "deliveryId")),
+		"channel":    notificationChannel(message),
+		"from":       commFrom(message),
+		"to":         commTo(message),
+		"subject":    commSubject(message),
+		"body":       commBody(message),
+		"receivedAt": commReceivedAt(message),
+	}
+	if notificationID := strings.TrimSpace(stringFromMap(message, "id")); notificationID != "" {
+		out["notificationId"] = notificationID
+	}
+	if source != "" {
+		out["source"] = source
+	}
+	if ref := strings.TrimSpace(firstNonEmptyStringMap(message, "messageRef", "deliveryId", "hostMessageId")); ref != "" {
+		out["messageRef"] = ref
+	}
+	return out
 }
 
 func resolveIdentityForVerification(ctx context.Context, client *soulapi.Client, channel string, identifier string) (map[string]any, map[string]any, error) {
@@ -189,6 +249,62 @@ func findCommunicationNotification(ctx context.Context, bearerToken string, mess
 	return nil, nil
 }
 
+func findCommunicationMessage(ctx context.Context, bearerToken string, messageID string) (map[string]any, string, error) {
+	messageID = strings.TrimSpace(messageID)
+	if messageID == "" {
+		return nil, "", nil
+	}
+
+	if isHostMailboxMessageRef(messageID) {
+		message, err := findHostMailboxMessage(ctx, messageID)
+		if err != nil {
+			if isHostMailboxNotFound(err) {
+				return nil, "lesser-host-mailbox", nil
+			}
+			return nil, "lesser-host-mailbox", err
+		}
+		return message, "lesser-host-mailbox", nil
+	}
+
+	notification, err := findCommunicationNotification(ctx, bearerToken, messageID)
+	if err != nil {
+		return nil, "lesser-notification", err
+	}
+	return notification, "lesser-notification", nil
+}
+
+func findHostMailboxMessage(ctx context.Context, messageID string) (map[string]any, error) {
+	deps, err := loadCommMailboxDependencies(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out, err := getHostMailboxMessage(ctx, deps, messageID, false)
+	if err != nil {
+		return nil, err
+	}
+	message, _ := out["message"].(map[string]any)
+	if message == nil {
+		return nil, errors.New("unexpected mailbox message response")
+	}
+	return message, nil
+}
+
+func isHostMailboxMessageRef(messageID string) bool {
+	messageID = strings.ToLower(strings.TrimSpace(messageID))
+	return strings.HasPrefix(messageID, "comm-delivery-") ||
+		strings.HasPrefix(messageID, "delivery-") ||
+		strings.HasPrefix(messageID, "mailbox-") ||
+		strings.HasPrefix(messageID, "message-ref-")
+}
+
+func isHostMailboxNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	var apiErr *soulapi.APIError
+	return errors.As(err, &apiErr) && apiErr.Status == 404
+}
+
 func verifySenderAgainstResolvedIdentity(agentID string, channel string, identifier string, channelsPayload map[string]any, from map[string]any) (bool, string) {
 	expected := resolvedVerificationMarkers(agentID, channel, identifier, mapOrEmpty(channelsPayload, "channels"))
 	actual := senderVerificationMarkers(from)
@@ -245,6 +361,44 @@ func senderVerificationMarkers(from map[string]any) verificationMarkers {
 
 func senderHasAuthoritativeAgentID(from map[string]any) bool {
 	return len(senderVerificationMarkers(from).agentIDs) > 0
+}
+
+func firstSenderAgentID(from map[string]any) string {
+	markers := senderVerificationMarkers(from)
+	for agentID := range markers.agentIDs {
+		return agentID
+	}
+	return ""
+}
+
+func senderIdentifierMatches(channel string, identifier string, from map[string]any) bool {
+	if from == nil {
+		return false
+	}
+	switch channel {
+	case "email":
+		want := normalizeVerificationEmail(identifier)
+		for _, key := range []string{"address", "email", "identifier"} {
+			if normalizeVerificationEmail(stringFromMap(from, key)) == want {
+				return true
+			}
+		}
+	case "phone":
+		want := normalizeVerificationPhone(identifier)
+		for _, key := range []string{"phone", "number", "identifier"} {
+			if normalizeVerificationPhone(stringFromMap(from, key)) == want {
+				return true
+			}
+		}
+	case "ens":
+		want := normalizeVerificationENS(identifier)
+		for _, key := range []string{"ens", "name", "identifier"} {
+			if normalizeVerificationENS(stringFromMap(from, key)) == want {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func newVerificationMarkers() verificationMarkers {
@@ -346,9 +500,19 @@ func firstNonEmpty(values ...string) string {
 	return ""
 }
 
-func identityVerifyNotificationResultFromError(err error) (*mcpruntime.ToolResult, error) {
+func identityVerifyMessageResultFromError(err error) (*mcpruntime.ToolResult, error) {
 	if err == nil {
 		return toolErrorResult("upstream_error", "error", 500, nil)
+	}
+
+	var userErr *toolUserError
+	if errors.As(err, &userErr) {
+		return toolErrorResult(userErr.Code, userErr.Message, userErr.Status, userErr.Details)
+	}
+
+	var soulErr *soulapi.APIError
+	if errors.As(err, &soulErr) {
+		return commToolResultFromError(err)
 	}
 
 	var apiErr *lesserapi.APIError

--- a/internal/mcpserver/social_tools.go
+++ b/internal/mcpserver/social_tools.go
@@ -22,11 +22,13 @@ import (
 )
 
 const (
-	notificationCursorMemoryPrefix = "notification_cursor:"
-	notificationCursorMemoryTag    = "notification_cursor"
-	notificationReadDefaultLimit   = 30
-	notificationReadMaxLimit       = 80
-	notificationReadMaxTypes       = 8
+	notificationCursorMemoryPrefix  = "notification_cursor:"
+	notificationCursorMemoryTag     = "notification_cursor"
+	notificationReadDefaultLimit    = 30
+	notificationReadMaxLimit        = 80
+	notificationReadMaxTypes        = 8
+	notificationContentPreviewRunes = 500
+	notificationCommPreviewRunes    = 240
 )
 
 var notificationCursorEventIDs = struct {
@@ -366,14 +368,16 @@ func handleConversationsRead(ctx context.Context, args json.RawMessage) (*mcprun
 
 func handleNotificationsRead(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
 	var in struct {
-		Types  []string `json:"types,omitempty"`
-		Since  *string  `json:"since"`
-		Cursor string   `json:"cursor,omitempty"`
-		Limit  int      `json:"limit,omitempty"`
+		Types      []string `json:"types,omitempty"`
+		Since      *string  `json:"since"`
+		Cursor     string   `json:"cursor,omitempty"`
+		Limit      int      `json:"limit,omitempty"`
+		IncludeRaw bool     `json:"include_raw,omitempty"`
 	}
 	if err := json.Unmarshal(args, &in); err != nil {
 		return nil, invalidParams("invalid args: " + err.Error())
 	}
+	startedAt := time.Now()
 	requestedTypes, upstreamTypes, err := normalizeRequestedNotificationTypes(in.Types)
 	if err != nil {
 		return nil, err
@@ -398,12 +402,15 @@ func handleNotificationsRead(ctx context.Context, args json.RawMessage) (*mcprun
 		return nil, err
 	}
 
+	apiStartedAt := time.Now()
 	list, nextCursor, err := readSocialNotifications(ctx, client, token, upstreamTypes, limit, effectiveCursor)
+	apiDuration := time.Since(apiStartedAt)
 	if err != nil {
 		return authToolResultFromError(err)
 	}
 
-	notifications := socialNotificationsFromAPI(list)
+	normalizeStartedAt := time.Now()
+	notifications := socialNotificationsFromAPI(list, in.IncludeRaw)
 	if hasTemporalSince {
 		notifications = filterSocialNotificationsAfter(notifications, sinceTime)
 	}
@@ -433,7 +440,8 @@ func handleNotificationsRead(ctx context.Context, args json.RawMessage) (*mcprun
 		nextSince = sinceTime.Format(time.RFC3339Nano)
 	}
 
-	return toolJSONResult(map[string]any{
+	normalizeDuration := time.Since(normalizeStartedAt)
+	payload := map[string]any{
 		"since":         effectiveSince,
 		"cursor":        effectiveCursor,
 		"nextSince":     nextSince,
@@ -441,7 +449,17 @@ func handleNotificationsRead(ctx context.Context, args json.RawMessage) (*mcprun
 		"count":         len(notifications),
 		"types":         requestedTypes,
 		"notifications": notifications,
-	}, nil)
+		"includeRaw":    in.IncludeRaw,
+	}
+	attachNotificationReadDiagnostics(payload, notificationReadDiagnostics{
+		API:             apiDuration,
+		Normalize:       normalizeDuration,
+		Total:           time.Since(startedAt),
+		UpstreamCount:   len(list),
+		NormalizedCount: len(notifications),
+		RawIncluded:     in.IncludeRaw,
+	})
+	return toolJSONResult(payload, nil)
 }
 
 func handleNotificationDismiss(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
@@ -764,7 +782,8 @@ func notificationsReadDef() mcpruntime.ToolDef {
 				"types":{"type":"array","items":{"type":"string"}},
 				"since":{"type":"string"},
 				"cursor":{"type":"string"},
-				"limit":{"type":"integer","minimum":1,"maximum":80}
+				"limit":{"type":"integer","minimum":1,"maximum":80},
+				"include_raw":{"type":"boolean","description":"Include verbose upstream notification payloads under _raw for audit/debug use. Defaults to false and increases response size."}
 			}
 		}`),
 	}
@@ -1043,14 +1062,14 @@ func readSocialNotificationsByType(ctx context.Context, client *lesserapi.Client
 	return list, nextNotificationCursorFromHeaders(headers), nil
 }
 
-func socialNotificationsFromAPI(items []any) []any {
+func socialNotificationsFromAPI(items []any, includeRaw bool) []any {
 	out := make([]any, 0, len(items))
 	for _, item := range items {
 		raw, ok := item.(map[string]any)
 		if !ok || raw == nil {
 			continue
 		}
-		out = append(out, normalizeSocialNotification(raw))
+		out = append(out, normalizeSocialNotification(raw, includeRaw))
 	}
 	return out
 }
@@ -1109,11 +1128,67 @@ func sortSocialNotificationsNewestFirst(items []any) {
 	})
 }
 
-func normalizeSocialNotification(raw map[string]any) map[string]any {
+type notificationReadDiagnostics struct {
+	API             time.Duration
+	Normalize       time.Duration
+	Total           time.Duration
+	UpstreamCount   int
+	NormalizedCount int
+	RawIncluded     bool
+}
+
+func attachNotificationReadDiagnostics(payload map[string]any, d notificationReadDiagnostics) {
+	if payload == nil {
+		return
+	}
+
+	metrics := map[string]any{
+		"lesserAPIMs":      durationMillis(d.API),
+		"normalizationMs":  durationMillis(d.Normalize),
+		"marshalMs":        int64(0),
+		"totalMs":          durationMillis(d.Total),
+		"upstreamCount":    d.UpstreamCount,
+		"normalizedCount":  d.NormalizedCount,
+		"rawIncluded":      d.RawIncluded,
+		"responseBytes":    0,
+		"mcpPayloadBytes":  0,
+		"instrumentation":  "best_effort",
+		"sizeMeasurement":  "json_content_text_bytes; final MCP envelope measured before ToolResult wrapping",
+		"diagnosticFields": []string{"lesserAPIMs", "normalizationMs", "marshalMs", "responseBytes", "mcpPayloadBytes"},
+	}
+	payload["diagnostics"] = metrics
+
+	marshalStartedAt := time.Now()
+	if b, err := json.Marshal(payload); err == nil {
+		metrics["marshalMs"] = durationMillis(time.Since(marshalStartedAt))
+		metrics["responseBytes"] = len(b)
+	}
+	if b, err := json.Marshal(map[string]any{"content": payload, "structuredContent": map[string]any{"data": payload}}); err == nil {
+		metrics["mcpPayloadBytes"] = len(b)
+	}
+	if b, err := json.Marshal(payload); err == nil {
+		metrics["responseBytes"] = len(b)
+	}
+}
+
+func durationMillis(d time.Duration) int64 {
+	if d <= 0 {
+		return 0
+	}
+	ms := d.Round(time.Millisecond).Milliseconds()
+	if ms == 0 {
+		return 1
+	}
+	return ms
+}
+
+func normalizeSocialNotification(raw map[string]any, includeRaw bool) map[string]any {
 	out := map[string]any{
 		"id":   strings.TrimSpace(stringFromMap(raw, "id")),
 		"type": normalizeSocialNotificationType(raw),
-		"raw":  raw,
+	}
+	if includeRaw {
+		out["_raw"] = raw
 	}
 
 	if createdAt := firstNonEmptyStringMap(raw, "created_at", "createdAt"); createdAt != "" {
@@ -1124,6 +1199,9 @@ func normalizeSocialNotification(raw map[string]any) map[string]any {
 	}
 	if post := normalizeSocialNotificationPost(firstMap(raw, "status", "post", "targetPost")); post != nil {
 		out["targetPost"] = post
+	}
+	if comm := normalizeSocialNotificationCommunication(raw); comm != nil {
+		out["communication"] = comm
 	}
 
 	return out
@@ -1164,7 +1242,7 @@ func normalizeSocialNotificationPost(raw map[string]any) map[string]any {
 	out := map[string]any{}
 	putIfNotEmpty(out, "id", firstNonEmptyStringMap(raw, "id"))
 	putIfNotEmpty(out, "url", firstNonEmptyStringMap(raw, "url", "uri"))
-	putIfNotEmpty(out, "content", firstNonEmptyStringMap(raw, "content", "text"))
+	putIfNotEmpty(out, "content", compactString(firstNonEmptyStringMap(raw, "content", "text"), notificationContentPreviewRunes))
 	putIfNotEmpty(out, "createdAt", firstNonEmptyStringMap(raw, "created_at", "createdAt"))
 	putIfNotEmpty(out, "inReplyToId", firstNonEmptyStringMap(raw, "in_reply_to_id", "inReplyToId"))
 	putIfNotEmpty(out, "visibility", firstNonEmptyStringMap(raw, "visibility"))
@@ -1175,6 +1253,102 @@ func normalizeSocialNotificationPost(raw map[string]any) map[string]any {
 		return nil
 	}
 	return out
+}
+
+func normalizeSocialNotificationCommunication(raw map[string]any) map[string]any {
+	if raw == nil {
+		return nil
+	}
+	channel := notificationChannel(raw)
+	if channel == "" {
+		return nil
+	}
+
+	out := map[string]any{
+		"channel": channel,
+	}
+	putIfNotEmpty(out, "messageId", commMessageID(raw))
+	putIfNotEmpty(out, "subject", commSubject(raw))
+	putIfNotEmpty(out, "receivedAt", commReceivedAt(raw))
+	if from := compactCommunicationEndpoint(commFrom(raw)); from != nil {
+		out["from"] = from
+	}
+	if to := compactCommunicationAny(commTo(raw)); to != nil {
+		out["to"] = to
+	}
+	if preview := compactString(firstNonEmpty(commPreview(raw), commBody(raw)), notificationCommPreviewRunes); preview != "" {
+		out["preview"] = preview
+	}
+	return out
+}
+
+func commPreview(n map[string]any) string {
+	for _, key := range []string{"preview", "snippet", "summary"} {
+		if v, _ := n[key].(string); strings.TrimSpace(v) != "" {
+			return strings.TrimSpace(v)
+		}
+	}
+	for _, container := range []string{"communication", "data", "payload"} {
+		if m, ok := n[container].(map[string]any); ok {
+			for _, key := range []string{"preview", "snippet", "summary"} {
+				if v, _ := m[key].(string); strings.TrimSpace(v) != "" {
+					return strings.TrimSpace(v)
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func compactCommunicationEndpoint(raw map[string]any) map[string]any {
+	if raw == nil {
+		return nil
+	}
+	out := map[string]any{}
+	for _, key := range []string{"name", "address", "email", "phone", "number", "identifier", "soulAgentId", "soul_agent_id", "agentId", "agent_id"} {
+		putIfNotEmpty(out, key, firstNonEmptyStringMap(raw, key))
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func compactCommunicationAny(raw any) any {
+	switch v := raw.(type) {
+	case nil:
+		return nil
+	case map[string]any:
+		return compactCommunicationEndpoint(v)
+	case []any:
+		out := make([]any, 0, len(v))
+		for _, item := range v {
+			if compact := compactCommunicationAny(item); compact != nil {
+				out = append(out, compact)
+			}
+		}
+		if len(out) == 0 {
+			return nil
+		}
+		return out
+	default:
+		return v
+	}
+}
+
+func compactString(value string, maxRunes int) string {
+	value = strings.TrimSpace(value)
+	if value == "" || maxRunes <= 0 {
+		return value
+	}
+	runes := []rune(value)
+	if len(runes) <= maxRunes {
+		return value
+	}
+	if maxRunes <= 1 {
+		return string(runes[:maxRunes])
+	}
+	return string(runes[:maxRunes-1]) + "…"
 }
 
 func firstMap(raw map[string]any, keys ...string) map[string]any {

--- a/internal/mcpserver/social_tools.go
+++ b/internal/mcpserver/social_tools.go
@@ -29,6 +29,8 @@ const (
 	notificationReadMaxTypes        = 8
 	notificationContentPreviewRunes = 500
 	notificationCommPreviewRunes    = 240
+	conversationReadDefaultLimit    = 20
+	conversationReadMaxLimit        = 80
 )
 
 var notificationCursorEventIDs = struct {
@@ -339,11 +341,13 @@ func handleFollowingList(ctx context.Context, args json.RawMessage) (*mcpruntime
 
 func handleConversationsRead(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
 	var in struct {
-		Limit int `json:"limit,omitempty"`
+		Limit      int  `json:"limit,omitempty"`
+		IncludeRaw bool `json:"include_raw,omitempty"`
 	}
 	if err := json.Unmarshal(args, &in); err != nil {
 		return nil, invalidParams("invalid args: " + err.Error())
 	}
+	limit := boundedConversationReadLimit(in.Limit)
 
 	token, err := requireOAuthBearer(ctx)
 	if err != nil {
@@ -355,15 +359,23 @@ func handleConversationsRead(ctx context.Context, args json.RawMessage) (*mcprun
 	}
 
 	query := url.Values{}
-	if in.Limit > 0 {
-		query.Set("limit", strconv.Itoa(in.Limit))
-	}
+	query.Set("limit", strconv.Itoa(limit))
 
 	out, err := client.DoJSON(ctx, "GET", "/api/v1/conversations", query, token, nil)
 	if err != nil {
 		return authToolResultFromError(err)
 	}
-	return toolJSONResult(out, nil)
+	conversations, err := socialConversationsFromAPI(out, in.IncludeRaw)
+	if err != nil {
+		return nil, err
+	}
+	payload := map[string]any{
+		"conversations": conversations,
+		"count":         len(conversations),
+		"limit":         limit,
+		"includeRaw":    in.IncludeRaw,
+	}
+	return toolJSONResult(payload, nil)
 }
 
 func handleNotificationsRead(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
@@ -792,11 +804,12 @@ func notificationsReadDef() mcpruntime.ToolDef {
 func conversationsReadDef() mcpruntime.ToolDef {
 	return mcpruntime.ToolDef{
 		Name:        "conversations_read",
-		Description: "Read the authenticated agent's direct message conversations.",
+		Description: "Read compact, bounded direct message conversation summaries. Use include_raw only for audit/debug.",
 		InputSchema: json.RawMessage(`{
 			"type":"object",
 			"properties":{
-				"limit":{"type":"integer","minimum":1,"maximum":80}
+				"limit":{"type":"integer","minimum":1,"maximum":80},
+				"include_raw":{"type":"boolean","description":"Include verbose upstream conversation payloads under _raw. Defaults to false."}
 			}
 		}`),
 	}
@@ -981,6 +994,17 @@ func boundedNotificationReadLimit(limit int) int {
 	}
 }
 
+func boundedConversationReadLimit(limit int) int {
+	switch {
+	case limit <= 0:
+		return conversationReadDefaultLimit
+	case limit > conversationReadMaxLimit:
+		return conversationReadMaxLimit
+	default:
+		return limit
+	}
+}
+
 func readSocialNotifications(ctx context.Context, client *lesserapi.Client, token string, upstreamTypes []string, limit int, cursor string) ([]any, string, error) {
 	if client == nil {
 		return nil, "", fmt.Errorf("lesser api client not initialized")
@@ -1060,6 +1084,52 @@ func readSocialNotificationsByType(ctx context.Context, client *lesserapi.Client
 		return nil, "", fmt.Errorf("unexpected notifications response")
 	}
 	return list, nextNotificationCursorFromHeaders(headers), nil
+}
+
+func socialConversationsFromAPI(raw any, includeRaw bool) ([]any, error) {
+	items, ok := raw.([]any)
+	if !ok {
+		return nil, fmt.Errorf("unexpected conversations response")
+	}
+	out := make([]any, 0, len(items))
+	for _, item := range items {
+		conversation, ok := item.(map[string]any)
+		if !ok || conversation == nil {
+			continue
+		}
+		out = append(out, normalizeSocialConversation(conversation, includeRaw))
+	}
+	return out, nil
+}
+
+func normalizeSocialConversation(raw map[string]any, includeRaw bool) map[string]any {
+	out := map[string]any{
+		"id": strings.TrimSpace(stringFromMap(raw, "id")),
+	}
+	if includeRaw {
+		out["_raw"] = raw
+	}
+	if unread, ok := raw["unread"].(bool); ok {
+		out["unread"] = unread
+	}
+	if updatedAt := firstNonEmptyStringMap(raw, "updated_at", "updatedAt"); updatedAt != "" {
+		out["updatedAt"] = updatedAt
+	}
+	if accountsRaw, ok := raw["accounts"].([]any); ok {
+		accounts := make([]any, 0, len(accountsRaw))
+		for _, item := range accountsRaw {
+			if account := normalizeSocialNotificationActor(mapFromAny(item)); account != nil {
+				accounts = append(accounts, account)
+			}
+		}
+		if len(accounts) > 0 {
+			out["participants"] = accounts
+		}
+	}
+	if last := normalizeSocialNotificationPost(firstMap(raw, "last_status", "lastStatus", "lastPost")); last != nil {
+		out["lastPost"] = last
+	}
+	return out
 }
 
 func socialNotificationsFromAPI(items []any, includeRaw bool) []any {

--- a/scripts/m0_baseline_mcp_probe.py
+++ b/scripts/m0_baseline_mcp_probe.py
@@ -209,6 +209,107 @@ def read_count(data: dict[str, Any], key: str) -> int:
     return int(count) if isinstance(count, (int, float)) else 0
 
 
+def assert_verified_identity(data: dict[str, Any], context: str) -> None:
+    if data.get("verified") is not True:
+        reason = data.get("reason", "verified was not true")
+        raise ProbeError(f"{context} did not verify: {reason}")
+
+
+def assert_verified_message_identity(data: dict[str, Any], context: str) -> None:
+    if data.get("messageFound") is not True:
+        reason = data.get("reason", "messageFound was not true")
+        raise ProbeError(f"{context} did not find the message: {reason}")
+    assert_verified_identity(data, context)
+
+
+def assert_notification_baseline(data: dict[str, Any], context: str) -> None:
+    diagnostics = data.get("diagnostics")
+    if not isinstance(diagnostics, dict):
+        raise ProbeError(f"{context} missing notifications_read diagnostics")
+    missing = [
+        key
+        for key in ("lesserAPIMs", "normalizationMs", "responseBytes", "mcpPayloadBytes")
+        if key not in diagnostics
+    ]
+    if missing:
+        raise ProbeError(f"{context} diagnostics missing fields: {', '.join(missing)}")
+
+    notifications = data.get("notifications")
+    if not isinstance(notifications, list):
+        raise ProbeError(f"{context} missing notifications list")
+    for index, item in enumerate(notifications):
+        if not isinstance(item, dict):
+            continue
+        if "raw" in item or "_raw" in item:
+            raise ProbeError(f"{context} notification {index} exposed raw payload by default")
+
+
+def assert_mailbox_page_sane(data: dict[str, Any], context: str) -> None:
+    messages = data.get("messages")
+    if not isinstance(messages, list):
+        raise ProbeError(f"{context} missing messages list")
+    count = read_count(data, "messages")
+    has_more = data.get("hasMore") is True
+    next_cursor = str(data.get("nextCursor", "")).strip()
+    if has_more and count == 0:
+        raise ProbeError(f"{context} returned count=0 with hasMore=true")
+    if has_more and not next_cursor:
+        raise ProbeError(f"{context} returned hasMore=true without nextCursor")
+
+
+def probe_verified_identity(name: str, channel: str, identifier: str, message_id: str = "") -> None:
+    args = {"channel": channel, "identifier": identifier}
+    if message_id:
+        args["messageId"] = message_id
+    result, data, elapsed, size = tool("identity_verify", args)
+    assert_tool_ok(result)
+    if message_id:
+        assert_verified_message_identity(data, name)
+    else:
+        assert_verified_identity(data, name)
+    details = {
+        "verified": data.get("verified"),
+        "matchedBy": data.get("matchedBy"),
+    }
+    message = data.get("message")
+    if isinstance(message, dict):
+        details["messageSource"] = message.get("source")
+    record(name, "pass", elapsed, size, **details)
+
+
+def probe_notifications_read(name: str, args: dict[str, Any]) -> None:
+    result, data, elapsed, size = tool("notifications_read", args)
+    assert_tool_ok(result)
+    assert_notification_baseline(data, name)
+    diagnostics = data.get("diagnostics")
+    details: dict[str, Any] = {
+        "count": read_count(data, "notifications"),
+    }
+    if isinstance(diagnostics, dict):
+        details["diagnostics"] = {
+            k: diagnostics.get(k)
+            for k in ("lesserAPIMs", "normalizationMs", "responseBytes", "mcpPayloadBytes")
+            if k in diagnostics
+        }
+    record(name, "pass", elapsed, size, **details)
+
+
+def probe_mailbox_read(name: str, tool_name: str, args: dict[str, Any]) -> tuple[dict[str, Any], int, int]:
+    result, data, elapsed, size = tool(tool_name, args)
+    assert_tool_ok(result)
+    assert_mailbox_page_sane(data, name)
+    record(
+        name,
+        "pass",
+        elapsed,
+        size,
+        count=read_count(data, "messages"),
+        hasMore=data.get("hasMore"),
+        nextCursor=bool(str(data.get("nextCursor", "")).strip()),
+    )
+    return data, elapsed, size
+
+
 def notification_since_default() -> str:
     return (dt.datetime.now(dt.UTC) - dt.timedelta(hours=24)).isoformat().replace("+00:00", "Z")
 
@@ -254,7 +355,7 @@ def main() -> int:
 
     ens = env("PROBE_ENS")
     if ens:
-        run_probe("identity_verify ENS identifier", lambda: probe_tool_success("identity_verify ENS identifier", "identity_verify", {"channel": "ens", "identifier": ens}))
+        run_probe("identity_verify ENS identifier", lambda: probe_verified_identity("identity_verify ENS identifier", "ens", ens))
     else:
         skip("identity_verify ENS identifier", "missing PROBE_ENS")
 
@@ -272,29 +373,40 @@ def main() -> int:
     message_ref = env("PROBE_MESSAGE_REF")
     if message_ref:
         if ens:
-            run_probe("identity_verify ENS messageRef", lambda: probe_tool_success("identity_verify ENS messageRef", "identity_verify", {"channel": "ens", "identifier": ens, "messageId": message_ref}))
+            run_probe("identity_verify ENS messageRef", lambda: probe_verified_identity("identity_verify ENS messageRef", "ens", ens, message_ref))
         for channel, env_name in [("email", "PROBE_EMAIL"), ("phone", "PROBE_PHONE")]:
             value = env(env_name)
             if value:
-                run_probe(f"identity_verify {channel} messageRef", lambda channel=channel, value=value: probe_tool_success(f"identity_verify {channel} messageRef", "identity_verify", {"channel": channel, "identifier": value, "messageId": message_ref}))
+                run_probe(
+                    f"identity_verify {channel} messageRef",
+                    lambda channel=channel, value=value: probe_verified_identity(
+                        f"identity_verify {channel} messageRef", channel, value, message_ref
+                    ),
+                )
     else:
         skip("identity_verify messageRef", "missing PROBE_MESSAGE_REF")
 
-    probe_tool_success("notifications_read limit=20", "notifications_read", {"limit": 20}, "notifications")
-    probe_tool_success("notifications_read since empty limit=30", "notifications_read", {"since": "", "limit": 30}, "notifications")
+    run_probe("notifications_read limit=20", lambda: probe_notifications_read("notifications_read limit=20", {"limit": 20}))
+    run_probe(
+        "notifications_read since empty limit=30",
+        lambda: probe_notifications_read("notifications_read since empty limit=30", {"since": "", "limit": 30}),
+    )
     since = env("PROBE_NOTIFICATION_SINCE", notification_since_default())
     for typ in ("mention", "reply"):
-        probe_tool_success(f"notifications_read {typ} timestamp", "notifications_read", {"since": since, "limit": 30, "types": [typ]}, "notifications")
+        run_probe(
+            f"notifications_read {typ} timestamp",
+            lambda typ=typ: probe_notifications_read(
+                f"notifications_read {typ} timestamp", {"since": since, "limit": 30, "types": [typ]}
+            ),
+        )
 
     inbox_message_id = ""
     for folder in ("inbox", "sent"):
         def email_read(folder: str = folder) -> None:
             nonlocal inbox_message_id
-            result, data, elapsed, size = tool("email_read", {"folder": folder, "limit": 20})
-            assert_tool_ok(result)
+            data, elapsed, size = probe_mailbox_read(f"email_read {folder} limit=20", "email_read", {"folder": folder, "limit": 20})
             if folder == "inbox":
                 inbox_message_id = first_message_id(data)
-            record(f"email_read {folder} limit=20", "pass", elapsed, size, count=read_count(data, "messages"), firstMessage=bool(first_message_id(data)))
         run_probe(f"email_read {folder} limit=20", email_read)
 
     if inbox_message_id:
@@ -312,8 +424,8 @@ def main() -> int:
     else:
         skip("self-email send/search/readback", "set PROBE_SAFE_SEND_EMAIL=true to run")
 
-    probe_tool_success("sms_read limit=20", "sms_read", {"limit": 20}, "messages")
-    probe_tool_success("voicemail_read limit=20", "voicemail_read", {"limit": 20}, "messages")
+    run_probe("sms_read limit=20", lambda: probe_mailbox_read("sms_read limit=20", "sms_read", {"limit": 20}))
+    run_probe("voicemail_read limit=20", lambda: probe_mailbox_read("voicemail_read limit=20", "voicemail_read", {"limit": 20}))
 
     event_id = "01" + uuid.uuid4().hex[:24].upper()
     run_probe("memory_append", lambda: probe_tool_success("memory_append", "memory_append", {"event_id": event_id, "content": "M0 baseline probe memory event", "tags": ["m0-probe"]}))

--- a/scripts/m0_baseline_mcp_probe.py
+++ b/scripts/m0_baseline_mcp_probe.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python3
+"""Run the Project 21 M0 baseline MCP usability probe.
+
+Required environment:
+  MCP_ENDPOINT        Actor-scoped endpoint, e.g. https://api.dev.example.com/mcp/agent
+  MCP_BEARER_TOKEN   OAuth token for that actor (or MCP_AUTHORIZATION="Bearer ...")
+
+Recommended probe inputs:
+  PROBE_LOCAL_ID              Current-instance local id for identity_lookup
+  PROBE_ENS                   ENS name for identity_lookup / identity_verify
+  PROBE_REMOTE_AP_HANDLE      Remote ActivityPub handle, e.g. @user@example.social
+  PROBE_ACTOR_URL             Canonical remote actor URL
+  PROBE_EMAIL                 Sender email for fail-closed and message-scoped verification
+  PROBE_PHONE                 Sender phone for fail-closed and message-scoped verification
+  PROBE_MESSAGE_REF           Host mailbox messageRef / comm-delivery-* for identity_verify
+  PROBE_NOTIFICATION_SINCE    RFC3339 timestamp for typed notification reads (default: now-24h)
+  PROBE_SAFE_SEND_EMAIL       Set true to run self-email send/search/readback
+  PROBE_SELF_EMAIL_TO         Recipient for the safe self-email send
+
+The script prints only probe status, timing, sizes, and compact metadata. It never prints bearer tokens,
+message bodies, full tool JSON, or full recipient lists.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import os
+import sys
+import time
+import uuid
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from typing import Any
+
+
+class ProbeError(RuntimeError):
+    pass
+
+
+def env(name: str, default: str = "") -> str:
+    return os.environ.get(name, default).strip()
+
+
+def require_env(name: str) -> str:
+    value = env(name)
+    if not value:
+        raise ProbeError(f"{name} is required")
+    return value
+
+
+ENDPOINT = require_env("MCP_ENDPOINT")
+AUTHORIZATION = env("MCP_AUTHORIZATION")
+if not AUTHORIZATION:
+    token = require_env("MCP_BEARER_TOKEN")
+    AUTHORIZATION = "Bearer " + token
+
+
+@dataclass
+class ProbeResult:
+    name: str
+    status: str
+    elapsed_ms: int = 0
+    response_bytes: int = 0
+    details: dict[str, Any] = field(default_factory=dict)
+
+
+results: list[ProbeResult] = []
+_session_id = ""
+_next_id = 1
+
+
+def redact(value: str) -> str:
+    value = value.strip()
+    if not value:
+        return ""
+    if "@" in value:
+        local, _, domain = value.partition("@")
+        return (local[:2] + "…@" + domain) if local else "…@" + domain
+    if value.startswith("+") and len(value) > 5:
+        return value[:3] + "…" + value[-2:]
+    if len(value) > 16:
+        return value[:8] + "…" + value[-4:]
+    return value
+
+
+def rpc(method: str, params: dict[str, Any] | None = None) -> tuple[dict[str, Any], int, int]:
+    global _next_id, _session_id
+    request_id = _next_id
+    _next_id += 1
+    payload = {"jsonrpc": "2.0", "id": request_id, "method": method}
+    if params is not None:
+        payload["params"] = params
+    body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+        "Authorization": AUTHORIZATION,
+    }
+    if _session_id:
+        headers["Mcp-Session-Id"] = _session_id
+    req = urllib.request.Request(ENDPOINT, data=body, headers=headers, method="POST")
+    started = time.perf_counter()
+    try:
+        with urllib.request.urlopen(req, timeout=130) as resp:
+            raw = resp.read()
+            if resp.headers.get("Mcp-Session-Id"):
+                _session_id = resp.headers["Mcp-Session-Id"].strip()
+            status = resp.status
+    except urllib.error.HTTPError as exc:
+        raw = exc.read()
+        status = exc.code
+    elapsed_ms = round((time.perf_counter() - started) * 1000)
+    try:
+        parsed = json.loads(raw.decode("utf-8")) if raw else {}
+    except json.JSONDecodeError as exc:
+        raise ProbeError(f"{method} returned non-JSON HTTP {status}: {exc}") from exc
+    return parsed, elapsed_ms, len(raw)
+
+
+def tool_result(parsed: dict[str, Any]) -> dict[str, Any]:
+    if parsed.get("error"):
+        raise ProbeError(f"JSON-RPC error: {parsed['error']}")
+    result = parsed.get("result")
+    if not isinstance(result, dict):
+        raise ProbeError(f"missing tool result: {parsed}")
+    return result
+
+
+def structured(result: dict[str, Any]) -> dict[str, Any]:
+    value = result.get("structuredContent")
+    if not isinstance(value, dict):
+        return {}
+    data = value.get("data")
+    if isinstance(data, dict):
+        return data
+    return value
+
+
+def tool(name: str, arguments: dict[str, Any] | None = None) -> tuple[dict[str, Any], dict[str, Any], int, int]:
+    parsed, elapsed_ms, size = rpc("tools/call", {"name": name, "arguments": arguments or {}})
+    result = tool_result(parsed)
+    return result, structured(result), elapsed_ms, size
+
+
+def record(name: str, status: str, elapsed_ms: int = 0, response_bytes: int = 0, **details: Any) -> None:
+    clean = {k: v for k, v in details.items() if v not in (None, "", [], {})}
+    results.append(ProbeResult(name=name, status=status, elapsed_ms=elapsed_ms, response_bytes=response_bytes, details=clean))
+    suffix = ""
+    if clean:
+        suffix = " " + json.dumps(clean, sort_keys=True, separators=(",", ":"))
+    print(f"{status.upper():7} {name:48} {elapsed_ms:5d}ms {response_bytes:7d}B{suffix}")
+
+
+def run_probe(name: str, fn) -> None:  # type: ignore[no-untyped-def]
+    try:
+        fn()
+    except ProbeError as exc:
+        record(name, "fail", error=str(exc))
+    except Exception as exc:  # noqa: BLE001 - top-level probe isolation
+        record(name, "fail", error=f"{type(exc).__name__}: {exc}")
+
+
+def skip(name: str, reason: str) -> None:
+    record(name, "skip", reason=reason)
+
+
+def require_input(probe_name: str, env_name: str) -> str | None:
+    value = env(env_name)
+    if not value:
+        skip(probe_name, f"missing {env_name}")
+        return None
+    return value
+
+
+def assert_tool_ok(result: dict[str, Any]) -> None:
+    if result.get("isError") is True:
+        raise ProbeError(f"tool returned isError: {structured(result).get('error', {})}")
+
+
+def expect_tool_error_code(result: dict[str, Any], want_code: str) -> None:
+    if result.get("isError") is not True:
+        raise ProbeError(f"expected tool error {want_code}, got success")
+    err = structured(result).get("error")
+    if not isinstance(err, dict) or err.get("code") != want_code:
+        raise ProbeError(f"expected tool error {want_code}, got {err}")
+
+
+def first_message_id(data: dict[str, Any]) -> str:
+    messages = data.get("messages")
+    if not isinstance(messages, list) or not messages:
+        return ""
+    first = messages[0]
+    if not isinstance(first, dict):
+        return ""
+    for key in ("messageId", "messageRef", "deliveryId"):
+        value = str(first.get(key, "")).strip()
+        if value:
+            return value
+    return ""
+
+
+def read_count(data: dict[str, Any], key: str) -> int:
+    value = data.get(key)
+    if isinstance(value, list):
+        return len(value)
+    count = data.get("count")
+    return int(count) if isinstance(count, (int, float)) else 0
+
+
+def notification_since_default() -> str:
+    return (dt.datetime.now(dt.UTC) - dt.timedelta(hours=24)).isoformat().replace("+00:00", "Z")
+
+
+def init() -> None:
+    parsed, elapsed, size = rpc("initialize", {"protocolVersion": "2025-06-18", "capabilities": {}, "clientInfo": {"name": "lesser-body-m0-probe", "version": "1"}})
+    if parsed.get("error"):
+        raise ProbeError(f"initialize failed: {parsed['error']}")
+    record("initialize", "pass", elapsed, size, session=bool(_session_id))
+
+
+def probe_tool_success(name: str, tool_name: str, args: dict[str, Any] | None = None, count_key: str = "") -> None:
+    result, data, elapsed, size = tool(tool_name, args)
+    assert_tool_ok(result)
+    details: dict[str, Any] = {}
+    if count_key:
+        details["count"] = read_count(data, count_key)
+    diagnostics = data.get("diagnostics")
+    if isinstance(diagnostics, dict):
+        details["diagnostics"] = {k: diagnostics.get(k) for k in ("lesserAPIMs", "normalizationMs", "responseBytes", "mcpPayloadBytes") if k in diagnostics}
+    record(name, "pass", elapsed, size, **details)
+
+
+def main() -> int:
+    print("Project 21 M0 baseline MCP usability probe")
+    print(f"endpoint={ENDPOINT}")
+    run_probe("initialize", init)
+    if not _session_id:
+        print("initialize failed before session establishment", file=sys.stderr)
+        return 1
+
+    probe_tool_success("identity_whoami", "identity_whoami")
+
+    for probe_name, env_name in [
+        ("identity_lookup local ID", "PROBE_LOCAL_ID"),
+        ("identity_lookup ENS", "PROBE_ENS"),
+        ("identity_lookup remote AP handle", "PROBE_REMOTE_AP_HANDLE"),
+        ("identity_lookup actor URL", "PROBE_ACTOR_URL"),
+    ]:
+        value = require_input(probe_name, env_name)
+        if value:
+            run_probe(probe_name, lambda value=value, probe_name=probe_name: probe_tool_success(probe_name, "identity_lookup", {"query": value}, "matches"))
+
+    ens = env("PROBE_ENS")
+    if ens:
+        run_probe("identity_verify ENS identifier", lambda: probe_tool_success("identity_verify ENS identifier", "identity_verify", {"channel": "ens", "identifier": ens}))
+    else:
+        skip("identity_verify ENS identifier", "missing PROBE_ENS")
+
+    for channel, env_name in [("email", "PROBE_EMAIL"), ("phone", "PROBE_PHONE")]:
+        value = env(env_name)
+        if not value:
+            skip(f"identity_verify {channel} fail-closed", f"missing {env_name}")
+            continue
+        def fail_closed(channel: str = channel, value: str = value) -> None:
+            result, _data, elapsed, size = tool("identity_verify", {"channel": channel, "identifier": value})
+            expect_tool_error_code(result, "private_reachability_unavailable")
+            record(f"identity_verify {channel} fail-closed", "pass", elapsed, size, identifier=redact(value))
+        run_probe(f"identity_verify {channel} fail-closed", fail_closed)
+
+    message_ref = env("PROBE_MESSAGE_REF")
+    if message_ref:
+        if ens:
+            run_probe("identity_verify ENS messageRef", lambda: probe_tool_success("identity_verify ENS messageRef", "identity_verify", {"channel": "ens", "identifier": ens, "messageId": message_ref}))
+        for channel, env_name in [("email", "PROBE_EMAIL"), ("phone", "PROBE_PHONE")]:
+            value = env(env_name)
+            if value:
+                run_probe(f"identity_verify {channel} messageRef", lambda channel=channel, value=value: probe_tool_success(f"identity_verify {channel} messageRef", "identity_verify", {"channel": channel, "identifier": value, "messageId": message_ref}))
+    else:
+        skip("identity_verify messageRef", "missing PROBE_MESSAGE_REF")
+
+    probe_tool_success("notifications_read limit=20", "notifications_read", {"limit": 20}, "notifications")
+    probe_tool_success("notifications_read since empty limit=30", "notifications_read", {"since": "", "limit": 30}, "notifications")
+    since = env("PROBE_NOTIFICATION_SINCE", notification_since_default())
+    for typ in ("mention", "reply"):
+        probe_tool_success(f"notifications_read {typ} timestamp", "notifications_read", {"since": since, "limit": 30, "types": [typ]}, "notifications")
+
+    inbox_message_id = ""
+    for folder in ("inbox", "sent"):
+        def email_read(folder: str = folder) -> None:
+            nonlocal inbox_message_id
+            result, data, elapsed, size = tool("email_read", {"folder": folder, "limit": 20})
+            assert_tool_ok(result)
+            if folder == "inbox":
+                inbox_message_id = first_message_id(data)
+            record(f"email_read {folder} limit=20", "pass", elapsed, size, count=read_count(data, "messages"), firstMessage=bool(first_message_id(data)))
+        run_probe(f"email_read {folder} limit=20", email_read)
+
+    if inbox_message_id:
+        run_probe("email_get_content listed message", lambda: probe_tool_success("email_get_content listed message", "email_get_content", {"messageId": inbox_message_id}))
+    else:
+        skip("email_get_content listed message", "email_read inbox returned no messageId")
+
+    if env("PROBE_SAFE_SEND_EMAIL").lower() == "true":
+        to = require_input("self-email send/search/readback", "PROBE_SELF_EMAIL_TO")
+        if to:
+            message_id = "m0-probe-" + uuid.uuid4().hex
+            subject = "lesser-body M0 baseline probe " + message_id[-8:]
+            run_probe("self-email send", lambda: probe_tool_success("self-email send", "email_send", {"to": to, "subject": subject, "body": "M0 baseline probe self-email.", "messageId": message_id}))
+            run_probe("self-email search/readback", lambda: probe_tool_success("self-email search/readback", "email_search", {"query": subject, "limit": 5}, "messages"))
+    else:
+        skip("self-email send/search/readback", "set PROBE_SAFE_SEND_EMAIL=true to run")
+
+    probe_tool_success("sms_read limit=20", "sms_read", {"limit": 20}, "messages")
+    probe_tool_success("voicemail_read limit=20", "voicemail_read", {"limit": 20}, "messages")
+
+    event_id = "01" + uuid.uuid4().hex[:24].upper()
+    run_probe("memory_append", lambda: probe_tool_success("memory_append", "memory_append", {"event_id": event_id, "content": "M0 baseline probe memory event", "tags": ["m0-probe"]}))
+    probe_tool_success("memory_query", "memory_query", {"query": "M0 baseline probe", "limit": 5}, "events")
+
+    probe_tool_success("conversations_read", "conversations_read", {"limit": 20}, "conversations")
+    probe_tool_success("timeline_read home", "timeline_read", {"timeline": "home", "limit": 20})
+
+    failed = sum(1 for r in results if r.status == "fail")
+    skipped = sum(1 for r in results if r.status == "skip")
+    passed = sum(1 for r in results if r.status == "pass")
+    summary = {"passed": passed, "failed": failed, "skipped": skipped, "results": [r.__dict__ for r in results]}
+    print("SUMMARY " + json.dumps(summary, sort_keys=True, separators=(",", ":")))
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except ProbeError as exc:
+        print(f"probe setup failed: {exc}", file=sys.stderr)
+        raise SystemExit(2)


### PR DESCRIPTION
## Milestone
Project 21 / #161 M0 continuation — finish baseline operability fixes for #163-#166.

## Classification
MCP-contract, tool-surface, lesser-integration, host-delegation-preserving, operational-reliability, docs, test-coverage.

## Surfaces affected
- `internal/mcpserver/social_tools.go`: compact `notifications_read`, bounded `conversations_read`, `include_raw` opt-ins, notification diagnostics.
- `internal/mcpserver/identity_verify_tools.go`: host mailbox `messageRef` provenance path for message-scoped verification.
- `internal/mcpapp/*_test.go`: regression coverage for notification raw omission, conversation bounds, and Host mailbox identity verification.
- `docs/mcp.md`, `docs/m0-baseline-probe.md`, `docs/README.md`: baseline payload policy and Ops probe runbook.
- `scripts/m0_baseline_mcp_probe.py`: post-deploy MCP usability probe with semantic success assertions.

## Specialist walks referenced
- Tool surface: modifies existing `notifications_read`, `conversations_read`, and `identity_verify`; no new tools; no scope/profile changes; static registration preserved.
- MCP contract: additive optional `include_raw` params and additional compact/diagnostic fields; default notification/conversation payloads remove default raw/debug bloat by design for M0 operability; JSON-RPC envelope unchanged.
- Lesser integration: existing Lesser `/api/v1/notifications` and `/api/v1/conversations` consumption preserved; no new Lesser endpoint or SSM/JWT/deploy-order changes.
- Host delegation: `identity_verify` uses lesser-host mailbox metadata for canonical host refs via existing `LESSER_HOST_INSTANCE_KEY`; no delivery bypass and no raw credential logging.
- Framework: idiomatic AppTheory MCP result/tool schema usage; no framework patches.

## Consumer impact
- `notifications_read` defaults are leaner: no full upstream `raw`; `include_raw: true` returns `_raw` intentionally.
- `notifications_read` now includes best-effort diagnostics for Lesser API latency, normalization time, and payload size.
- `conversations_read` now has a bounded default (`limit=20`, max `80`) and compact summaries; `include_raw: true` restores upstream payloads under `_raw`.
- `identity_verify(..., messageId=<comm-delivery-*>)` verifies against host mailbox message provenance where `from.soulAgentId` is authoritative.
- General email/phone identity verification without `messageId` still fails closed with `private_reachability_unavailable`.

## Tasks
- [x] #163 — compact `notifications_read` defaults and instrument latency/size.
- [x] #164 — verify Host mailbox messageRefs in `identity_verify`.
- [x] #165 — establish core read-tool payload budgets and bounded defaults.
- [x] #166 — add post-deploy Ops baseline probe tooling/runbook with semantic success checks. Actual probe execution remains a deploy/Ops closure gate after this PR is deployed.

## Validation
- [x] Baseline on `main` before branching: `go test ./...`
- [x] Baseline on `main` before branching: `go vet ./...`
- [x] Baseline on `main` before branching: `gofmt -l $(git ls-files '*.go')` empty
- [x] Baseline on `main` before branching: `scripts/build.sh`
- [x] #163 targeted: `go test ./internal/mcpapp -run 'TestM5_ToolsListContainsCoreTools|TestM5_NotificationsReadReturnsStructuredNotifications|TestM5_NotificationsReadOmitsRawByDefaultAndExposesDiagnostics|TestM5_NotificationsReadTimestampSinceFiltersRecentRemoteCreates|TestM5_NotificationCursorSemantics'`
- [x] #164 targeted: `go test ./internal/mcpapp -run 'TestLBM1_IdentityToolsAndChannelResources'`
- [x] #165 targeted: `go test ./internal/mcpapp -run 'TestM5_ConversationsReadUsesCompactBoundedDefaults|TestM5_NotificationsReadOmitsRawByDefaultAndExposesDiagnostics|TestLBM3_InboxToolsUseHostMailbox|TestLBM1_MemoryToolsUseFlatStructuredContent'`
- [x] #166 targeted: `python3 -m py_compile scripts/m0_baseline_mcp_probe.py`
- [x] Review fix targeted: `python3 -m py_compile scripts/m0_baseline_mcp_probe.py`
- [x] Review fix targeted: `git diff --check`
- [x] Review fix targeted: `go test ./...`
- [x] Review fix targeted: `go vet ./...`
- [x] Final: `git diff --check`
- [x] Final: `python3 -m py_compile scripts/m0_baseline_mcp_probe.py`
- [x] Final: `go test ./...`
- [x] Final: `go vet ./...`
- [x] Final: `gofmt -l $(git ls-files '*.go')` empty
- [x] Final: `scripts/build.sh`
- [x] Additional: `cd cdk && go test ./...`

## Stage rollout plan (handoff to deploy-body)
- [ ] Merged to main
- [ ] Deployed to lab / dev
- [ ] Run `scripts/m0_baseline_mcp_probe.py` with Ops fixtures
- [ ] Lab/Ops probe evidence attached to #166 / Project 21
- [ ] Lab soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
- No Lesser code changes required; this preserves existing Lesser notification/conversation endpoints.
- No lesser-host code changes required; body consumes existing host mailbox metadata endpoint with the existing instance-key delegation contract.
- #166 cannot be fully accepted until post-deploy Ops probe evidence is collected.

## Advisor-brief authorization
Not applicable; Aron-directed GitHub Project work.
