### PR TITLE
feat(soul): complete soul_read runtime and composition

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -348,11 +348,18 @@ Notes:
   `direction`, `threadId`, bounded `query`, `unreadOnly`/`read`, `includeArchived`/`archived`, and
   `includeDeleted`/`deleted`.
 - Voice is currently receive-only: use `voicemail_read` for inbound voicemail; outbound `phone_call` is intentionally disabled.
-- `soul_read` is the Project 21 M1 public soul read-model tool. It accepts one of `agentId`, `ensName`, or
-  `query` (full soul agent ID, ENS name, current-instance local ID, explicit `@user@domain` ActivityPub handle, or
-  canonical actor URL), plus optional `limit` for search-backed matches and `include_raw=true` for audit/debug. The
-  default response is compact and returns `souls[]`, each with stable MCP blocks: `identity`, `registration`,
+- `soul_read` is the Project 21 M1 public soul read-model tool. It accepts either `self=true` (the caller's
+  OAuth-bound soul), or one of `agentId`, `ensName`, or `query` (full soul agent ID, ENS name, current-instance local
+  ID, explicit `@user@domain` ActivityPub handle, or canonical actor URL), plus optional `limit` for search-backed
+  matches and `include_raw=true` for audit/debug. `self=true` conflicts with `agentId`, `ensName`, and `query`.
+  Bare current-instance local IDs require trustworthy current-instance domain context; use a full soul `agentId`,
+  ENS name, explicit handle, canonical actor URL, or `self=true` when that context is unavailable. The default response
+  is compact and returns `access` metadata plus `souls[]`, each with stable MCP blocks: `identity`, `registration`,
   `capabilities`, `boundaries`, `transparency`, `channels`, `avatar`, `sources`, and `deferred`.
+- `soul_read.access` makes caller-self versus public-read behavior explicit. Default public reads return
+  `mode:"public"`, `callerRelation:"public"`, `publicOnly:true`, and `privateExpansion:false`. `self=true` verifies the
+  caller's bound lesser soul before using the same public Host/Soul read model and returns `mode:"self"` and
+  `callerRelation:"self"`. M1 does not expose private reachability even for `self=true`.
 - `soul_read` uses only public Host/Soul endpoints without `LESSER_HOST_INSTANCE_KEY`: `/api/v1/soul/agents/{agentId}`,
   `/registration`, `/capabilities`, `/boundaries`, `/transparency`, public ENS resolution, and public search. It must
   not call private email/phone resolvers, private channel/preference endpoints, contactability APIs, or mailbox APIs for

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -355,7 +355,10 @@ Notes:
   Bare current-instance local IDs require trustworthy current-instance domain context; use a full soul `agentId`,
   ENS name, explicit handle, canonical actor URL, or `self=true` when that context is unavailable. The default response
   is compact and returns `access` metadata plus `souls[]`, each with stable MCP blocks: `identity`, `registration`,
-  `capabilities`, `boundaries`, `transparency`, `channels`, `avatar`, `sources`, and `deferred`.
+  `capabilities`, `boundaries`, `transparency`, `channels`, `avatar`, `sources`, `sourceEndpoints`, and `deferred`.
+- `soul_read` composes from the most-specific public source available. When dedicated public `capabilities`,
+  `boundaries`, or `transparency` endpoints are unavailable, it falls back to the same blocks in public registration
+  data and still records each attempted endpoint under both ordered `sources[]` and keyed `sourceEndpoints`.
 - `soul_read.access` makes caller-self versus public-read behavior explicit. Default public reads return
   `mode:"public"`, `callerRelation:"public"`, `publicOnly:true`, and `privateExpansion:false`. `self=true` verifies the
   caller's bound lesser soul before using the same public Host/Soul read model and returns `mode:"self"` and

--- a/internal/mcpapp/comm_contract_test.go
+++ b/internal/mcpapp/comm_contract_test.go
@@ -167,6 +167,7 @@ func TestLBM0_CommunicationToolSchemasMatchSpec(t *testing.T) {
 		expectPropType(t, s, "query", "string")
 		expectPropType(t, s, "agentId", "string")
 		expectPropType(t, s, "ensName", "string")
+		expectPropType(t, s, "self", "boolean")
 		expectPropType(t, s, "limit", "integer")
 		expectPropType(t, s, "include_raw", "boolean")
 	}

