### PR TITLE
fix(notifications): preserve read state in MCP output

### DIFF
--- a/docs/m0-baseline-probe.md
+++ b/docs/m0-baseline-probe.md
@@ -39,6 +39,8 @@ export PROBE_LESSER_API_BASE_URL='https://api.<stage-domain>'
 # Optional: target a specific list-returned ID or run one workflow per type filter.
 export PROBE_NOTIFICATION_WORKFLOW_ID='notification-id-from-list'
 export PROBE_NOTIFICATION_WORKFLOW_TYPES='mention,reply'
+# Future-only: set true only when the probe intentionally uses an explicit unread-only notification view.
+export PROBE_NOTIFICATION_WORKFLOW_UNREAD_ONLY_VIEW=false
 # Optional wrong-user negative controls, where a safe second actor token is available.
 export PROBE_WRONG_USER_BEARER_TOKEN='<OAuth token for a different actor>'
 ```
@@ -62,8 +64,9 @@ The probe treats semantic failure payloads as failures, not successful MCP trans
   `hasMore:true` page must include `nextCursor`.
 - when `PROBE_M0_CLOSURE=true`, a list-returned notification ID must pass the semantic workflow
   list -> same-user single-get -> optional wrong-user negative control -> MCP `notification_dismiss` ->
-  follow-up list/read-state. A 404 or semantic error in the same-user state transition remains a failure; the probe does
-  not add body-side fallback behavior for `lesser#944`.
+  follow-up list/read-state. Under the current all-notifications default, if the same notification ID remains visible in
+  `notifications_read`, it must expose `read:true`. A 404 or semantic error in the same-user state transition remains a
+  failure; the probe does not add body-side fallback behavior for `lesser#944`.
 
 ## Required evidence
 
@@ -76,7 +79,8 @@ The report must include:
 - whether default notification output omitted raw/debug payloads;
 - whether the run is smoke-only or closure-mode (`SUMMARY.mode` and `SUMMARY.closureReady`);
 - for closure-mode runs, notification workflow details: selected notification type/id (redacted), direct Lesser
-  single-get status, MCP dismiss result, follow-up list/read-state evidence, and whether wrong-user negative controls ran;
+  single-get status, MCP dismiss result, follow-up `notifications_read` `read` state, direct follow-up read-state
+  evidence, and whether wrong-user negative controls ran;
 - whether failures appear to be Lesser API latency, body shaping/serialization, or MCP transport timeout.
 
 ## Closure expectations
@@ -88,7 +92,8 @@ M0 is not closed until Ops reports repeatable baseline usability in the deployed
 - email/SMS/voicemail filtered pagination is sane;
 - identity lookup/verify and timestamp-since notification reads do not regress;
 - no baseline read-tool output is truncated under realistic mailbox/notification state;
-- `SUMMARY.closureReady` is `true` from a closure-mode run after `lesser#944` is merged and deployed.
+- `SUMMARY.closureReady` is `true` from a closure-mode run after `lesser#944` is merged and deployed, with same-ID
+  `notifications_read` follow-up showing `read:true` under the current all-notifications default.
 
 Smoke/read-surface runs without `PROBE_M0_CLOSURE=true` are useful deploy evidence, but they are not M0 closure. They
 should be attached as smoke evidence and followed by a closure-mode run once Lesser's user-scoped canonical notification

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -312,8 +312,9 @@ Notes:
   `since` values remain a legacy cursor alias for compatibility, but new callers should not rely on that path.
 - `notifications_read` omits full upstream `raw` notification objects by default and accepts optional
   `include_raw=true`, which returns `_raw` on each notification for expensive audit/debug use. Default notifications
-  contain compact `actor`, bounded `targetPost`, optional bounded `communication` summaries, cursor/since metadata, and
-  best-effort `diagnostics` timing/size fields for Ops probes.
+  contain compact `actor`, bounded `targetPost`, optional bounded `communication` summaries, normalized read state
+  (`read` when Lesser exposes it, inferred from `unread` where needed), cursor/since metadata, and best-effort
+  `diagnostics` timing/size fields for Ops probes.
 - `conversations_read` defaults to `limit=20` (maximum `80`) and returns compact conversation summaries: id, unread
   state, updated timestamp, compact participants, and bounded `lastPost`. It accepts optional `include_raw=true`, which
   returns `_raw` for audit/debug use.

