### PR TITLE
[codex] feat(mcp): add public soul read tool

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -149,7 +149,7 @@ AppTheory’s MCP server implements:
 
 - `drone`
   - Lightweight body before soul promotion.
-  - Social + memory MCP surfaces remain available.
+  - Social, memory, and public soul-read MCP surfaces remain available.
   - Communication surfaces and wallet-backed product semantics stay disabled.
 - `souled`
   - Full lesser-body MCP surface, including communication tooling and soul-linked runtime behavior.
@@ -294,6 +294,7 @@ Scope key:
 | `sms_read` | Read | List inbound SMS metadata/previews from lesser-host's canonical mailbox. |
 | `voicemail_read` | Read | List inbound voice/voicemail metadata/previews from lesser-host's canonical mailbox. |
 | `identity_whoami` | Read | Return the current soul agent identity, channels, and contact preferences. |
+| `soul_read` | Read | Read a public-only soul identity bundle from Host/Soul public endpoints; private reachability and contact preferences are omitted or marked unavailable. |
 | `identity_lookup` | Read | Resolve a public soul identity by full agent ID, ENS name, a current-instance local ID such as `medic`, an explicit remote ActivityPub handle such as `@steward@remote.example`, or a canonical actor URL such as `https://remote.example/users/steward`; returns public identity summary only. |
 | `identity_verify` | Read | Verify that a recent communication matches a resolved soul identity using public ENS resolution plus authoritative message provenance. Private email/phone reachability verification fails closed until lesser-host exposes a body-facing resolver. |
 
@@ -347,6 +348,19 @@ Notes:
   `direction`, `threadId`, bounded `query`, `unreadOnly`/`read`, `includeArchived`/`archived`, and
   `includeDeleted`/`deleted`.
 - Voice is currently receive-only: use `voicemail_read` for inbound voicemail; outbound `phone_call` is intentionally disabled.
+- `soul_read` is the Project 21 M1 public soul read-model tool. It accepts one of `agentId`, `ensName`, or
+  `query` (full soul agent ID, ENS name, current-instance local ID, explicit `@user@domain` ActivityPub handle, or
+  canonical actor URL), plus optional `limit` for search-backed matches and `include_raw=true` for audit/debug. The
+  default response is compact and returns `souls[]`, each with stable MCP blocks: `identity`, `registration`,
+  `capabilities`, `boundaries`, `transparency`, `channels`, `avatar`, `sources`, and `deferred`.
+- `soul_read` uses only public Host/Soul endpoints without `LESSER_HOST_INSTANCE_KEY`: `/api/v1/soul/agents/{agentId}`,
+  `/registration`, `/capabilities`, `/boundaries`, `/transparency`, public ENS resolution, and public search. It must
+  not call private email/phone resolvers, private channel/preference endpoints, contactability APIs, or mailbox APIs for
+  arbitrary public reads.
+- `soul_read.channels` includes public ENS data when available. Email/phone reachability, private contact preferences,
+  availability, and first-contact policy are deferred/private in M1 and are omitted or represented with
+  `status:"unavailable"` and `reason:"deferred_private_reachability"`. Missing avatar/style data is treated as
+  unavailable, not as an error.
 - `identity_lookup` accepts:
   - full soul `agentId`
   - ENS name