--- a/internal/mcpapp/identity_surfaces_test.go
+++ b/internal/mcpapp/identity_surfaces_test.go
@@ -1453,3 +1453,140 @@ func TestLBM1_SoulReadSelfModeVerifiesBoundCaller(t *testing.T) {
 		t.Fatalf("unexpected self identity: %+v", identity)
 	}
 }
+
+func TestLBM1_SoulReadComposesRegistrationFallbackBlocks(t *testing.T) {
+	t.Setenv("MCP_SESSION_TABLE", "")
+	t.Setenv("JWT_SECRET", "test")
+	installMissingSoulBindingLookup(t)
+	auth.ResetForTests()
+	lesserapi.ResetForTests()
+	soulapi.ResetForTests()
+	t.Cleanup(soulapi.ResetForTests)
+
+	const agentID = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/soul/agents/" + agentID:
+			_, _ = w.Write([]byte(`{
+				"agent":{
+					"agent_id":"` + agentID + `",
+					"domain":"test.example.com",
+					"local_id":"agent-e",
+					"ens_name":"agent-e.lessersoul.eth",
+					"status":"active"
+				}
+			}`))
+		case "/api/v1/soul/agents/" + agentID + "/registration":
+			_, _ = w.Write([]byte(`{
+				"registration":{
+					"version":"7",
+					"url":"https://host.example/soul/agents/` + agentID + `/registration",
+					"self_description":{"summary":"public fallback"},
+					"channels":{"ens":{"name":"agent-e.lessersoul.eth"}},
+					"avatar":{
+						"token_uri":"ipfs://avatar-e",
+						"image":"https://cdn.example/avatar-e.png",
+						"current_style_id":"minimal",
+						"current_style_name":"Minimal",
+						"styles":[{"style_id":"minimal","style_name":"Minimal","selected":true}]
+					},
+					"capabilities":{"items":[{"name":"memory.read","scope":"public","claim_level":"declared"}]},
+					"boundaries":{"results":[{"boundaryId":"b-reg","category":"safety","statement":"Use public data only","addedAt":"2026-05-11T16:00:00Z","addedInVersion":"7"}]},
+					"transparency":{"ai_generated":true,"operator_disclosed":true}
+				}
+			}`))
+		case "/api/v1/soul/agents/" + agentID + "/capabilities",
+			"/api/v1/soul/agents/" + agentID + "/boundaries",
+			"/api/v1/soul/agents/" + agentID + "/transparency":
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":{"message":"not found"}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":{"message":"not found"}}`))
+		}
+	}))
+	defer server.Close()
+
+	t.Setenv("LESSER_SOUL_API_BASE_URL", server.URL)
+	soulapi.ResetForTests()
+
+	app, err := mcpapp.New("test", "dev")
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+	env := testkit.New()
+	token := newTestToken(t, "test", "agent1", []string{"read"})
+	authHeader := "Bearer " + token
+
+	initResp := invokeJSON(t, env, app, map[string][]string{
+		"authorization": {authHeader},
+	}, &mcpruntime.Request{JSONRPC: "2.0", ID: 1, Method: "initialize"})
+	if initResp.Status != 200 {
+		t.Fatalf("initialize: status=%d body=%s", initResp.Status, string(initResp.Body))
+	}
+	sessionID := initResp.Headers["mcp-session-id"][0]
+
+	callParams, _ := json.Marshal(map[string]any{
+		"name":      "soul_read",
+		"arguments": map[string]any{"agentId": agentID},
+	})
+	resp := invokeJSON(t, env, app, map[string][]string{
+		"authorization":  {authHeader},
+		"mcp-session-id": {sessionID},
+	}, &mcpruntime.Request{JSONRPC: "2.0", ID: 2, Method: "tools/call", Params: callParams})
+	if resp.Status != 200 {
+		t.Fatalf("soul_read(fallback): status=%d body=%s", resp.Status, string(resp.Body))
+	}
+
+	var rpc mcpruntime.Response
+	if err := json.Unmarshal(resp.Body, &rpc); err != nil {
+		t.Fatalf("unmarshal soul_read fallback response: %v", err)
+	}
+	if rpc.Error != nil {
+		t.Fatalf("soul_read fallback rpc error: %+v", rpc.Error)
+	}
+	var toolOut mcpruntime.ToolResult
+	{
+		b, _ := json.Marshal(rpc.Result)
+		_ = json.Unmarshal(b, &toolOut)
+	}
+	data, _ := toolOut.StructuredContent["data"].(map[string]any)
+	souls, _ := data["souls"].([]any)
+	if len(souls) != 1 {
+		t.Fatalf("expected one composed soul, got %+v", data)
+	}
+	soul, _ := souls[0].(map[string]any)
+	registration, _ := soul["registration"].(map[string]any)
+	if registration["version"] != "7" || registration["rawAvailable"] != true {
+		t.Fatalf("expected registration envelope to normalize, got %+v", registration)
+	}
+	capabilities, _ := soul["capabilities"].([]any)
+	if len(capabilities) != 1 || capabilities[0].(map[string]any)["name"] != "memory.read" {
+		t.Fatalf("expected capabilities fallback from registration, got %+v", capabilities)
+	}
+	boundaries, _ := soul["boundaries"].([]any)
+	if len(boundaries) != 1 {
+		t.Fatalf("expected boundaries fallback from registration, got %+v", boundaries)
+	}
+	boundary, _ := boundaries[0].(map[string]any)
+	if boundary["id"] != "b-reg" || boundary["issuedAt"] != "2026-05-11T16:00:00Z" || boundary["addedInVersion"] != "7" {
+		t.Fatalf("expected normalized fallback boundary metadata, got %+v", boundary)
+	}
+	transparency, _ := soul["transparency"].(map[string]any)
+	if transparency["aiGenerated"] != true || transparency["operatorDisclosed"] != true {
+		t.Fatalf("expected transparency fallback from registration, got %+v", transparency)
+	}
+	avatar, _ := soul["avatar"].(map[string]any)
+	if avatar["status"] != "available" || avatar["currentStyleId"] != "minimal" {
+		t.Fatalf("expected avatar fallback from registration, got %+v", avatar)
+	}
+	sourceEndpoints, _ := soul["sourceEndpoints"].(map[string]any)
+	capSource, _ := sourceEndpoints["capabilities"].(map[string]any)
+	if capSource["status"] != "unavailable" || capSource["reason"] != "not_found" {
+		t.Fatalf("expected sourceEndpoints to preserve capabilities endpoint status, got %+v", sourceEndpoints)
+	}
+	if _, ok := sourceEndpoints["identity"].(map[string]any); !ok {
+		t.Fatalf("expected identity source endpoint, got %+v", sourceEndpoints)
+	}
+}

--- a/internal/mcpapp/identity_surfaces_test.go
+++ b/internal/mcpapp/identity_surfaces_test.go
@@ -1491,7 +1491,7 @@ func TestLBM1_SoulReadComposesRegistrationFallbackBlocks(t *testing.T) {
 						"current_style_name":"Minimal",
 						"styles":[{"style_id":"minimal","style_name":"Minimal","selected":true}]
 					},
-					"capabilities":{"items":[{"name":"memory.read","scope":"public","claim_level":"declared"}]},
+					"capabilities":["social.post"],
 					"boundaries":{"results":[{"boundaryId":"b-reg","category":"safety","statement":"Use public data only","addedAt":"2026-05-11T16:00:00Z","addedInVersion":"7"}]},
 					"transparency":{"ai_generated":true,"operator_disclosed":true}
 				}
@@ -1562,8 +1562,12 @@ func TestLBM1_SoulReadComposesRegistrationFallbackBlocks(t *testing.T) {
 		t.Fatalf("expected registration envelope to normalize, got %+v", registration)
 	}
 	capabilities, _ := soul["capabilities"].([]any)
-	if len(capabilities) != 1 || capabilities[0].(map[string]any)["name"] != "memory.read" {
+	if len(capabilities) != 1 {
 		t.Fatalf("expected capabilities fallback from registration, got %+v", capabilities)
+	}
+	capability, _ := capabilities[0].(map[string]any)
+	if capability["name"] != "social.post" || capability["claimLevel"] != "self-declared" {
+		t.Fatalf("expected v1 flat-string capability promotion, got %+v", capability)
 	}
 	boundaries, _ := soul["boundaries"].([]any)
 	if len(boundaries) != 1 {

--- a/internal/mcpapp/identity_surfaces_test.go
+++ b/internal/mcpapp/identity_surfaces_test.go
@@ -1306,6 +1306,10 @@ func TestLBM1_SoulReadPublicMVPUsesPublicEndpoints(t *testing.T) {
 	if data["count"] != float64(1) {
 		t.Fatalf("expected count=1, got %+v", data)
 	}
+	access, _ := data["access"].(map[string]any)
+	if access["mode"] != "public" || access["callerRelation"] != "public" || access["publicOnly"] != true || access["privateExpansion"] != false {
+		t.Fatalf("expected explicit public-only access metadata, got %+v", access)
+	}
 	souls, _ := data["souls"].([]any)
 	if len(souls) != 1 {
 		t.Fatalf("expected one soul, got %+v", data)
@@ -1338,5 +1342,114 @@ func TestLBM1_SoulReadPublicMVPUsesPublicEndpoints(t *testing.T) {
 	}
 	if _, ok := soul["_raw"]; ok {
 		t.Fatalf("did not expect raw payload by default: %+v", soul)
+	}
+}
+
+func TestLBM1_SoulReadSelfModeVerifiesBoundCaller(t *testing.T) {
+	t.Setenv("MCP_SESSION_TABLE", "")
+	t.Setenv("JWT_SECRET", "test")
+	auth.ResetForTests()
+	lesserapi.ResetForTests()
+	soulapi.ResetForTests()
+	t.Cleanup(lesserapi.ResetForTests)
+	t.Cleanup(soulapi.ResetForTests)
+
+	const agentID = "0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+	installSoulBindingLookup(t, "Agent1", agentID)
+
+	var publicAuthHeaders []string
+	var lesserAuthHeader string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/souls/bound/me":
+			lesserAuthHeader = r.Header.Get("Authorization")
+			_, _ = w.Write([]byte(boundSelfResponse(agentID, "agent1", "test.example.com", "agent-self")))
+		case "/api/v1/soul/agents/" + agentID:
+			publicAuthHeaders = append(publicAuthHeaders, r.Header.Get("Authorization"))
+			_, _ = w.Write([]byte(`{"agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-self","ens_name":"agent-self.lessersoul.eth","status":"active"}}`))
+		case "/api/v1/soul/agents/" + agentID + "/registration":
+			publicAuthHeaders = append(publicAuthHeaders, r.Header.Get("Authorization"))
+			_, _ = w.Write([]byte(`{"version":"1","channels":{"ens":{"name":"agent-self.lessersoul.eth"}}}`))
+		case "/api/v1/soul/agents/" + agentID + "/capabilities",
+			"/api/v1/soul/agents/" + agentID + "/boundaries",
+			"/api/v1/soul/agents/" + agentID + "/transparency":
+			publicAuthHeaders = append(publicAuthHeaders, r.Header.Get("Authorization"))
+			_, _ = w.Write([]byte(`{}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":{"message":"not found"}}`))
+		}
+	}))
+	defer server.Close()
+
+	t.Setenv("LESSER_API_BASE_URL", server.URL)
+	t.Setenv("LESSER_SOUL_API_BASE_URL", server.URL)
+	lesserapi.ResetForTests()
+	soulapi.ResetForTests()
+
+	app, err := mcpapp.New("test", "dev")
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+	env := testkit.New()
+	token := newTestToken(t, "test", "Agent1", []string{"read"})
+	authHeader := "Bearer " + token
+
+	initResp := invokeJSON(t, env, app, map[string][]string{
+		"authorization": {authHeader},
+	}, &mcpruntime.Request{JSONRPC: "2.0", ID: 1, Method: "initialize"})
+	if initResp.Status != 200 {
+		t.Fatalf("initialize: status=%d body=%s", initResp.Status, string(initResp.Body))
+	}
+	sessionID := initResp.Headers["mcp-session-id"][0]
+
+	callParams, _ := json.Marshal(map[string]any{
+		"name":      "soul_read",
+		"arguments": map[string]any{"self": true},
+	})
+	resp := invokeJSON(t, env, app, map[string][]string{
+		"authorization":  {authHeader},
+		"mcp-session-id": {sessionID},
+	}, &mcpruntime.Request{JSONRPC: "2.0", ID: 2, Method: "tools/call", Params: callParams})
+	if resp.Status != 200 {
+		t.Fatalf("soul_read(self): status=%d body=%s", resp.Status, string(resp.Body))
+	}
+	if lesserAuthHeader != authHeader {
+		t.Fatalf("expected self verification to pass caller bearer to lesser, got %q", lesserAuthHeader)
+	}
+	for _, got := range publicAuthHeaders {
+		if strings.TrimSpace(got) != "" {
+			t.Fatalf("self soul_read public endpoint should be unauthenticated, got Authorization=%q", got)
+		}
+	}
+
+	var rpc mcpruntime.Response
+	if err := json.Unmarshal(resp.Body, &rpc); err != nil {
+		t.Fatalf("unmarshal soul_read self response: %v", err)
+	}
+	if rpc.Error != nil {
+		t.Fatalf("soul_read self rpc error: %+v", rpc.Error)
+	}
+	var toolOut mcpruntime.ToolResult
+	{
+		b, _ := json.Marshal(rpc.Result)
+		_ = json.Unmarshal(b, &toolOut)
+	}
+	data, _ := toolOut.StructuredContent["data"].(map[string]any)
+	if data["query"] != "self" || data["count"] != float64(1) {
+		t.Fatalf("unexpected self result header: %+v", data)
+	}
+	access, _ := data["access"].(map[string]any)
+	if access["mode"] != "self" || access["callerRelation"] != "self" || access["publicOnly"] != true || access["privateExpansion"] != false || access["resolution"] != "bound_caller" {
+		t.Fatalf("expected explicit self access metadata, got %+v", access)
+	}
+	souls, _ := data["souls"].([]any)
+	if len(souls) != 1 {
+		t.Fatalf("expected one self soul, got %+v", data)
+	}
+	identity, _ := souls[0].(map[string]any)["identity"].(map[string]any)
+	if identity["agentId"] != agentID || identity["localId"] != "agent-self" {
+		t.Fatalf("unexpected self identity: %+v", identity)
 	}
 }