--- a/internal/mcpapp/social_tools_test.go
+++ b/internal/mcpapp/social_tools_test.go
@@ -868,6 +868,95 @@ func TestM5_NotificationsReadOmitsRawByDefaultAndExposesDiagnostics(t *testing.T
 	}
 }
 
+func TestM5_NotificationsReadPreservesReadState(t *testing.T) {
+	t.Setenv("MCP_SESSION_TABLE", "")
+	t.Setenv("JWT_SECRET", "test")
+	auth.ResetForTests()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/api/v1/notifications" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[
+			{"id":"n-unread","type":"mention","read":false,"created_at":"2026-05-11T02:00:00Z","account":{"id":"acct-1","acct":"alice@example.com"},"status":{"id":"post-1","content":"hello","visibility":"public"}},
+			{"id":"n-read","type":"reply","read":true,"read_at":"2026-05-11T02:05:00Z","created_at":"2026-05-11T02:04:00Z","account":{"id":"acct-2","acct":"bob@example.com"},"status":{"id":"post-2","content":"read reply","visibility":"public"}},
+			{"id":"n-unread-shape","type":"favourite","unread":true,"created_at":"2026-05-11T02:03:00Z","account":{"id":"acct-3","acct":"carol@example.com"},"status":{"id":"post-3","content":"fav","visibility":"public"}},
+			{"id":"n-read-shape","type":"reblog","unread":false,"created_at":"2026-05-11T02:02:00Z","account":{"id":"acct-4","acct":"drew@example.com"},"status":{"id":"post-4","content":"boost","visibility":"public"}}
+		]`))
+	}))
+	defer server.Close()
+
+	t.Setenv("LESSER_API_BASE_URL", server.URL)
+	lesserapi.ResetForTests()
+
+	app, err := mcpapp.New("test", "dev")
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+
+	env := testkit.New()
+	token := newTestToken(t, "test", "agent1", []string{"read"})
+	authHeader := "Bearer " + token
+
+	initResp := invokeJSON(t, env, app, map[string][]string{"authorization": {authHeader}}, &mcpruntime.Request{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "initialize",
+	})
+	if initResp.Status != 200 {
+		t.Fatalf("initialize: status=%d body=%s", initResp.Status, string(initResp.Body))
+	}
+	sessionID := initResp.Headers["mcp-session-id"][0]
+
+	callParams, _ := json.Marshal(map[string]any{"name": "notifications_read", "arguments": map[string]any{"limit": 20}})
+	resp := invokeJSON(t, env, app, map[string][]string{
+		"authorization":  {authHeader},
+		"mcp-session-id": {sessionID},
+	}, &mcpruntime.Request{JSONRPC: "2.0", ID: 2, Method: "tools/call", Params: callParams})
+	if resp.Status != 200 {
+		t.Fatalf("notifications_read: status=%d body=%s", resp.Status, string(resp.Body))
+	}
+
+	var rpc mcpruntime.Response
+	if err := json.Unmarshal(resp.Body, &rpc); err != nil {
+		t.Fatalf("unmarshal notifications_read: %v", err)
+	}
+	if rpc.Error != nil {
+		t.Fatalf("notifications_read rpc error: %+v", rpc.Error)
+	}
+	var out mcpruntime.ToolResult
+	b, _ := json.Marshal(rpc.Result)
+	_ = json.Unmarshal(b, &out)
+	data, _ := out.StructuredContent["data"].(map[string]any)
+	notifications, _ := data["notifications"].([]any)
+	byID := map[string]map[string]any{}
+	for _, item := range notifications {
+		n, _ := item.(map[string]any)
+		id, _ := n["id"].(string)
+		byID[id] = n
+		if _, ok := n["raw"]; ok {
+			t.Fatalf("raw field should be absent by default: %+v", n)
+		}
+		if _, ok := n["_raw"]; ok {
+			t.Fatalf("_raw field should be absent by default: %+v", n)
+		}
+	}
+
+	if byID["n-unread"]["read"] != false {
+		t.Fatalf("expected read:false to be preserved, got %+v", byID["n-unread"])
+	}
+	if byID["n-read"]["read"] != true || byID["n-read"]["readAt"] != "2026-05-11T02:05:00Z" {
+		t.Fatalf("expected read:true and readAt to be preserved, got %+v", byID["n-read"])
+	}
+	if byID["n-unread-shape"]["read"] != false || byID["n-unread-shape"]["unread"] != true {
+		t.Fatalf("expected unread:true to infer read:false and preserve unread, got %+v", byID["n-unread-shape"])
+	}
+	if byID["n-read-shape"]["read"] != true || byID["n-read-shape"]["unread"] != false {
+		t.Fatalf("expected unread:false to infer read:true and preserve unread, got %+v", byID["n-read-shape"])
+	}
+}
+
 func TestM5_ProfileReadRejectsNonObjectArguments(t *testing.T) {
 	t.Setenv("MCP_SESSION_TABLE", "")
 	t.Setenv("JWT_SECRET", "test")

--- a/internal/mcpserver/social_tools.go
+++ b/internal/mcpserver/social_tools.go
@@ -1264,6 +1264,7 @@ func normalizeSocialNotification(raw map[string]any, includeRaw bool) map[string
 	if createdAt := firstNonEmptyStringMap(raw, "created_at", "createdAt"); createdAt != "" {
 		out["createdAt"] = createdAt
 	}
+	attachSocialNotificationReadState(out, raw)
 	if actor := normalizeSocialNotificationActor(firstMap(raw, "account", "actor")); actor != nil {
 		out["actor"] = actor
 	}
@@ -1275,6 +1276,43 @@ func normalizeSocialNotification(raw map[string]any, includeRaw bool) map[string
 	}
 
 	return out
+}
+
+func attachSocialNotificationReadState(out map[string]any, raw map[string]any) {
+	if read, ok := firstBoolMap(raw, "read", "is_read", "isRead"); ok {
+		out["read"] = read
+	}
+	if unread, ok := firstBoolMap(raw, "unread", "is_unread", "isUnread"); ok {
+		out["unread"] = unread
+		if _, hasRead := out["read"]; !hasRead {
+			out["read"] = !unread
+		}
+	}
+	if readAt := firstNonEmptyStringMap(raw, "read_at", "readAt"); readAt != "" {
+		out["readAt"] = readAt
+	}
+}
+
+func firstBoolMap(m map[string]any, keys ...string) (bool, bool) {
+	for _, key := range keys {
+		value, ok := m[key]
+		if !ok {
+			continue
+		}
+		switch typed := value.(type) {
+		case bool:
+			return typed, true
+		case string:
+			v := strings.TrimSpace(typed)
+			if strings.EqualFold(v, "true") || v == "1" {
+				return true, true
+			}
+			if strings.EqualFold(v, "false") || v == "0" {
+				return false, true
+			}
+		}
+	}
+	return false, false
 }
 
 func normalizeSocialNotificationType(raw map[string]any) string {

--- a/scripts/m0_baseline_mcp_probe.py
+++ b/scripts/m0_baseline_mcp_probe.py
@@ -344,7 +344,7 @@ def extract_notification(value: dict[str, Any]) -> dict[str, Any]:
 
 def notification_readish_state(item: dict[str, Any]) -> dict[str, Any]:
     state: dict[str, Any] = {}
-    for key in ("read", "isRead", "is_read", "dismissed", "isDismissed", "is_dismissed"):
+    for key in ("read", "isRead", "is_read", "unread", "isUnread", "is_unread", "dismissed", "isDismissed", "is_dismissed"):
         if key in item:
             state[key] = item.get(key)
     for key in ("readAt", "read_at", "dismissedAt", "dismissed_at"):
@@ -354,12 +354,30 @@ def notification_readish_state(item: dict[str, Any]) -> dict[str, Any]:
     return state
 
 
+def notification_read_value(item: dict[str, Any]) -> bool | None:
+    for key in ("read", "isRead", "is_read"):
+        value = item.get(key)
+        if isinstance(value, bool):
+            return value
+    for key in ("unread", "isUnread", "is_unread"):
+        value = item.get(key)
+        if isinstance(value, bool):
+            return not value
+    return None
+
+
 def is_read_or_dismissed(item: dict[str, Any]) -> bool:
-    state = notification_readish_state(item)
-    for value in state.values():
-        if value is True:
+    read = notification_read_value(item)
+    if read is True:
+        return True
+    if read is False:
+        return False
+    for key in ("dismissed", "isDismissed", "is_dismissed"):
+        if item.get(key) is True:
             return True
-        if isinstance(value, str) and value.strip():
+    for key in ("readAt", "read_at", "dismissedAt", "dismissed_at"):
+        value = str(item.get(key, "")).strip()
+        if value:
             return True
     return False
 
@@ -386,6 +404,10 @@ def workflow_read_args(notification_type: str = "") -> dict[str, Any]:
     if notification_type:
         args["types"] = [notification_type]
     return args
+
+
+def workflow_uses_unread_only_view() -> bool:
+    return env_bool("PROBE_NOTIFICATION_WORKFLOW_UNREAD_ONLY_VIEW")
 
 
 def probe_verified_identity(name: str, channel: str, identifier: str, message_id: str = "") -> None:
@@ -498,18 +520,35 @@ def probe_notification_workflow(name: str, args: dict[str, Any]) -> None:
     assert_tool_ok(result)
     assert_notification_baseline(relisted, name + " follow-up list")
 
-    still_listed = find_notification(relisted, selected_id) is not None
-    transition = "list_absence" if not still_listed else ""
+    relisted_notification = find_notification(relisted, selected_id)
+    still_listed = relisted_notification is not None
+    follow_up_read: bool | None = None
+    transition = ""
     after_state: dict[str, Any] = {}
     if after_status == 200:
         after_notification = extract_notification(after)
         after_state = notification_readish_state(after_notification)
-        if is_read_or_dismissed(after_notification):
-            transition = "read_state"
+        if not is_read_or_dismissed(after_notification):
+            raise ProbeError("direct Lesser single-get did not show read/dismissed state after notification_dismiss")
     elif after_status == 404 and not still_listed:
-        transition = "gone_after_dismiss"
+        raise ProbeError("follow-up same-user single-get returned HTTP 404 after notification_dismiss")
     elif after_status != 200:
         raise ProbeError(f"follow-up same-user single-get returned HTTP {after_status}")
+
+    if still_listed:
+        assert relisted_notification is not None
+        follow_up_read = notification_read_value(relisted_notification)
+        if follow_up_read is not True:
+            raise ProbeError(
+                "follow-up notifications_read kept the notification visible but did not expose read:true"
+            )
+        transition = "notifications_read_read_state"
+    elif workflow_uses_unread_only_view():
+        transition = "unread_view_absence"
+    else:
+        raise ProbeError(
+            "follow-up notifications_read did not include the notification; current all-notifications closure expects the same ID to remain visible with read:true"
+        )
 
     if not transition:
         raise ProbeError("follow-up list/read-state did not reflect notification dismiss/mark-read")
@@ -523,6 +562,7 @@ def probe_notification_workflow(name: str, args: dict[str, Any]) -> None:
         "dismiss": dismiss_data.get("dismiss"),
         "followUpGetStatus": after_status,
         "followUpInList": still_listed,
+        "followUpRead": follow_up_read,
         "transition": transition,
         "beforeState": notification_readish_state(before_notification),
         "afterState": after_state,


### PR DESCRIPTION
## Milestone
Project 21 / #161 M0 — #169 preserve notification read state in `notifications_read` output.

## Classification
Tool-surface, MCP-contract additive response shape, lesser-integration preserving, operational-reliability, docs, test-coverage.

## Surfaces affected
- `internal/mcpserver/social_tools.go`: compact notification normalization now includes read-state fields.
- `internal/mcpapp/social_tools_test.go`: regression coverage for upstream `read` and `unread` shapes while keeping default output raw-free.
- `scripts/m0_baseline_mcp_probe.py`: closure-mode workflow now requires `notifications_read` to show `read:true` when the same notification ID remains visible after dismiss.
- `docs/mcp.md`, `docs/m0-baseline-probe.md`: document normalized read-state and closure evidence expectations.

## Specialist walks referenced
- Tool surface: modifies existing social read tool `notifications_read`; no new tools; no input schema change; scope remains `read`; profile availability remains unchanged for drone/souled; static registration untouched.
- MCP contract: additive optional fields in `tools/call` structured output (`read`, `unread`, `readAt` when upstream exposes them or `read` can be inferred from `unread`). JSON-RPC envelope, OAuth metadata, discovery shape, and error semantics unchanged.
- Lesser integration: consumes Lesser's existing notification `read`/`unread` fields; no new Lesser endpoint and no body-side fallback for `equaltoai/lesser#944`.
- Host delegation: unchanged.
- Framework: unchanged.