--- a/internal/mcpapp/comm_contract_test.go
+++ b/internal/mcpapp/comm_contract_test.go
@@ -86,6 +86,7 @@ func TestLBM0_CommunicationToolSchemasMatchSpec(t *testing.T) {
 		"sms_read",
 		"voicemail_read",
 		"identity_whoami",
+		"soul_read",
 		"identity_lookup",
 		"identity_verify",
 	} {
@@ -156,6 +157,18 @@ func TestLBM0_CommunicationToolSchemasMatchSpec(t *testing.T) {
 		expectPropType(t, s, "replyTo", "string")
 		expectPropType(t, s, "messageId", "string")
 		expectPropType(t, s, "inReplyTo", "string")
+	}
+
+	{
+		s := mustSchema(t, toolsByName["soul_read"])
+		if s.Type != "object" {
+			t.Fatalf("soul_read schema type: want object got %q", s.Type)
+		}
+		expectPropType(t, s, "query", "string")
+		expectPropType(t, s, "agentId", "string")
+		expectPropType(t, s, "ensName", "string")
+		expectPropType(t, s, "limit", "integer")
+		expectPropType(t, s, "include_raw", "boolean")
 	}
 
 	{

--- a/internal/mcpapp/drone_capabilities_test.go
+++ b/internal/mcpapp/drone_capabilities_test.go
@@ -69,8 +69,8 @@ func TestDroneRuntimeCapabilityContractIsExplicit(t *testing.T) {
 		for _, tool := range out.Tools {
 			have[tool.Name] = true
 		}
-		if !have["post_create"] || !have["memory_query"] {
-			t.Fatalf("expected social and memory tools for drone runtime, got %+v", out.Tools)
+		if !have["post_create"] || !have["memory_query"] || !have["soul_read"] {
+			t.Fatalf("expected social, memory, and public soul tools for drone runtime, got %+v", out.Tools)
 		}
 		for _, blocked := range []string{
 			"email_send", "email_read", "email_get", "email_get_content", "email_search", "email_reply",
@@ -243,7 +243,7 @@ func TestDroneRuntimeCapabilityContractIsExplicit(t *testing.T) {
 		if droneProfile.CommunicationsEnabled || droneProfile.WalletAccessEnabled {
 			t.Fatalf("expected drone discovery profile to disable comms and wallet access, got %+v", droneProfile)
 		}
-		if !containsString(droneProfile.Tools, "post_create") {
+		if !containsString(droneProfile.Tools, "post_create") || !containsString(droneProfile.Tools, "soul_read") {
 			t.Fatalf("unexpected drone discovery tools: %+v", droneProfile.Tools)
 		}
 		for _, blocked := range []string{

--- a/internal/mcpapp/identity_surfaces_test.go
+++ b/internal/mcpapp/identity_surfaces_test.go
@@ -1153,3 +1153,186 @@ func TestLBM1_IdentityLookupUnsupportedRemoteActorURLReturnsBadRequest(t *testin
 		t.Fatalf("identity_lookup should reject unsupported remote actor URLs before search")
 	}
 }
+
+func TestLBM1_SoulReadPublicMVPUsesPublicEndpoints(t *testing.T) {
+	t.Setenv("MCP_SESSION_TABLE", "")
+	t.Setenv("JWT_SECRET", "test")
+	installMissingSoulBindingLookup(t)
+	auth.ResetForTests()
+	lesserapi.ResetForTests()
+	soulapi.ResetForTests()
+
+	const agentID = "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+	var publicAuthHeaders []string
+	privatePathCalled := ""
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(r.URL.Path, "/resolve/email/") || strings.Contains(r.URL.Path, "/resolve/phone/") || strings.Contains(r.URL.Path, "/channels") || strings.Contains(r.URL.Path, "/comm/") {
+			privatePathCalled = r.URL.Path
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"error":{"message":"private endpoint called"}}`))
+			return
+		}
+		publicAuthHeaders = append(publicAuthHeaders, r.Header.Get("Authorization"))
+		switch r.URL.Path {
+		case "/api/v1/soul/agents/" + agentID:
+			_, _ = w.Write([]byte(`{
+				"agent":{
+					"agent_id":"` + agentID + `",
+					"domain":"test.example.com",
+					"local_id":"agent-c",
+					"ens_name":"agent-c.lessersoul.eth",
+					"wallet":"0x1234",
+					"token_id":"42",
+					"meta_uri":"ipfs://meta",
+					"status":"active",
+					"lifecycle_status":"active",
+					"self_description_version":"3",
+					"updated_at":"2026-05-11T15:00:00Z",
+					"avatar":{
+						"token_uri":"ipfs://avatar",
+						"image":"https://cdn.example/avatar.png",
+						"current_style_id":"friendly",
+						"current_style_name":"Friendly",
+						"styles":[{"style_id":"friendly","style_name":"Friendly","selected":true}]
+					}
+				}
+			}`))
+		case "/api/v1/soul/agents/" + agentID + "/registration":
+			_, _ = w.Write([]byte(`{
+				"version":"3",
+				"selfDescription":{"summary":"public self description"},
+				"transparency":{"ai_generated":true},
+				"channels":{"ens":{"name":"agent-c.lessersoul.eth"}}
+			}`))
+		case "/api/v1/soul/agents/" + agentID + "/capabilities":
+			_, _ = w.Write([]byte(`{"capabilities":[{"capability":"social.post","scope":"public","claim_level":"declared","degrades_to":"read-only"}]}`))
+		case "/api/v1/soul/agents/" + agentID + "/boundaries":
+			_, _ = w.Write([]byte(`{"boundaries":[{"id":"b1","category":"communication_policy","statement":"No private channels in public read","issued_at":"2026-05-11T15:00:00Z"}]}`))
+		case "/api/v1/soul/agents/" + agentID + "/transparency":
+			_, _ = w.Write([]byte(`{"transparency":{"ai_generated":true,"operator_disclosed":true}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":{"message":"not found"}}`))
+		}
+	}))
+	defer server.Close()
+
+	t.Setenv("LESSER_SOUL_API_BASE_URL", server.URL)
+	soulapi.ResetForTests()
+
+	app, err := mcpapp.New("test", "dev")
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+	env := testkit.New()
+	token := newTestToken(t, "test", "agent1", []string{"read"})
+	authHeader := "Bearer " + token
+
+	initResp := invokeJSON(t, env, app, map[string][]string{
+		"authorization": {authHeader},
+	}, &mcpruntime.Request{JSONRPC: "2.0", ID: 1, Method: "initialize"})
+	if initResp.Status != 200 {
+		t.Fatalf("initialize: status=%d body=%s", initResp.Status, string(initResp.Body))
+	}
+	sessionID := initResp.Headers["mcp-session-id"][0]
+
+	listResp := invokeJSON(t, env, app, map[string][]string{
+		"authorization":  {authHeader},
+		"mcp-session-id": {sessionID},
+	}, &mcpruntime.Request{JSONRPC: "2.0", ID: 2, Method: "tools/list"})
+	if listResp.Status != 200 {
+		t.Fatalf("tools/list: status=%d body=%s", listResp.Status, string(listResp.Body))
+	}
+	var listRPC mcpruntime.Response
+	_ = json.Unmarshal(listResp.Body, &listRPC)
+	if listRPC.Error != nil {
+		t.Fatalf("tools/list error: %+v", listRPC.Error)
+	}
+	var listOut struct {
+		Tools []mcpruntime.ToolDef `json:"tools"`
+	}
+	{
+		b, _ := json.Marshal(listRPC.Result)
+		_ = json.Unmarshal(b, &listOut)
+	}
+	haveSoulRead := false
+	for _, tool := range listOut.Tools {
+		if tool.Name == "soul_read" {
+			haveSoulRead = true
+			break
+		}
+	}
+	if !haveSoulRead {
+		t.Fatalf("expected soul_read in drone tools/list, got %+v", listOut.Tools)
+	}
+
+	callParams, _ := json.Marshal(map[string]any{
+		"name": "soul_read",
+		"arguments": map[string]any{
+			"agentId": agentID,
+		},
+	})
+	resp := invokeJSON(t, env, app, map[string][]string{
+		"authorization":  {authHeader},
+		"mcp-session-id": {sessionID},
+	}, &mcpruntime.Request{JSONRPC: "2.0", ID: 3, Method: "tools/call", Params: callParams})
+	if resp.Status != 200 {
+		t.Fatalf("soul_read: status=%d body=%s", resp.Status, string(resp.Body))
+	}
+	if privatePathCalled != "" {
+		t.Fatalf("soul_read called private endpoint %q", privatePathCalled)
+	}
+	for _, got := range publicAuthHeaders {
+		if strings.TrimSpace(got) != "" {
+			t.Fatalf("public soul_read endpoint should be unauthenticated, got Authorization=%q", got)
+		}
+	}
+
+	var rpc mcpruntime.Response
+	if err := json.Unmarshal(resp.Body, &rpc); err != nil {
+		t.Fatalf("unmarshal soul_read response: %v", err)
+	}
+	if rpc.Error != nil {
+		t.Fatalf("soul_read rpc error: %+v", rpc.Error)
+	}
+	var toolOut mcpruntime.ToolResult
+	{
+		b, _ := json.Marshal(rpc.Result)
+		_ = json.Unmarshal(b, &toolOut)
+	}
+	data, _ := toolOut.StructuredContent["data"].(map[string]any)
+	if data["count"] != float64(1) {
+		t.Fatalf("expected count=1, got %+v", data)
+	}
+	souls, _ := data["souls"].([]any)
+	if len(souls) != 1 {
+		t.Fatalf("expected one soul, got %+v", data)
+	}
+	soul, _ := souls[0].(map[string]any)
+	identity, _ := soul["identity"].(map[string]any)
+	if identity["agentId"] != agentID || identity["localId"] != "agent-c" || identity["ensName"] != "agent-c.lessersoul.eth" {
+		t.Fatalf("unexpected identity block: %+v", identity)
+	}
+	capabilities, _ := soul["capabilities"].([]any)
+	if len(capabilities) != 1 || capabilities[0].(map[string]any)["name"] != "social.post" {
+		t.Fatalf("unexpected capabilities: %+v", capabilities)
+	}
+	boundaries, _ := soul["boundaries"].([]any)
+	if len(boundaries) != 1 || boundaries[0].(map[string]any)["issuedAt"] != "2026-05-11T15:00:00Z" {
+		t.Fatalf("unexpected boundaries: %+v", boundaries)
+	}
+	channels, _ := soul["channels"].(map[string]any)
+	emailChannel, _ := channels["email"].(map[string]any)
+	if emailChannel["status"] != "unavailable" || emailChannel["reason"] != "deferred_private_reachability" {
+		t.Fatalf("expected private email channel to be unavailable, got %+v", channels)
+	}
+	avatar, _ := soul["avatar"].(map[string]any)
+	if avatar["status"] != "available" || avatar["currentStyleId"] != "friendly" {
+		t.Fatalf("unexpected avatar block: %+v", avatar)
+	}
+	if _, ok := soul["_raw"]; ok {
+		t.Fatalf("did not expect raw payload by default: %+v", soul)
+	}
+}

--- a/internal/mcpapp/identity_surfaces_test.go
+++ b/internal/mcpapp/identity_surfaces_test.go
@@ -1209,7 +1209,7 @@ func TestLBM1_SoulReadPublicMVPUsesPublicEndpoints(t *testing.T) {
 		case "/api/v1/soul/agents/" + agentID + "/capabilities":
 			_, _ = w.Write([]byte(`{"capabilities":[{"capability":"social.post","scope":"public","claim_level":"declared","degrades_to":"read-only"}]}`))
 		case "/api/v1/soul/agents/" + agentID + "/boundaries":
-			_, _ = w.Write([]byte(`{"boundaries":[{"id":"b1","category":"communication_policy","statement":"No private channels in public read","issued_at":"2026-05-11T15:00:00Z"}]}`))
+			_, _ = w.Write([]byte(`{"boundaries":[{"boundary_id":"b1","category":"communication_policy","statement":"No private channels in public read","added_at":"2026-05-11T15:00:00Z","added_in_version":"3"}]}`))
 		case "/api/v1/soul/agents/" + agentID + "/transparency":
 			_, _ = w.Write([]byte(`{"transparency":{"ai_generated":true,"operator_disclosed":true}}`))
 		default:
@@ -1320,8 +1320,12 @@ func TestLBM1_SoulReadPublicMVPUsesPublicEndpoints(t *testing.T) {
 		t.Fatalf("unexpected capabilities: %+v", capabilities)
 	}
 	boundaries, _ := soul["boundaries"].([]any)
-	if len(boundaries) != 1 || boundaries[0].(map[string]any)["issuedAt"] != "2026-05-11T15:00:00Z" {
+	if len(boundaries) != 1 {
 		t.Fatalf("unexpected boundaries: %+v", boundaries)
+	}
+	boundary, _ := boundaries[0].(map[string]any)
+	if boundary["id"] != "b1" || boundary["issuedAt"] != "2026-05-11T15:00:00Z" || boundary["version"] != "3" || boundary["addedInVersion"] != "3" {
+		t.Fatalf("unexpected normalized boundary: %+v", boundary)
 	}
 	channels, _ := soul["channels"].(map[string]any)
 	emailChannel, _ := channels["email"].(map[string]any)

--- a/internal/mcpapp/tool_annotations_test.go
+++ b/internal/mcpapp/tool_annotations_test.go
@@ -100,7 +100,7 @@ func TestMCPToolAnnotationsForMailboxAndMemory(t *testing.T) {
 	truth := true
 	falsehood := false
 
-	for _, name := range []string{"email_read", "email_get", "email_get_content", "email_search", "sms_read", "voicemail_read", "memory_query"} {
+	for _, name := range []string{"email_read", "email_get", "email_get_content", "email_search", "sms_read", "voicemail_read", "memory_query", "soul_read"} {
 		assertHint(name, &truth, nil, nil)
 	}
 	for _, name := range []string{"email_send", "email_reply", "email_delete", "sms_send"} {

--- a/internal/mcpserver/comm_tools.go
+++ b/internal/mcpserver/comm_tools.go
@@ -31,6 +31,7 @@ func registerCommunicationTools(r *mcpruntime.ToolRegistry) error {
 		{Def: smsReadDef(), Handler: handleSmsRead},
 		{Def: voicemailReadDef(), Handler: handleVoicemailRead},
 		{Def: identityWhoamiDef(), Handler: handleIdentityWhoami},
+		{Def: soulReadDef(), Handler: handleSoulRead},
 		{Def: identityLookupDef(), Handler: handleIdentityLookup},
 		{Def: identityVerifyDef(), Handler: handleIdentityVerify},
 	} {
@@ -303,6 +304,24 @@ func voicemailReadDef() mcpruntime.ToolDef {
 				"limit":{"type":"integer","minimum":1,"maximum":100},
 				"cursor":{"type":"string"},
 				"threadId":{"type":"string"}
+			}
+		}`),
+	}
+}
+
+func soulReadDef() mcpruntime.ToolDef {
+	return mcpruntime.ToolDef{
+		Name:        "soul_read",
+		Description: "Read a public-only soul identity bundle from Host/Soul public endpoints. Private email/phone reachability and contact preferences are omitted or marked unavailable.",
+		Annotations: readOnlyToolAnnotations(),
+		InputSchema: json.RawMessage(`{
+			"type":"object",
+			"properties":{
+				"query":{"type":"string","description":"Full soul agentId, ENS name, current-instance local ID, explicit @user@domain ActivityPub handle, or canonical actor URL."},
+				"agentId":{"type":"string","description":"Full soul agent ID. Takes precedence over query when provided."},
+				"ensName":{"type":"string","description":"Public ENS name. Takes precedence over query when agentId is absent."},
+				"limit":{"type":"integer","minimum":1,"maximum":3,"description":"Maximum matches to compose when query resolves through search. Defaults to 1."},
+				"include_raw":{"type":"boolean","description":"Include raw public Host/Soul endpoint payloads under _raw for audit/debug use. Defaults to false."}
 			}
 		}`),
 	}

--- a/internal/mcpserver/soul_read_tools.go
+++ b/internal/mcpserver/soul_read_tools.go
@@ -265,13 +265,14 @@ func normalizeSoulReadBoundaries(raw any, reg map[string]any) []any {
 			continue
 		}
 		boundary := map[string]any{}
-		putFirstAny(boundary, "id", m, "id")
+		putFirstAny(boundary, "id", m, "id", "boundary_id", "boundaryId")
 		putFirstAny(boundary, "category", m, "category")
 		putFirstAny(boundary, "statement", m, "statement")
 		putFirstAny(boundary, "rationale", m, "rationale")
 		putFirstAny(boundary, "supersedes", m, "supersedes")
-		putFirstAny(boundary, "version", m, "version")
-		putFirstAny(boundary, "issuedAt", m, "issued_at", "issuedAt")
+		putFirstAny(boundary, "version", m, "version", "added_in_version", "addedInVersion")
+		putFirstAny(boundary, "addedInVersion", m, "added_in_version", "addedInVersion")
+		putFirstAny(boundary, "issuedAt", m, "issued_at", "issuedAt", "added_at", "addedAt")
 		if len(boundary) > 0 {
 			out = append(out, boundary)
 		}

--- a/internal/mcpserver/soul_read_tools.go
+++ b/internal/mcpserver/soul_read_tools.go
@@ -1,0 +1,424 @@
+package mcpserver
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/url"
+	"strings"
+
+	"github.com/equaltoai/lesser-body/internal/soulapi"
+	mcpruntime "github.com/theory-cloud/apptheory/runtime/mcp"
+)
+
+const soulReadMaxMatches = 3
+
+func handleSoulRead(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
+	var in struct {
+		Query      string `json:"query"`
+		AgentID    string `json:"agentId"`
+		ENSName    string `json:"ensName"`
+		Limit      int    `json:"limit,omitempty"`
+		IncludeRaw bool   `json:"include_raw,omitempty"`
+	}
+	if err := json.Unmarshal(args, &in); err != nil {
+		return toolErrorResult("invalid_request", "invalid args: "+err.Error(), 400, nil)
+	}
+
+	query := firstNonEmpty(strings.TrimSpace(in.AgentID), strings.TrimSpace(in.ENSName), strings.TrimSpace(in.Query))
+	if query == "" {
+		return toolErrorResult("invalid_request", "query, agentId, or ensName is required", 400, nil)
+	}
+	if strings.TrimSpace(in.ENSName) != "" && !looksLikeENSName(in.ENSName) {
+		return toolErrorResult("invalid_request", "ensName must be a public ENS name", 400, map[string]any{"query": strings.TrimSpace(in.ENSName)})
+	}
+	if looksLikeEmail(query) {
+		return identityToolResultFromError(privateReachabilityUnavailableError("email", "soul_read"))
+	}
+	if looksLikePhoneIdentifier(query) {
+		return identityToolResultFromError(privateReachabilityUnavailableError("phone", "soul_read"))
+	}
+
+	limit := boundedSoulReadLimit(in.Limit)
+	client, err := soulapi.Default()
+	if err != nil {
+		return toolErrorResult("not_configured", err.Error(), 500, nil)
+	}
+
+	agentIDs := []string{}
+	if in.AgentID != "" || isSoulAgentID(query) {
+		agentID := normalizeSoulAgentID(query)
+		if agentID == "" {
+			return toolErrorResult("invalid_request", "agentId must be a full soul agent ID", 400, map[string]any{"query": query})
+		}
+		agentIDs = append(agentIDs, agentID)
+	} else {
+		resolved, err := lookupAgentIDs(ctx, client, query)
+		if err != nil {
+			return identityToolResultFromError(err)
+		}
+		agentIDs = append(agentIDs, resolved...)
+		if len(agentIDs) == 0 {
+			return toolErrorResult("not_found", "no matching soul agent found", 404, map[string]any{"query": query})
+		}
+	}
+	if len(agentIDs) > limit {
+		agentIDs = agentIDs[:limit]
+	}
+
+	souls := make([]any, 0, len(agentIDs))
+	for _, agentID := range agentIDs {
+		soul, err := soulReadPayload(ctx, client, agentID, in.IncludeRaw)
+		if err != nil {
+			return identityToolResultFromError(err)
+		}
+		souls = append(souls, soul)
+	}
+
+	return toolJSONResult(map[string]any{
+		"query": query,
+		"count": len(souls),
+		"souls": souls,
+	}, nil)
+}
+
+func boundedSoulReadLimit(limit int) int {
+	switch {
+	case limit <= 0:
+		return 1
+	case limit > soulReadMaxMatches:
+		return soulReadMaxMatches
+	default:
+		return limit
+	}
+}
+
+func soulReadPayload(ctx context.Context, client *soulapi.Client, agentID string, includeRaw bool) (map[string]any, error) {
+	agentID = normalizeSoulAgentID(agentID)
+	if agentID == "" {
+		return nil, &toolUserError{Code: "invalid_request", Message: "missing agentId", Status: 400}
+	}
+
+	sources := []map[string]any{}
+	deferred := []map[string]any{
+		{"field": "channels.email", "status": "unavailable", "reason": "deferred_private_reachability"},
+		{"field": "channels.phone", "status": "unavailable", "reason": "deferred_private_reachability"},
+		{"field": "contactPreferences", "status": "unavailable", "reason": "deferred_private_reachability"},
+	}
+
+	agentPath := "/api/v1/soul/agents/" + url.PathEscape(agentID)
+	agentRaw, err := client.DoJSON(ctx, "GET", agentPath, nil, "", nil)
+	if err != nil {
+		return nil, err
+	}
+	agentEnvelope, _ := agentRaw.(map[string]any)
+	agent := firstMap(agentEnvelope, "agent")
+	if agent == nil {
+		agent = agentEnvelope
+	}
+	sources = append(sources, soulReadSource("identity", agentPath, "ok", ""))
+
+	registrationPath := agentPath + "/registration"
+	registrationRaw, registrationSource := soulReadOptional(ctx, client, "registration", registrationPath)
+	sources = append(sources, registrationSource)
+	registration, _ := registrationRaw.(map[string]any)
+
+	capabilitiesPath := agentPath + "/capabilities"
+	capabilitiesRaw, capabilitiesSource := soulReadOptional(ctx, client, "capabilities", capabilitiesPath)
+	sources = append(sources, capabilitiesSource)
+
+	boundariesPath := agentPath + "/boundaries"
+	boundariesRaw, boundariesSource := soulReadOptional(ctx, client, "boundaries", boundariesPath)
+	sources = append(sources, boundariesSource)
+
+	transparencyPath := agentPath + "/transparency"
+	transparencyRaw, transparencySource := soulReadOptional(ctx, client, "transparency", transparencyPath)
+	sources = append(sources, transparencySource)
+
+	payload := map[string]any{
+		"agentId":      agentID,
+		"identity":     normalizeSoulReadIdentity(agentID, agent),
+		"registration": normalizeSoulReadRegistration(registration, agent),
+		"capabilities": normalizeSoulReadCapabilities(capabilitiesRaw, registration),
+		"boundaries":   normalizeSoulReadBoundaries(boundariesRaw, registration),
+		"transparency": normalizeSoulReadTransparency(transparencyRaw, registration),
+		"channels":     normalizeSoulReadChannels(agent, registration),
+		"avatar":       normalizeSoulReadAvatar(firstMap(agent, "avatar")),
+		"sources":      sources,
+		"deferred":     deferred,
+	}
+	if includeRaw {
+		payload["_raw"] = map[string]any{
+			"identity":     agentRaw,
+			"registration": registrationRaw,
+			"capabilities": capabilitiesRaw,
+			"boundaries":   boundariesRaw,
+			"transparency": transparencyRaw,
+		}
+	}
+	return payload, nil
+}
+
+func soulReadOptional(ctx context.Context, client *soulapi.Client, block string, path string) (any, map[string]any) {
+	out, err := client.DoJSON(ctx, "GET", path, nil, "", nil)
+	if err == nil {
+		return out, soulReadSource(block, path, "ok", "")
+	}
+
+	status := "unavailable"
+	reason := "public_endpoint_unavailable"
+	var apiErr *soulapi.APIError
+	if errors.As(err, &apiErr) {
+		reason = identityErrorCodeForStatus(apiErr.Status)
+		return nil, soulReadSource(block, path, status, reason)
+	}
+	return nil, soulReadSource(block, path, status, reason)
+}
+
+func soulReadSource(block string, endpoint string, status string, reason string) map[string]any {
+	out := map[string]any{
+		"block":    strings.TrimSpace(block),
+		"endpoint": strings.TrimSpace(endpoint),
+		"status":   strings.TrimSpace(status),
+	}
+	if reason != "" {
+		out["reason"] = strings.TrimSpace(reason)
+	}
+	return out
+}
+
+func normalizeSoulReadIdentity(agentID string, agent map[string]any) map[string]any {
+	out := map[string]any{"agentId": agentID}
+	putFirstAny(out, "domain", agent, "domain")
+	putFirstAny(out, "localId", agent, "local_id", "localId")
+	putFirstAny(out, "ensName", agent, "ens_name", "ensName")
+	putFirstAny(out, "wallet", agent, "wallet")
+	putFirstAny(out, "tokenId", agent, "token_id", "tokenId")
+	putFirstAny(out, "metaUri", agent, "meta_uri", "metaUri")
+	putFirstAny(out, "status", agent, "status")
+	putFirstAny(out, "lifecycleStatus", agent, "lifecycle_status", "lifecycleStatus")
+	putFirstAny(out, "lifecycleReason", agent, "lifecycle_reason", "lifecycleReason")
+	putFirstAny(out, "successorAgentId", agent, "successor_agent_id", "successorAgentId")
+	putFirstAny(out, "predecessorAgentId", agent, "predecessor_agent_id", "predecessorAgentId")
+	putFirstAny(out, "principalAddress", agent, "principal_address", "principalAddress")
+	putFirstAny(out, "selfDescriptionVersion", agent, "self_description_version", "selfDescriptionVersion")
+	putFirstAny(out, "mintTxHash", agent, "mint_tx_hash", "mintTxHash")
+	putFirstAny(out, "mintedAt", agent, "minted_at", "mintedAt")
+	putFirstAny(out, "updatedAt", agent, "updated_at", "updatedAt")
+	return out
+}
+
+func normalizeSoulReadRegistration(reg map[string]any, agent map[string]any) map[string]any {
+	out := map[string]any{"rawAvailable": reg != nil}
+	if reg == nil {
+		out["status"] = "unavailable"
+		out["reason"] = "public_endpoint_unavailable"
+		putFirstAny(out, "metaUri", agent, "meta_uri", "metaUri")
+		return out
+	}
+	putFirstAny(out, "url", reg, "url")
+	putFirstAny(out, "metaUri", reg, "meta_uri", "metaUri")
+	if _, ok := out["metaUri"]; !ok {
+		putFirstAny(out, "metaUri", agent, "meta_uri", "metaUri")
+	}
+	putFirstAny(out, "version", reg, "version")
+	putFirstAny(out, "selfDescription", reg, "selfDescription", "self_description")
+	putFirstAny(out, "principal", reg, "principal")
+	return out
+}
+
+func normalizeSoulReadCapabilities(raw any, reg map[string]any) []any {
+	items := firstArrayFromAny(raw, "capabilities", "items", "results")
+	if len(items) == 0 && reg != nil {
+		items = firstArrayFromAny(reg, "capabilities")
+	}
+	out := make([]any, 0, len(items))
+	for _, item := range items {
+		m, _ := item.(map[string]any)
+		if m == nil {
+			continue
+		}
+		capability := map[string]any{}
+		putFirstAny(capability, "name", m, "capability", "name")
+		putFirstAny(capability, "scope", m, "scope")
+		putFirstAny(capability, "constraints", m, "constraints")
+		putFirstAny(capability, "claimLevel", m, "claim_level", "claimLevel")
+		putFirstAny(capability, "lastValidated", m, "last_validated", "lastValidated")
+		putFirstAny(capability, "validationRef", m, "validation_ref", "validationRef")
+		putFirstAny(capability, "degradesTo", m, "degrades_to", "degradesTo")
+		if len(capability) > 0 {
+			out = append(out, capability)
+		}
+	}
+	return out
+}
+
+func normalizeSoulReadBoundaries(raw any, reg map[string]any) []any {
+	items := firstArrayFromAny(raw, "boundaries", "items", "results")
+	if len(items) == 0 && reg != nil {
+		items = firstArrayFromAny(reg, "boundaries")
+	}
+	out := make([]any, 0, len(items))
+	for _, item := range items {
+		m, _ := item.(map[string]any)
+		if m == nil {
+			continue
+		}
+		boundary := map[string]any{}
+		putFirstAny(boundary, "id", m, "id")
+		putFirstAny(boundary, "category", m, "category")
+		putFirstAny(boundary, "statement", m, "statement")
+		putFirstAny(boundary, "rationale", m, "rationale")
+		putFirstAny(boundary, "supersedes", m, "supersedes")
+		putFirstAny(boundary, "version", m, "version")
+		putFirstAny(boundary, "issuedAt", m, "issued_at", "issuedAt")
+		if len(boundary) > 0 {
+			out = append(out, boundary)
+		}
+	}
+	return out
+}
+
+func normalizeSoulReadTransparency(raw any, reg map[string]any) map[string]any {
+	m, _ := raw.(map[string]any)
+	if nested := firstMap(m, "transparency"); nested != nil {
+		m = nested
+	}
+	if len(m) == 0 && reg != nil {
+		m = firstMap(reg, "transparency")
+	}
+	if len(m) == 0 {
+		return map[string]any{"status": "unavailable", "reason": "public_endpoint_unavailable"}
+	}
+	return normalizeSoulReadMap(m)
+}
+
+func normalizeSoulReadChannels(agent map[string]any, reg map[string]any) map[string]any {
+	ensName := firstNonEmptyStringMap(agent, "ens_name", "ensName")
+	if ensName == "" && reg != nil {
+		channels := firstMap(reg, "channels")
+		ens := firstMap(channels, "ens")
+		ensName = firstNonEmptyStringMap(ens, "name", "ensName", "ens_name")
+	}
+	ens := map[string]any{"status": "unavailable", "reason": "ens_not_declared"}
+	if ensName != "" {
+		ens = map[string]any{"status": "available", "name": ensName}
+	}
+	return map[string]any{
+		"ens":   ens,
+		"email": map[string]any{"status": "unavailable", "reason": "deferred_private_reachability"},
+		"phone": map[string]any{"status": "unavailable", "reason": "deferred_private_reachability"},
+	}
+}
+
+func normalizeSoulReadAvatar(raw map[string]any) map[string]any {
+	if len(raw) == 0 {
+		return map[string]any{"status": "unavailable", "reason": "avatar_not_available"}
+	}
+	out := map[string]any{"status": "available"}
+	putFirstAny(out, "tokenUri", raw, "token_uri", "tokenUri")
+	putFirstAny(out, "image", raw, "image")
+	putFirstAny(out, "currentStyleId", raw, "current_style_id", "currentStyleId")
+	putFirstAny(out, "currentStyleName", raw, "current_style_name", "currentStyleName")
+	putFirstAny(out, "currentRendererAddress", raw, "current_renderer_address", "currentRendererAddress")
+	items := firstArrayFromAny(raw, "styles")
+	styles := make([]any, 0, len(items))
+	for _, item := range items {
+		m, _ := item.(map[string]any)
+		if m == nil {
+			continue
+		}
+		style := map[string]any{}
+		putFirstAny(style, "styleId", m, "style_id", "styleId")
+		putFirstAny(style, "styleName", m, "style_name", "styleName")
+		putFirstAny(style, "rendererAddress", m, "renderer_address", "rendererAddress")
+		putFirstAny(style, "image", m, "image")
+		putFirstAny(style, "selected", m, "selected")
+		if len(style) > 0 {
+			styles = append(styles, style)
+		}
+	}
+	if len(styles) > 0 {
+		out["styles"] = styles
+	}
+	return out
+}
+
+func normalizeSoulReadMap(in map[string]any) map[string]any {
+	out := map[string]any{}
+	for key, value := range in {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		out[snakeToLowerCamel(key)] = normalizeSoulReadValue(value)
+	}
+	return out
+}
+
+func normalizeSoulReadValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		return normalizeSoulReadMap(typed)
+	case []any:
+		out := make([]any, 0, len(typed))
+		for _, item := range typed {
+			out = append(out, normalizeSoulReadValue(item))
+		}
+		return out
+	default:
+		return value
+	}
+}
+
+func snakeToLowerCamel(key string) string {
+	key = strings.TrimSpace(key)
+	if !strings.Contains(key, "_") {
+		return key
+	}
+	parts := strings.Split(key, "_")
+	out := parts[0]
+	for _, part := range parts[1:] {
+		if part == "" {
+			continue
+		}
+		out += strings.ToUpper(part[:1]) + part[1:]
+	}
+	return out
+}
+
+func firstArrayFromAny(raw any, keys ...string) []any {
+	switch typed := raw.(type) {
+	case []any:
+		return typed
+	case map[string]any:
+		for _, key := range keys {
+			if items, ok := typed[key].([]any); ok {
+				return items
+			}
+		}
+	}
+	return nil
+}
+
+func putFirstAny(dest map[string]any, key string, src map[string]any, names ...string) {
+	if dest == nil || src == nil || strings.TrimSpace(key) == "" {
+		return
+	}
+	for _, name := range names {
+		value, ok := src[name]
+		if !ok || value == nil {
+			continue
+		}
+		if s, ok := value.(string); ok {
+			s = strings.TrimSpace(s)
+			if s == "" {
+				continue
+			}
+			dest[key] = s
+			return
+		}
+		dest[key] = value
+		return
+	}
+}

--- a/internal/runtimepolicy/runtimepolicy.go
+++ b/internal/runtimepolicy/runtimepolicy.go
@@ -70,6 +70,7 @@ var profileContracts = map[Profile]Contract{
 			"profile_update",
 			"memory_append",
 			"memory_query",
+			"soul_read",
 		},
 		Resources: []string{
 			"agent://profile",
@@ -126,6 +127,7 @@ var profileContracts = map[Profile]Contract{
 			"sms_read",
 			"voicemail_read",
 			"identity_whoami",
+			"soul_read",
 			"identity_lookup",
 			"identity_verify",
 		},


### PR DESCRIPTION
## Milestone
Project 21 M1.1 — define and expose the public-only soul MCP contract/discovery surface.

Closes #130.
Refs #128, #132, #131, #133.

## Classification
MCP-contract / tool-surface / scope-profile / host-delegation-aware / test-coverage / docs.

## What changed
- Adds `soul_read`, a read-only MCP tool that composes a public-only soul bundle from Host/Soul public endpoints.
- Exposes `soul_read` through static tool registration, `tools/list`, `.well-known/mcp.json`, and runtime profile contracts.
- Makes `soul_read` available to both `drone` and `souled` profiles while keeping normal MCP `read` authorization required.
- Uses public endpoints without `LESSER_HOST_INSTANCE_KEY` and explicitly avoids private reachability, channels/preferences, contactability, and mailbox APIs.
- Documents the stable MCP response blocks: `identity`, `registration`, `capabilities`, `boundaries`, `transparency`, `channels`, `avatar`, `sources`, and `deferred`.

## Specialist walks referenced
- MCP contract: additive observable tool/discovery change; no OAuth metadata or JSON-RPC envelope change.
- Tool surface: additive read-only identity/public-soul tool; no scope/profile loosening for communication surfaces; static registration preserved.
- Host delegation: Host reply delivery `delivery-1d3899194eaf0a73` confirmed public unauthenticated soul reads and drone/souled availability from Host's perspective.
- Lesser integration: no JWT, DynamoDB, REST API, CDK, or SSM contract changes.
- Framework: AppTheory MCP runtime usage remains idiomatic static registration.

## Consumer impact
- MCP clients see a new additive `soul_read` tool.
- Drone clients may call `soul_read` for public data with `read` scope; communication tools remain filtered/blocked.
- Private email/phone reachability and private contact preferences are omitted or represented as unavailable/deferred.

## Validation
- `go test ./...`
- `go vet ./...`
- `gofmt -l .` (empty)
- `git diff --check`
- `scripts/build.sh`
- Targeted: `go test ./internal/mcpapp -run TestLBM1_SoulReadPublicMVPUsesPublicEndpoints -count=1`

## Stage rollout plan (handoff to deploy-body)
- [ ] Merged to main
- [ ] Deployed to lab / dev
- [ ] Lab soak validates discovery, `tools/list`, `soul_read` happy path, drone access, and private endpoint non-use
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
- Host: response received; #156 remains the place for future public aggregation/input gaps.
- Host #263/#262 is not required for this PR; that applies to the separate `email_send` residual.
- Lesser/Soul/Sim: no code changes required here.

## Advisor-brief authorization
Pilot's Project 21 assignment was received via `pilot@lessersoul.ai` and directly authorized by Aron in-session on 2026-05-11.