--- a/internal/mcpserver/comm_tools.go
+++ b/internal/mcpserver/comm_tools.go
@@ -320,6 +320,7 @@ func soulReadDef() mcpruntime.ToolDef {
 				"query":{"type":"string","description":"Full soul agentId, ENS name, current-instance local ID, explicit @user@domain ActivityPub handle, or canonical actor URL."},
 				"agentId":{"type":"string","description":"Full soul agent ID. Takes precedence over query when provided."},
 				"ensName":{"type":"string","description":"Public ENS name. Takes precedence over query when agentId is absent."},
+				"self":{"type":"boolean","description":"Read the caller's own bound soul through the OAuth-bound lesser identity. Conflicts with query, agentId, and ensName."},
 				"limit":{"type":"integer","minimum":1,"maximum":3,"description":"Maximum matches to compose when query resolves through search. Defaults to 1."},
 				"include_raw":{"type":"boolean","description":"Include raw public Host/Soul endpoint payloads under _raw for audit/debug use. Defaults to false."}
 			}

--- a/internal/mcpserver/soul_read_tools.go
+++ b/internal/mcpserver/soul_read_tools.go
@@ -11,7 +11,10 @@ import (
 	mcpruntime "github.com/theory-cloud/apptheory/runtime/mcp"
 )
 