## Consumer impact
MCP clients get compact notification read-state in `notifications_read`, so M0 closure can distinguish a failed dismiss from a successfully read notification that remains visible in Lesser's current all-notifications default list. Existing clients ignoring unknown fields remain compatible.

## Tasks
- [x] Preserve upstream `read` when present.
- [x] Infer normalized `read` from upstream `unread` where needed and preserve `unread` for callers that want the original polarity.
- [x] Preserve `readAt` when upstream exposes it.
- [x] Keep compact defaults and raw payloads opt-in through `include_raw:true` / `_raw`.
- [x] Tighten the M0 closure probe so same-ID follow-up visibility requires `read:true` from `notifications_read`.
- [x] Update #166/#169 runbook/docs expectations.

## Validation
- [x] Baseline from `origin/main`/v0.2.39 before changes: `go test ./...`
- [x] Baseline from `origin/main`/v0.2.39 before changes: `go vet ./...`
- [x] Baseline from `origin/main`/v0.2.39 before changes: `gofmt -l $(git ls-files '*.go')` empty
- [x] Baseline from `origin/main`/v0.2.39 before changes: `scripts/build.sh`
- [x] Test-first failure observed for `go test ./internal/mcpapp -run TestM5_NotificationsReadPreservesReadState` before implementation.
- [x] Targeted: `go test ./internal/mcpapp -run 'TestM5_NotificationsReadPreservesReadState|TestM5_NotificationsReadOmitsRawByDefaultAndExposesDiagnostics|TestM5_NotificationCursorSemantics|TestM5_NotificationsReadTimestampSinceFiltersRecentRemoteCreates'`
- [x] `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile scripts/m0_baseline_mcp_probe.py`
- [x] `git diff --check`
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l $(git ls-files '*.go')` empty
- [x] `scripts/build.sh`

## Stage rollout plan (handoff to deploy-body)
- [ ] Merged to main
- [ ] Deployed to lab / dev
- [ ] Run smoke probe and attach evidence to #166
- [ ] Run closure-mode probe after Lesser #944/#945 migration state is deployed/verified
- [ ] Confirm `SUMMARY.closureReady:true` with same-ID `notifications_read` follow-up showing `read:true`
- [ ] Lab soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
- Lesser #944 is closed via PR #945; this PR does not change Lesser and does not add fallback behavior for failed notification dismiss/read transitions.
- If Ops finds a remaining GSI4/migration/index issue, that should route back to Lesser; otherwise M0 closure is body/Ops probe evidence after this deploy.

## Advisor-brief authorization
Pilot emailed the #169 handoff, and the public advisory record exists in #169/#161/#166. The email body lacks a formal provenance signature block, so this is carried as direct user/project-manager authorization after Aron explicitly asked to retrieve, investigate, and then proceed.

Closes #169. Updates #166.