-const soulReadMaxMatches = 3
+const (
+	soulReadMaxMatches        = 3
+	soulReadDefaultClaimLevel = "self-declared"
+)
 
 func handleSoulRead(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
 	var in struct {
@@ -309,20 +312,35 @@ func normalizeSoulReadCapabilities(raw any, reg map[string]any) []any {
 	}
 	out := make([]any, 0, len(items))
 	for _, item := range items {
-		m, _ := item.(map[string]any)
-		if m == nil {
+		switch typed := item.(type) {
+		case string:
+			name := strings.TrimSpace(typed)
+			if name == "" {
+				continue
+			}
+			out = append(out, map[string]any{
+				"name":       name,
+				"claimLevel": soulReadDefaultClaimLevel,
+			})
+		case map[string]any:
+			capability := map[string]any{}
+			putFirstAny(capability, "name", typed, "capability", "name")
+			putFirstAny(capability, "scope", typed, "scope")
+			putFirstAny(capability, "constraints", typed, "constraints")
+			putFirstAny(capability, "claimLevel", typed, "claim_level", "claimLevel")
+			putFirstAny(capability, "lastValidated", typed, "last_validated", "lastValidated")
+			putFirstAny(capability, "validationRef", typed, "validation_ref", "validationRef")
+			putFirstAny(capability, "degradesTo", typed, "degrades_to", "degradesTo")
+			if _, ok := capability["name"]; ok {
+				if _, ok := capability["claimLevel"]; !ok {
+					capability["claimLevel"] = soulReadDefaultClaimLevel
+				}
+			}
+			if len(capability) > 0 {
+				out = append(out, capability)
+			}
+		default:
 			continue
-		}
-		capability := map[string]any{}
-		putFirstAny(capability, "name", m, "capability", "name")
-		putFirstAny(capability, "scope", m, "scope")
-		putFirstAny(capability, "constraints", m, "constraints")
-		putFirstAny(capability, "claimLevel", m, "claim_level", "claimLevel")
-		putFirstAny(capability, "lastValidated", m, "last_validated", "lastValidated")
-		putFirstAny(capability, "validationRef", m, "validation_ref", "validationRef")
-		putFirstAny(capability, "degradesTo", m, "degrades_to", "degradesTo")
-		if len(capability) > 0 {
-			out = append(out, capability)
 		}
 	}
 	return out

--- a/internal/mcpserver/soul_read_tools.go
+++ b/internal/mcpserver/soul_read_tools.go
@@ -162,7 +162,7 @@ func soulReadPayload(ctx context.Context, client *soulapi.Client, agentID string
 	registrationPath := agentPath + "/registration"
 	registrationRaw, registrationSource := soulReadOptional(ctx, client, "registration", registrationPath)
 	sources = append(sources, registrationSource)
-	registration, _ := registrationRaw.(map[string]any)
+	registration := normalizeSoulReadRegistrationEnvelope(registrationRaw)
 
 	capabilitiesPath := agentPath + "/capabilities"
 	capabilitiesRaw, capabilitiesSource := soulReadOptional(ctx, client, "capabilities", capabilitiesPath)
@@ -176,17 +176,23 @@ func soulReadPayload(ctx context.Context, client *soulapi.Client, agentID string
 	transparencyRaw, transparencySource := soulReadOptional(ctx, client, "transparency", transparencyPath)
 	sources = append(sources, transparencySource)
 
+	avatar := firstMap(agent, "avatar")
+	if len(avatar) == 0 {
+		avatar = firstMap(registration, "avatar")
+	}
+
 	payload := map[string]any{
-		"agentId":      agentID,
-		"identity":     normalizeSoulReadIdentity(agentID, agent),
-		"registration": normalizeSoulReadRegistration(registration, agent),
-		"capabilities": normalizeSoulReadCapabilities(capabilitiesRaw, registration),
-		"boundaries":   normalizeSoulReadBoundaries(boundariesRaw, registration),
-		"transparency": normalizeSoulReadTransparency(transparencyRaw, registration),
-		"channels":     normalizeSoulReadChannels(agent, registration),
-		"avatar":       normalizeSoulReadAvatar(firstMap(agent, "avatar")),
-		"sources":      sources,
-		"deferred":     deferred,
+		"agentId":         agentID,
+		"identity":        normalizeSoulReadIdentity(agentID, agent),
+		"registration":    normalizeSoulReadRegistration(registration, agent),
+		"capabilities":    normalizeSoulReadCapabilities(capabilitiesRaw, registration),
+		"boundaries":      normalizeSoulReadBoundaries(boundariesRaw, registration),
+		"transparency":    normalizeSoulReadTransparency(transparencyRaw, registration),
+		"channels":        normalizeSoulReadChannels(agent, registration),
+		"avatar":          normalizeSoulReadAvatar(avatar),
+		"sources":         sources,
+		"sourceEndpoints": soulReadSourceEndpoints(sources),
+		"deferred":        deferred,
 	}
 	if includeRaw {
 		payload["_raw"] = map[string]any{
@@ -198,6 +204,14 @@ func soulReadPayload(ctx context.Context, client *soulapi.Client, agentID string
 		}
 	}
 	return payload, nil
+}
+
+func normalizeSoulReadRegistrationEnvelope(raw any) map[string]any {
+	m, _ := raw.(map[string]any)
+	if nested := firstMap(m, "registration"); nested != nil {
+		return nested
+	}
+	return m
 }
 
 func soulReadOptional(ctx context.Context, client *soulapi.Client, block string, path string) (any, map[string]any) {
@@ -224,6 +238,26 @@ func soulReadSource(block string, endpoint string, status string, reason string)
 	}
 	if reason != "" {
 		out["reason"] = strings.TrimSpace(reason)
+	}
+	return out
+}
+
+func soulReadSourceEndpoints(sources []map[string]any) map[string]any {
+	out := map[string]any{}
+	for _, source := range sources {
+		block, _ := source["block"].(string)
+		block = strings.TrimSpace(block)
+		if block == "" {
+			continue
+		}
+		entry := map[string]any{}
+		for _, key := range []string{"endpoint", "status", "reason"} {
+			value, _ := source[key].(string)
+			if strings.TrimSpace(value) != "" {
+				entry[key] = strings.TrimSpace(value)
+			}
+		}
+		out[block] = entry
 	}
 	return out
 }
@@ -435,8 +469,13 @@ func firstArrayFromAny(raw any, keys ...string) []any {
 		return typed
 	case map[string]any:
 		for _, key := range keys {
-			if items, ok := typed[key].([]any); ok {
-				return items
+			switch value := typed[key].(type) {
+			case []any:
+				return value
+			case map[string]any:
+				if items := firstArrayFromAny(value, "items", "results"); len(items) > 0 {
+					return items
+				}
 			}
 		}
 	}

--- a/internal/mcpserver/soul_read_tools.go
+++ b/internal/mcpserver/soul_read_tools.go
@@ -18,6 +18,7 @@ func handleSoulRead(ctx context.Context, args json.RawMessage) (*mcpruntime.Tool
 		Query      string `json:"query"`
 		AgentID    string `json:"agentId"`
 		ENSName    string `json:"ensName"`
+		Self       bool   `json:"self,omitempty"`
 		Limit      int    `json:"limit,omitempty"`
 		IncludeRaw bool   `json:"include_raw,omitempty"`
 	}
@@ -25,12 +26,20 @@ func handleSoulRead(ctx context.Context, args json.RawMessage) (*mcpruntime.Tool
 		return toolErrorResult("invalid_request", "invalid args: "+err.Error(), 400, nil)
 	}
 
-	query := firstNonEmpty(strings.TrimSpace(in.AgentID), strings.TrimSpace(in.ENSName), strings.TrimSpace(in.Query))
-	if query == "" {
+	agentIDInput := strings.TrimSpace(in.AgentID)
+	ensNameInput := strings.TrimSpace(in.ENSName)
+	queryInput := strings.TrimSpace(in.Query)
+	query := firstNonEmpty(agentIDInput, ensNameInput, queryInput)
+	accessMode := "public"
+
+	if in.Self && query != "" {
+		return toolErrorResult("invalid_request", "self cannot be combined with query, agentId, or ensName", 400, nil)
+	}
+	if !in.Self && query == "" {
 		return toolErrorResult("invalid_request", "query, agentId, or ensName is required", 400, nil)
 	}
-	if strings.TrimSpace(in.ENSName) != "" && !looksLikeENSName(in.ENSName) {
-		return toolErrorResult("invalid_request", "ensName must be a public ENS name", 400, map[string]any{"query": strings.TrimSpace(in.ENSName)})
+	if ensNameInput != "" && !looksLikeENSName(ensNameInput) {
+		return toolErrorResult("invalid_request", "ensName must be a public ENS name", 400, map[string]any{"query": ensNameInput})
 	}
 	if looksLikeEmail(query) {
 		return identityToolResultFromError(privateReachabilityUnavailableError("email", "soul_read"))
@@ -46,7 +55,18 @@ func handleSoulRead(ctx context.Context, args json.RawMessage) (*mcpruntime.Tool
 	}
 
 	agentIDs := []string{}
-	if in.AgentID != "" || isSoulAgentID(query) {
+	if in.Self {
+		agentID, err := authenticatedAgentID(ctx)
+		if err != nil {
+			return identityToolResultFromError(err)
+		}
+		if agentID == "" {
+			return toolErrorResult("not_found", "no bound soul found for this agent", 404, nil)
+		}
+		query = "self"
+		accessMode = "self"
+		agentIDs = append(agentIDs, agentID)
+	} else if agentIDInput != "" || isSoulAgentID(query) {
 		agentID := normalizeSoulAgentID(query)
 		if agentID == "" {
 			return toolErrorResult("invalid_request", "agentId must be a full soul agent ID", 400, map[string]any{"query": query})
@@ -76,10 +96,31 @@ func handleSoulRead(ctx context.Context, args json.RawMessage) (*mcpruntime.Tool
 	}
 
 	return toolJSONResult(map[string]any{
-		"query": query,
-		"count": len(souls),
-		"souls": souls,
+		"query":  query,
+		"count":  len(souls),
+		"access": soulReadAccess(accessMode),
+		"souls":  souls,
 	}, nil)
+}
+
+func soulReadAccess(mode string) map[string]any {
+	mode = strings.ToLower(strings.TrimSpace(mode))
+	callerRelation := "public"
+	resolution := "public_lookup"
+	if mode == "self" {
+		callerRelation = "self"
+		resolution = "bound_caller"
+	} else {
+		mode = "public"
+	}
+	return map[string]any{
+		"mode":             mode,
+		"callerRelation":   callerRelation,
+		"publicOnly":       true,
+		"privateExpansion": false,
+		"authorization":    "mcp_read_scope",
+		"resolution":       resolution,
+	}
 }
 
 func boundedSoulReadLimit(limit int) int {


### PR DESCRIPTION
## Milestone
Project 21 M1 runtime policy + public soul response composition — finish lesser-body issues #131 and #132 on top of the deployed/verified `soul_read` MVP from #173.

Closes #131.
Closes #132.

## Classification
MCP-contract / tool-surface / scope-profile / lesser-integration / identity read-model hardening.

## Surfaces affected
- `soul_read` MCP tool input schema: additive optional `self` boolean.
- `soul_read` MCP tool response shape: additive `access` metadata and per-soul `sourceEndpoints` provenance map.
- `soul_read` response assembly: public registration fallback composition for capabilities, boundaries, transparency, and avatar/style data.
- Documentation for `docs/mcp.md`.

## Specialist walks referenced
- Tool surface: additive modification to existing read-only identity tool; scope remains `read`; profile availability remains both drone and souled; no side effects; static registration preserved.
- MCP contract: additive/backward-compatible optional input and response fields; no JSON-RPC envelope, OAuth metadata, endpoint, or scope semantics changed.
- Lesser integration: `self=true` uses the existing OAuth-bound `/api/v1/souls/bound/me` verification path before public composition; no new lesser endpoint or SSM/deploy contract change.
- Host delegation: Host guidance from Project 21 remains followed; public Host/Soul endpoints only; no `LESSER_HOST_INSTANCE_KEY`, private resolver, channel/preference, contactability, or mailbox API use.
- Framework: idiomatic AppTheory MCP tool registration; no framework patch.

## Consumer impact
Existing MCP clients can continue calling `soul_read` with `agentId`, `ensName`, or `query` unchanged. Clients that want caller-self reads can pass `self=true`; clients that need provenance can read additive `access` and `sourceEndpoints` fields.

## Tasks
- [x] #131 — Add runtime policy and auth handling for soul MVP.
- [x] #132 — Compose soul responses from lesser-host public sources.

## Validation
- `go test ./...`
- `go vet ./...`
- `gofmt -l .` (empty)
- `git diff --check`
- `scripts/build.sh`
- Targeted: `go test ./internal/mcpapp ./internal/mcpserver`

## Stage rollout plan (handoff to deploy-body)
- [ ] Merged to main
- [ ] Deployed to lab / dev
- [ ] Lab soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
Host steward answered the open Project 21 questions before implementation. No lesser-side or host-side code changes are required for this PR.

## Advisor-brief authorization
Aron directly authorized proceeding from the advisor-originated Project 21 brief before implementation.
