### PR TITLE
feat(soul): add private mint-conversation self reads

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -294,7 +294,7 @@ Scope key:
 | `sms_read` | Read | List inbound SMS metadata/previews from lesser-host's canonical mailbox. |
 | `voicemail_read` | Read | List inbound voice/voicemail metadata/previews from lesser-host's canonical mailbox. |
 | `identity_whoami` | Read | Return the current soul agent identity, channels, and contact preferences. |
-| `soul_read` | Read | Read a public-only soul identity bundle from Host/Soul public endpoints; private reachability and contact preferences are omitted or marked unavailable. |
+| `soul_read` | Read | Read a public soul identity bundle and, with explicit self-scope opt-in, bounded private mint-conversation data through Lesser. |
 | `identity_lookup` | Read | Resolve a public soul identity by full agent ID, ENS name, a current-instance local ID such as `medic`, an explicit remote ActivityPub handle such as `@steward@remote.example`, or a canonical actor URL such as `https://remote.example/users/steward`; returns public identity summary only. |
 | `identity_verify` | Read | Verify that a recent communication matches a resolved soul identity using public ENS resolution plus authoritative message provenance. Private email/phone reachability verification fails closed until lesser-host exposes a body-facing resolver. |
 
@@ -348,7 +348,7 @@ Notes:
   `direction`, `threadId`, bounded `query`, `unreadOnly`/`read`, `includeArchived`/`archived`, and
   `includeDeleted`/`deleted`.
 - Voice is currently receive-only: use `voicemail_read` for inbound voicemail; outbound `phone_call` is intentionally disabled.
-- `soul_read` is the Project 21 M1 public soul read-model tool. It accepts either `self=true` (the caller's
+- `soul_read` is the Project 21 public soul read-model tool. It accepts either `self=true` (the caller's
   OAuth-bound soul), or one of `agentId`, `ensName`, or `query` (full soul agent ID, ENS name, current-instance local
   ID, explicit `@user@domain` ActivityPub handle, or canonical actor URL), plus optional `limit` for search-backed
   matches and `include_raw=true` for audit/debug. `self=true` conflicts with `agentId`, `ensName`, and `query`.
@@ -362,7 +362,20 @@ Notes:
 - `soul_read.access` makes caller-self versus public-read behavior explicit. Default public reads return
   `mode:"public"`, `callerRelation:"public"`, `publicOnly:true`, and `privateExpansion:false`. `self=true` verifies the
   caller's bound lesser soul before using the same public Host/Soul read model and returns `mode:"self"` and
-  `callerRelation:"self"`. M1 does not expose private reachability even for `self=true`.
+  `callerRelation:"self"`.
+- Private M2 mint-conversation expansion is explicit and self-only. Callers must send `self=true` and
+  `include_private:["mintConversations"]`. Without `include_private`, `self=true` remains public-only. Compact private
+  list reads use `mintConversationLimit` (default `20`, maximum `50`) and call Lesser's
+  `/api/v1/souls/bound/me/mint-conversations` with the MCP caller bearer. Explicit single-conversation reads use
+  `mintConversationId` (opaque safe path value, maximum `128`) and call
+  `/api/v1/souls/bound/me/mint-conversations/{conversationId}`. The list block returns compact summaries and never
+  exposes `messages` or `producedDeclarations`; those are only returned by explicit single-conversation reads.
+- For private expansion, `soul_read.access` returns `mode:"self"`, `callerRelation:"self"`, `publicOnly:false`,
+  `privateExpansion:true`, `authorization:"lesser_self_scope_instance_trust"`, and
+  `privateBlocks:["mintConversations"]`.
+- Private mint-conversation expansion is Lesser-mediated: lesser-body forwards the MCP caller bearer only to Lesser's
+  `/api/v1/souls/bound/me/...` routes. lesser-body does not call lesser-host directly for this private soul path and
+  does not pass the MCP caller bearer to lesser-host.
 - `soul_read` uses only public Host/Soul endpoints without `LESSER_HOST_INSTANCE_KEY`: `/api/v1/soul/agents/{agentId}`,
   `/registration`, `/capabilities`, `/boundaries`, `/transparency`, public ENS resolution, and public search. It must
   not call private email/phone resolvers, private channel/preference endpoints, contactability APIs, or mailbox APIs for

--- a/docs/security.md
+++ b/docs/security.md
@@ -63,6 +63,31 @@ remain the long-term inbound client auth model.
 
 It does not log bearer tokens or tool arguments by default.
 
+## Private soul self-scope reads
+
+Project 21 M2 private mint-conversation reads use a Lesser-mediated trust seam:
+
+```text
+MCP caller -> lesser-body /mcp/{actor}
+lesser-body -> Lesser /api/v1/souls/bound/me/...
+Lesser -> lesser-host with managed instance trust
+```
+
+`soul_read` may request bounded private mint-conversation data only when the caller explicitly sends `self=true` and
+`include_private:["mintConversations"]`. `self=true` alone remains public-only. For this path, lesser-body forwards the
+MCP caller bearer only to Lesser's self-scope routes. It does **not** call lesser-host directly, does **not** use
+`LESSER_HOST_INSTANCE_KEY`, and does **not** pass MCP caller bearer tokens to lesser-host control-plane auth.
+
+The rejected unsafe pattern is direct MCP bearer forwarding to lesser-host. MCP bearers are issued by Lesser for an
+actor-scoped MCP resource; lesser-host control-plane auth cannot derive the local account, current instance domain, or
+soul/body binding proof from that token. Lesser owns that self-scope proof, derives the bound Host `agentId`, and then
+uses managed instance trust to call Host.
+
+Private mint-conversation list responses are compact summaries only. Full `messages` and `producedDeclarations` content
+is returned only by explicit single-conversation reads and must not be logged. Error details preserve machine-readable
+upstream reason codes without logging tokens, instance keys, message bodies, produced declarations, or raw private
+conversation content.
+
 ## IAM (least privilege)
 
 At a minimum, the MCP Lambda needs:

--- a/internal/mcpapp/comm_contract_test.go
+++ b/internal/mcpapp/comm_contract_test.go
@@ -168,6 +168,9 @@ func TestLBM0_CommunicationToolSchemasMatchSpec(t *testing.T) {
 		expectPropType(t, s, "agentId", "string")
 		expectPropType(t, s, "ensName", "string")
 		expectPropType(t, s, "self", "boolean")
+		expectPropType(t, s, "include_private", "array")
+		expectPropType(t, s, "mintConversationId", "string")
+		expectPropType(t, s, "mintConversationLimit", "integer")
 		expectPropType(t, s, "limit", "integer")
 		expectPropType(t, s, "include_raw", "boolean")
 	}

--- a/internal/mcpapp/identity_surfaces_test.go
+++ b/internal/mcpapp/identity_surfaces_test.go
@@ -1594,3 +1594,443 @@ func TestLBM1_SoulReadComposesRegistrationFallbackBlocks(t *testing.T) {
 		t.Fatalf("expected identity source endpoint, got %+v", sourceEndpoints)
 	}
 }
+
+func TestLBM2_SoulReadPrivateMintConversationsUsesLesserSelfRoute(t *testing.T) {
+	t.Setenv("MCP_SESSION_TABLE", "")
+	t.Setenv("JWT_SECRET", "test")
+	auth.ResetForTests()
+	lesserapi.ResetForTests()
+	soulapi.ResetForTests()
+	t.Cleanup(lesserapi.ResetForTests)
+	t.Cleanup(soulapi.ResetForTests)
+
+	const agentID = "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+	installSoulBindingLookup(t, "Agent1", agentID)
+
+	var lesserSelfAuth string
+	var privateListAuth string
+	var privateListLimit string
+	var directHostPath string
+	var publicAuthHeaders []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.HasPrefix(r.URL.Path, "/api/v1/soul/instance/") {
+			directHostPath = r.URL.Path
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"error":"body must not call host directly"}`))
+			return
+		}
+		switch r.URL.Path {
+		case "/api/v1/souls/bound/me":
+			lesserSelfAuth = r.Header.Get("Authorization")
+			_, _ = w.Write([]byte(boundSelfResponse(agentID, "agent1", "test.example.com", "agent-private")))
+		case "/api/v1/soul/agents/" + agentID:
+			publicAuthHeaders = append(publicAuthHeaders, r.Header.Get("Authorization"))
+			_, _ = w.Write([]byte(`{"agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-private","status":"active"}}`))
+		case "/api/v1/soul/agents/" + agentID + "/registration":
+			publicAuthHeaders = append(publicAuthHeaders, r.Header.Get("Authorization"))
+			_, _ = w.Write([]byte(`{"version":"1"}`))
+		case "/api/v1/soul/agents/" + agentID + "/capabilities",
+			"/api/v1/soul/agents/" + agentID + "/boundaries",
+			"/api/v1/soul/agents/" + agentID + "/transparency":
+			publicAuthHeaders = append(publicAuthHeaders, r.Header.Get("Authorization"))
+			_, _ = w.Write([]byte(`{}`))
+		case "/api/v1/souls/bound/me/mint-conversations":
+			privateListAuth = r.Header.Get("Authorization")
+			privateListLimit = r.URL.Query().Get("limit")
+			_, _ = w.Write([]byte(`{
+				"version":"1",
+				"conversations":[{
+					"agent_id":"` + agentID + `",
+					"conversation_id":"conv-1",
+					"model":"gpt-test",
+					"messages":"private list content must not appear",
+					"produced_declarations":"private declarations must not appear",
+					"status":"completed",
+					"usage":{"input_tokens":1},
+					"charged_credits":3,
+					"created_at":"2026-05-11T21:00:00Z",
+					"completed_at":"2026-05-11T21:01:00Z"
+				}],
+				"count":1,
+				"limit":2
+			}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":{"message":"not found"}}`))
+		}
+	}))
+	defer server.Close()
+
+	t.Setenv("LESSER_API_BASE_URL", server.URL)
+	t.Setenv("LESSER_SOUL_API_BASE_URL", server.URL)
+	t.Setenv("LESSER_HOST_INSTANCE_KEY", "must-not-be-used-by-soul-read")
+	lesserapi.ResetForTests()
+	soulapi.ResetForTests()
+
+	app, err := mcpapp.New("test", "dev")
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+	env := testkit.New()
+	token := newTestToken(t, "test", "Agent1", []string{"read"})
+	authHeader := "Bearer " + token
+
+	initResp := invokeJSON(t, env, app, map[string][]string{"authorization": {authHeader}}, &mcpruntime.Request{JSONRPC: "2.0", ID: 1, Method: "initialize"})
+	if initResp.Status != 200 {
+		t.Fatalf("initialize: status=%d body=%s", initResp.Status, string(initResp.Body))
+	}
+	sessionID := initResp.Headers["mcp-session-id"][0]
+
+	callParams, _ := json.Marshal(map[string]any{
+		"name": "soul_read",
+		"arguments": map[string]any{
+			"self":                  true,
+			"include_private":       []string{"mintConversations"},
+			"mintConversationLimit": 2,
+		},
+	})
+	resp := invokeJSON(t, env, app, map[string][]string{
+		"authorization":  {authHeader},
+		"mcp-session-id": {sessionID},
+	}, &mcpruntime.Request{JSONRPC: "2.0", ID: 2, Method: "tools/call", Params: callParams})
+	if resp.Status != 200 {
+		t.Fatalf("soul_read private list: status=%d body=%s", resp.Status, string(resp.Body))
+	}
+	if lesserSelfAuth != authHeader || privateListAuth != authHeader {
+		t.Fatalf("expected caller bearer only to Lesser self routes, bound=%q private=%q", lesserSelfAuth, privateListAuth)
+	}
+	if privateListLimit != "2" {
+		t.Fatalf("expected private list limit=2, got %q", privateListLimit)
+	}
+	if directHostPath != "" {
+		t.Fatalf("soul_read must not call Host directly, hit %q", directHostPath)
+	}
+	for _, got := range publicAuthHeaders {
+		if strings.TrimSpace(got) != "" {
+			t.Fatalf("public soul_read endpoint should be unauthenticated, got Authorization=%q", got)
+		}
+	}
+
+	var rpc mcpruntime.Response
+	if err := json.Unmarshal(resp.Body, &rpc); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if rpc.Error != nil {
+		t.Fatalf("rpc error: %+v", rpc.Error)
+	}
+	var toolOut mcpruntime.ToolResult
+	{
+		b, _ := json.Marshal(rpc.Result)
+		_ = json.Unmarshal(b, &toolOut)
+	}
+	data, _ := toolOut.StructuredContent["data"].(map[string]any)
+	access, _ := data["access"].(map[string]any)
+	if access["mode"] != "self" || access["publicOnly"] != false || access["privateExpansion"] != true || access["authorization"] != "lesser_self_scope_instance_trust" {
+		t.Fatalf("unexpected private access metadata: %+v", access)
+	}
+	souls, _ := data["souls"].([]any)
+	soul, _ := souls[0].(map[string]any)
+	privateBlocks, _ := soul["private"].(map[string]any)
+	mint, _ := privateBlocks["mintConversations"].(map[string]any)
+	if mint["mode"] != "list" || mint["limit"] != float64(2) || mint["count"] != float64(1) {
+		t.Fatalf("unexpected private mint list block: %+v", mint)
+	}
+	conversations, _ := mint["conversations"].([]any)
+	if len(conversations) != 1 {
+		t.Fatalf("expected one conversation summary, got %+v", mint)
+	}
+	summary, _ := conversations[0].(map[string]any)
+	if summary["conversationId"] != "conv-1" || summary["chargedCredits"] != float64(3) {
+		t.Fatalf("unexpected conversation summary: %+v", summary)
+	}
+	if _, ok := summary["messages"]; ok {
+		t.Fatalf("list summaries must not expose messages: %+v", summary)
+	}
+	if _, ok := summary["producedDeclarations"]; ok {
+		t.Fatalf("list summaries must not expose produced declarations: %+v", summary)
+	}
+}
+
+func TestLBM2_SoulReadPrivateMintConversationSingleIncludesExplicitContent(t *testing.T) {
+	t.Setenv("MCP_SESSION_TABLE", "")
+	t.Setenv("JWT_SECRET", "test")
+	auth.ResetForTests()
+	lesserapi.ResetForTests()
+	soulapi.ResetForTests()
+	t.Cleanup(lesserapi.ResetForTests)
+	t.Cleanup(soulapi.ResetForTests)
+
+	const agentID = "0x9999999999999999999999999999999999999999999999999999999999999999"
+	const conversationID = "conv:single.1"
+	installSoulBindingLookup(t, "Agent1", agentID)
+
+	var privateGetAuth string
+	var privateGetQuery string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/souls/bound/me":
+			_, _ = w.Write([]byte(boundSelfResponse(agentID, "agent1", "test.example.com", "agent-private")))
+		case "/api/v1/soul/agents/" + agentID:
+			_, _ = w.Write([]byte(`{"agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-private","status":"active"}}`))
+		case "/api/v1/soul/agents/" + agentID + "/registration",
+			"/api/v1/soul/agents/" + agentID + "/capabilities",
+			"/api/v1/soul/agents/" + agentID + "/boundaries",
+			"/api/v1/soul/agents/" + agentID + "/transparency":
+			_, _ = w.Write([]byte(`{}`))
+		case "/api/v1/souls/bound/me/mint-conversations/" + conversationID:
+			privateGetAuth = r.Header.Get("Authorization")
+			privateGetQuery = r.URL.RawQuery
+			_, _ = w.Write([]byte(`{
+				"version":"1",
+				"conversation":{
+					"agent_id":"` + agentID + `",
+					"conversation_id":"` + conversationID + `",
+					"model":"gpt-test",
+					"messages":"[{\"role\":\"user\",\"content\":\"private\"}]",
+					"produced_declarations":"{\"capabilities\":[]}",
+					"status":"completed",
+					"usage":{"output_tokens":2},
+					"charged_credits":7,
+					"created_at":"2026-05-11T21:00:00Z",
+					"completed_at":"2026-05-11T21:01:00Z"
+				}
+			}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":{"message":"not found"}}`))
+		}
+	}))
+	defer server.Close()
+
+	t.Setenv("LESSER_API_BASE_URL", server.URL)
+	t.Setenv("LESSER_SOUL_API_BASE_URL", server.URL)
+	lesserapi.ResetForTests()
+	soulapi.ResetForTests()
+
+	app, err := mcpapp.New("test", "dev")
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+	env := testkit.New()
+	token := newTestToken(t, "test", "Agent1", []string{"read"})
+	authHeader := "Bearer " + token
+
+	initResp := invokeJSON(t, env, app, map[string][]string{"authorization": {authHeader}}, &mcpruntime.Request{JSONRPC: "2.0", ID: 1, Method: "initialize"})
+	if initResp.Status != 200 {
+		t.Fatalf("initialize: status=%d body=%s", initResp.Status, string(initResp.Body))
+	}
+	sessionID := initResp.Headers["mcp-session-id"][0]
+	callParams, _ := json.Marshal(map[string]any{
+		"name": "soul_read",
+		"arguments": map[string]any{
+			"self":               true,
+			"include_private":    []string{"mintConversations"},
+			"mintConversationId": conversationID,
+		},
+	})
+	resp := invokeJSON(t, env, app, map[string][]string{
+		"authorization":  {authHeader},
+		"mcp-session-id": {sessionID},
+	}, &mcpruntime.Request{JSONRPC: "2.0", ID: 2, Method: "tools/call", Params: callParams})
+	if resp.Status != 200 {
+		t.Fatalf("soul_read private single: status=%d body=%s", resp.Status, string(resp.Body))
+	}
+	if privateGetAuth != authHeader {
+		t.Fatalf("expected caller bearer to Lesser private get route, got %q", privateGetAuth)
+	}
+	if privateGetQuery != "" {
+		t.Fatalf("single conversation read must not send list query, got %q", privateGetQuery)
+	}
+	var rpc mcpruntime.Response
+	_ = json.Unmarshal(resp.Body, &rpc)
+	if rpc.Error != nil {
+		t.Fatalf("rpc error: %+v", rpc.Error)
+	}
+	var toolOut mcpruntime.ToolResult
+	{
+		b, _ := json.Marshal(rpc.Result)
+		_ = json.Unmarshal(b, &toolOut)
+	}
+	data, _ := toolOut.StructuredContent["data"].(map[string]any)
+	souls, _ := data["souls"].([]any)
+	soul, _ := souls[0].(map[string]any)
+	privateBlocks, _ := soul["private"].(map[string]any)
+	mint, _ := privateBlocks["mintConversations"].(map[string]any)
+	if mint["mode"] != "single" {
+		t.Fatalf("expected single private mode, got %+v", mint)
+	}
+	conversation, _ := mint["conversation"].(map[string]any)
+	if conversation["conversationId"] != conversationID || !strings.Contains(conversation["messages"].(string), "private") || conversation["producedDeclarations"] == "" {
+		t.Fatalf("unexpected single private conversation: %+v", conversation)
+	}
+}
+
+func TestLBM2_SoulReadPrivateMintConversationsFailsClosed(t *testing.T) {
+	t.Setenv("MCP_SESSION_TABLE", "")
+	t.Setenv("JWT_SECRET", "test")
+	installMissingSoulBindingLookup(t)
+	auth.ResetForTests()
+	lesserapi.ResetForTests()
+	soulapi.ResetForTests()
+	t.Cleanup(lesserapi.ResetForTests)
+	t.Cleanup(soulapi.ResetForTests)
+
+	const agentID = "0x8888888888888888888888888888888888888888888888888888888888888888"
+	var privateRouteCalled bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/soul/agents/" + agentID:
+			_, _ = w.Write([]byte(`{"agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-public","status":"active"}}`))
+		case "/api/v1/souls/bound/me/mint-conversations":
+			privateRouteCalled = true
+			_, _ = w.Write([]byte(`{"version":"1","conversations":[],"count":0,"limit":20}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":{"message":"not found"}}`))
+		}
+	}))
+	defer server.Close()
+
+	t.Setenv("LESSER_API_BASE_URL", server.URL)
+	t.Setenv("LESSER_SOUL_API_BASE_URL", server.URL)
+	lesserapi.ResetForTests()
+	soulapi.ResetForTests()
+
+	app, err := mcpapp.New("test", "dev")
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+	env := testkit.New()
+	token := newTestToken(t, "test", "Agent1", []string{"read"})
+	authHeader := "Bearer " + token
+	initResp := invokeJSON(t, env, app, map[string][]string{"authorization": {authHeader}}, &mcpruntime.Request{JSONRPC: "2.0", ID: 1, Method: "initialize"})
+	if initResp.Status != 200 {
+		t.Fatalf("initialize: status=%d body=%s", initResp.Status, string(initResp.Body))
+	}
+	sessionID := initResp.Headers["mcp-session-id"][0]
+
+	callParams, _ := json.Marshal(map[string]any{
+		"name": "soul_read",
+		"arguments": map[string]any{
+			"agentId":         agentID,
+			"include_private": []string{"mintConversations"},
+		},
+	})
+	resp := invokeJSON(t, env, app, map[string][]string{
+		"authorization":  {authHeader},
+		"mcp-session-id": {sessionID},
+	}, &mcpruntime.Request{JSONRPC: "2.0", ID: 2, Method: "tools/call", Params: callParams})
+	if resp.Status != 200 {
+		t.Fatalf("soul_read non-self private: status=%d body=%s", resp.Status, string(resp.Body))
+	}
+	var rpc mcpruntime.Response
+	_ = json.Unmarshal(resp.Body, &rpc)
+	if rpc.Error != nil {
+		t.Fatalf("rpc error: %+v", rpc.Error)
+	}
+	var toolOut mcpruntime.ToolResult
+	{
+		b, _ := json.Marshal(rpc.Result)
+		_ = json.Unmarshal(b, &toolOut)
+	}
+	if !toolOut.IsError {
+		t.Fatalf("expected private non-self request to fail closed, got %+v", toolOut)
+	}
+	errPayload, _ := toolOut.StructuredContent["error"].(map[string]any)
+	if errPayload["code"] != "invalid_request" {
+		t.Fatalf("expected invalid_request, got %+v", errPayload)
+	}
+	if privateRouteCalled {
+		t.Fatalf("private route should not be called for non-self request")
+	}
+}
+
+func TestLBM2_SoulReadPrivateMintConversationsMapsLesserErrors(t *testing.T) {
+	t.Setenv("MCP_SESSION_TABLE", "")
+	t.Setenv("JWT_SECRET", "test")
+	auth.ResetForTests()
+	lesserapi.ResetForTests()
+	soulapi.ResetForTests()
+	t.Cleanup(lesserapi.ResetForTests)
+	t.Cleanup(soulapi.ResetForTests)
+
+	const agentID = "0x7777777777777777777777777777777777777777777777777777777777777777"
+	installSoulBindingLookup(t, "Agent1", agentID)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/souls/bound/me":
+			_, _ = w.Write([]byte(boundSelfResponse(agentID, "agent1", "test.example.com", "agent-private")))
+		case "/api/v1/soul/agents/" + agentID:
+			_, _ = w.Write([]byte(`{"agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-private","status":"active"}}`))
+		case "/api/v1/soul/agents/" + agentID + "/registration",
+			"/api/v1/soul/agents/" + agentID + "/capabilities",
+			"/api/v1/soul/agents/" + agentID + "/boundaries",
+			"/api/v1/soul/agents/" + agentID + "/transparency":
+			_, _ = w.Write([]byte(`{}`))
+		case "/api/v1/souls/bound/me/mint-conversations":
+			w.Header().Set("Retry-After", "3")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"error":"private soul conversation read rate limited","error_description":"slow down","error_code":"SOUL_PRIVATE_RATE_LIMITED"}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":{"message":"not found"}}`))
+		}
+	}))
+	defer server.Close()
+	t.Setenv("LESSER_API_BASE_URL", server.URL)
+	t.Setenv("LESSER_SOUL_API_BASE_URL", server.URL)
+	lesserapi.ResetForTests()
+	soulapi.ResetForTests()
+
+	app, err := mcpapp.New("test", "dev")
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+	env := testkit.New()
+	token := newTestToken(t, "test", "Agent1", []string{"read"})
+	authHeader := "Bearer " + token
+	initResp := invokeJSON(t, env, app, map[string][]string{"authorization": {authHeader}}, &mcpruntime.Request{JSONRPC: "2.0", ID: 1, Method: "initialize"})
+	if initResp.Status != 200 {
+		t.Fatalf("initialize: status=%d body=%s", initResp.Status, string(initResp.Body))
+	}
+	sessionID := initResp.Headers["mcp-session-id"][0]
+	callParams, _ := json.Marshal(map[string]any{
+		"name": "soul_read",
+		"arguments": map[string]any{
+			"self":            true,
+			"include_private": []string{"mintConversations"},
+		},
+	})
+	resp := invokeJSON(t, env, app, map[string][]string{
+		"authorization":  {authHeader},
+		"mcp-session-id": {sessionID},
+	}, &mcpruntime.Request{JSONRPC: "2.0", ID: 2, Method: "tools/call", Params: callParams})
+	if resp.Status != 200 {
+		t.Fatalf("soul_read private rate limited: status=%d body=%s", resp.Status, string(resp.Body))
+	}
+	var rpc mcpruntime.Response
+	_ = json.Unmarshal(resp.Body, &rpc)
+	if rpc.Error != nil {
+		t.Fatalf("rpc error: %+v", rpc.Error)
+	}
+	var toolOut mcpruntime.ToolResult
+	{
+		b, _ := json.Marshal(rpc.Result)
+		_ = json.Unmarshal(b, &toolOut)
+	}
+	if !toolOut.IsError {
+		t.Fatalf("expected tool error, got %+v", toolOut)
+	}
+	errPayload, _ := toolOut.StructuredContent["error"].(map[string]any)
+	if errPayload["code"] != "rate_limited" || errPayload["status"] != float64(http.StatusTooManyRequests) {
+		t.Fatalf("unexpected private rate-limit error: %+v", errPayload)
+	}
+	details, _ := errPayload["details"].(map[string]any)
+	if details["upstreamErrorCode"] != "SOUL_PRIVATE_RATE_LIMITED" || details["retryAfter"] != "3" {
+		t.Fatalf("expected upstream error details, got %+v", details)
+	}
+}

--- a/internal/mcpserver/comm_tools.go
+++ b/internal/mcpserver/comm_tools.go
@@ -312,7 +312,7 @@ func voicemailReadDef() mcpruntime.ToolDef {
 func soulReadDef() mcpruntime.ToolDef {
 	return mcpruntime.ToolDef{
 		Name:        "soul_read",
-		Description: "Read a public-only soul identity bundle from Host/Soul public endpoints. Private email/phone reachability and contact preferences are omitted or marked unavailable.",
+		Description: "Read a public soul identity bundle and, with explicit self-scope opt-in, bounded private mint-conversation data through Lesser. Private email/phone reachability and contact preferences are omitted or marked unavailable.",
 		Annotations: readOnlyToolAnnotations(),
 		InputSchema: json.RawMessage(`{
 			"type":"object",
@@ -321,6 +321,9 @@ func soulReadDef() mcpruntime.ToolDef {
 				"agentId":{"type":"string","description":"Full soul agent ID. Takes precedence over query when provided."},
 				"ensName":{"type":"string","description":"Public ENS name. Takes precedence over query when agentId is absent."},
 				"self":{"type":"boolean","description":"Read the caller's own bound soul through the OAuth-bound lesser identity. Conflicts with query, agentId, and ensName."},
+				"include_private":{"type":"array","items":{"type":"string","enum":["mintConversations"]},"description":"Explicit private self-scope blocks to include. Requires self=true. M2 supports mintConversations only."},
+				"mintConversationId":{"type":"string","maxLength":128,"description":"Opaque mint-conversation ID for an explicit single-conversation private self read. Requires include_private=[\"mintConversations\"]."},
+				"mintConversationLimit":{"type":"integer","minimum":1,"maximum":50,"description":"Maximum compact mint-conversation summaries for private self list reads. Defaults to 20 and does not affect public search match limit."},
 				"limit":{"type":"integer","minimum":1,"maximum":3,"description":"Maximum matches to compose when query resolves through search. Defaults to 1."},
 				"include_raw":{"type":"boolean","description":"Include raw public Host/Soul endpoint payloads under _raw for audit/debug use. Defaults to false."}
 			}

--- a/internal/mcpserver/soul_read_tools.go
+++ b/internal/mcpserver/soul_read_tools.go
@@ -4,27 +4,48 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/http"
 	"net/url"
+	"regexp"
+	"strconv"
 	"strings"
 
+	"github.com/equaltoai/lesser-body/internal/lesserapi"
 	"github.com/equaltoai/lesser-body/internal/soulapi"
 	mcpruntime "github.com/theory-cloud/apptheory/runtime/mcp"
 )
 
 const (
-	soulReadMaxMatches        = 3
-	soulReadDefaultClaimLevel = "self-declared"
+	soulReadMaxMatches                      = 3
+	soulReadDefaultClaimLevel               = "self-declared"
+	soulReadPrivateMintConversationsBlock   = "mintConversations"
+	soulReadPrivateDefaultConversationLimit = 20
+	soulReadPrivateMaxConversationLimit     = 50
+	soulReadPrivateConversationIDMaxLen     = 128
 )
 
+var soulReadPrivateConversationIDPattern = regexp.MustCompile(`^[A-Za-z0-9._:-]{1,128}$`)
+
+type soulReadInput struct {
+	Query                 string   `json:"query"`
+	AgentID               string   `json:"agentId"`
+	ENSName               string   `json:"ensName"`
+	Self                  bool     `json:"self,omitempty"`
+	Limit                 int      `json:"limit,omitempty"`
+	IncludePrivate        []string `json:"include_private,omitempty"`
+	MintConversationID    string   `json:"mintConversationId,omitempty"`
+	MintConversationLimit int      `json:"mintConversationLimit,omitempty"`
+	IncludeRaw            bool     `json:"include_raw,omitempty"`
+}
+
+type soulReadPrivateRequest struct {
+	IncludeMintConversations bool
+	ConversationID           string
+	Limit                    int
+}
+
 func handleSoulRead(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
-	var in struct {
-		Query      string `json:"query"`
-		AgentID    string `json:"agentId"`
-		ENSName    string `json:"ensName"`
-		Self       bool   `json:"self,omitempty"`
-		Limit      int    `json:"limit,omitempty"`
-		IncludeRaw bool   `json:"include_raw,omitempty"`
-	}
+	var in soulReadInput
 	if err := json.Unmarshal(args, &in); err != nil {
 		return toolErrorResult("invalid_request", "invalid args: "+err.Error(), 400, nil)
 	}
@@ -40,6 +61,10 @@ func handleSoulRead(ctx context.Context, args json.RawMessage) (*mcpruntime.Tool
 	}
 	if !in.Self && query == "" {
 		return toolErrorResult("invalid_request", "query, agentId, or ensName is required", 400, nil)
+	}
+	privateReq, err := soulReadPrivateRequestFromInput(in)
+	if err != nil {
+		return identityToolResultFromError(err)
 	}
 	if ensNameInput != "" && !looksLikeENSName(ensNameInput) {
 		return toolErrorResult("invalid_request", "ensName must be a public ENS name", 400, map[string]any{"query": ensNameInput})
@@ -91,7 +116,7 @@ func handleSoulRead(ctx context.Context, args json.RawMessage) (*mcpruntime.Tool
 
 	souls := make([]any, 0, len(agentIDs))
 	for _, agentID := range agentIDs {
-		soul, err := soulReadPayload(ctx, client, agentID, in.IncludeRaw)
+		soul, err := soulReadPayload(ctx, client, agentID, in.IncludeRaw, privateReq)
 		if err != nil {
 			return identityToolResultFromError(err)
 		}
@@ -101,29 +126,99 @@ func handleSoulRead(ctx context.Context, args json.RawMessage) (*mcpruntime.Tool
 	return toolJSONResult(map[string]any{
 		"query":  query,
 		"count":  len(souls),
-		"access": soulReadAccess(accessMode),
+		"access": soulReadAccess(accessMode, privateReq.privateBlocks()),
 		"souls":  souls,
 	}, nil)
 }
 
-func soulReadAccess(mode string) map[string]any {
+func soulReadPrivateRequestFromInput(in soulReadInput) (soulReadPrivateRequest, error) {
+	out := soulReadPrivateRequest{}
+	privateBlocks := map[string]struct{}{}
+	for _, raw := range in.IncludePrivate {
+		block := strings.TrimSpace(raw)
+		switch block {
+		case "":
+			continue
+		case soulReadPrivateMintConversationsBlock:
+			privateBlocks[block] = struct{}{}
+		default:
+			return out, &toolUserError{Code: "invalid_request", Message: "unsupported include_private block: " + block, Status: 400}
+		}
+	}
+
+	_, wantsMintConversations := privateBlocks[soulReadPrivateMintConversationsBlock]
+	conversationID := strings.TrimSpace(in.MintConversationID)
+	if conversationID != "" && !wantsMintConversations {
+		return out, &toolUserError{Code: "invalid_request", Message: "mintConversationId requires include_private=[\"mintConversations\"]", Status: 400}
+	}
+	if in.MintConversationLimit != 0 && !wantsMintConversations {
+		return out, &toolUserError{Code: "invalid_request", Message: "mintConversationLimit requires include_private=[\"mintConversations\"]", Status: 400}
+	}
+	if !wantsMintConversations {
+		return out, nil
+	}
+	if !in.Self {
+		return out, &toolUserError{Code: "invalid_request", Message: "private mint-conversation expansion requires self=true", Status: 400}
+	}
+	if conversationID != "" {
+		if len(conversationID) > soulReadPrivateConversationIDMaxLen || !soulReadPrivateConversationIDPattern.MatchString(conversationID) {
+			return out, &toolUserError{Code: "invalid_request", Message: "mintConversationId must be an opaque safe path value", Status: 400}
+		}
+		if in.MintConversationLimit > 0 {
+			return out, &toolUserError{Code: "invalid_request", Message: "mintConversationLimit cannot be combined with mintConversationId", Status: 400}
+		}
+		out.ConversationID = conversationID
+	}
+
+	limit := in.MintConversationLimit
+	if limit < 0 || limit > soulReadPrivateMaxConversationLimit {
+		return out, &toolUserError{Code: "invalid_request", Message: "mintConversationLimit must be between 1 and 50", Status: 400}
+	}
+	if limit == 0 {
+		limit = soulReadPrivateDefaultConversationLimit
+	}
+	out.IncludeMintConversations = true
+	out.Limit = limit
+	return out, nil
+}
+
+func (r soulReadPrivateRequest) privateBlocks() []any {
+	if !r.IncludeMintConversations {
+		return nil
+	}
+	return []any{soulReadPrivateMintConversationsBlock}
+}
+
+func soulReadAccess(mode string, privateBlocks []any) map[string]any {
 	mode = strings.ToLower(strings.TrimSpace(mode))
 	callerRelation := "public"
 	resolution := "public_lookup"
+	authorization := "mcp_read_scope"
+	publicOnly := true
+	privateExpansion := false
 	if mode == "self" {
 		callerRelation = "self"
 		resolution = "bound_caller"
 	} else {
 		mode = "public"
 	}
-	return map[string]any{
+	if len(privateBlocks) > 0 {
+		publicOnly = false
+		privateExpansion = true
+		authorization = "lesser_self_scope_instance_trust"
+	}
+	out := map[string]any{
 		"mode":             mode,
 		"callerRelation":   callerRelation,
-		"publicOnly":       true,
-		"privateExpansion": false,
-		"authorization":    "mcp_read_scope",
+		"publicOnly":       publicOnly,
+		"privateExpansion": privateExpansion,
+		"authorization":    authorization,
 		"resolution":       resolution,
 	}
+	if len(privateBlocks) > 0 {
+		out["privateBlocks"] = privateBlocks
+	}
+	return out
 }
 
 func boundedSoulReadLimit(limit int) int {
@@ -137,7 +232,7 @@ func boundedSoulReadLimit(limit int) int {
 	}
 }
 
-func soulReadPayload(ctx context.Context, client *soulapi.Client, agentID string, includeRaw bool) (map[string]any, error) {
+func soulReadPayload(ctx context.Context, client *soulapi.Client, agentID string, includeRaw bool, privateReq soulReadPrivateRequest) (map[string]any, error) {
 	agentID = normalizeSoulAgentID(agentID)
 	if agentID == "" {
 		return nil, &toolUserError{Code: "invalid_request", Message: "missing agentId", Status: 400}
@@ -206,7 +301,52 @@ func soulReadPayload(ctx context.Context, client *soulapi.Client, agentID string
 			"transparency": transparencyRaw,
 		}
 	}
+	if privateReq.IncludeMintConversations {
+		privatePayload, err := soulReadPrivateMintConversations(ctx, privateReq)
+		if err != nil {
+			return nil, err
+		}
+		payload["private"] = map[string]any{
+			soulReadPrivateMintConversationsBlock: privatePayload,
+		}
+	}
 	return payload, nil
+}
+
+func soulReadPrivateMintConversations(ctx context.Context, privateReq soulReadPrivateRequest) (map[string]any, error) {
+	token, err := requireOAuthBearer(ctx)
+	if err != nil {
+		return nil, err
+	}
+	client, err := lesser(ctx)
+	if err != nil {
+		return nil, &toolUserError{Code: "not_configured", Message: err.Error(), Status: 500}
+	}
+
+	path := "/api/v1/souls/bound/me/mint-conversations"
+	query := url.Values{}
+	mode := "list"
+	if privateReq.ConversationID != "" {
+		path += "/" + url.PathEscape(privateReq.ConversationID)
+		mode = "single"
+	} else {
+		query.Set("limit", strconv.Itoa(privateReq.Limit))
+	}
+
+	raw, headers, err := client.DoJSONWithHeaders(ctx, "GET", path, query, token, nil)
+	if err != nil {
+		return nil, soulReadPrivateLesserError(err, headers)
+	}
+
+	var out map[string]any
+	if mode == "single" {
+		out = normalizeSoulReadMintConversationSingle(raw)
+	} else {
+		out = normalizeSoulReadMintConversationList(raw)
+	}
+	out["mode"] = mode
+	out["source"] = soulReadSource(soulReadPrivateMintConversationsBlock, path, "ok", "")
+	return out, nil
 }
 
 func normalizeSoulReadRegistrationEnvelope(raw any) map[string]any {
@@ -261,6 +401,139 @@ func soulReadSourceEndpoints(sources []map[string]any) map[string]any {
 			}
 		}
 		out[block] = entry
+	}
+	return out
+}
+
+func soulReadPrivateLesserError(err error, headers http.Header) error {
+	if err == nil {
+		return nil
+	}
+	if failure := lesserAuthFailureFromError(err); failure != nil {
+		return failure
+	}
+
+	var apiErr *lesserapi.APIError
+	if errors.As(err, &apiErr) {
+		message, upstreamCode, parsed := soulReadPrivateLesserErrorMessage(apiErr.Body)
+		details := map[string]any{
+			"source":         "lesser_private_self_scope",
+			"upstreamStatus": apiErr.Status,
+		}
+		if upstreamCode != "" {
+			details["upstreamErrorCode"] = upstreamCode
+		}
+		if parsed != nil {
+			details["apiError"] = parsed
+		}
+		if retryAfter := strings.TrimSpace(headers.Get("Retry-After")); retryAfter != "" {
+			details["retryAfter"] = retryAfter
+		}
+		return &toolUserError{
+			Code:    soulReadPrivateToolErrorCode(apiErr.Status, upstreamCode),
+			Message: message,
+			Status:  apiErr.Status,
+			Details: details,
+		}
+	}
+	return &toolUserError{Code: "upstream_error", Message: err.Error(), Status: 500}
+}
+
+func soulReadPrivateLesserErrorMessage(body []byte) (message string, upstreamCode string, parsed map[string]any) {
+	raw := strings.TrimSpace(string(body))
+	if strings.HasPrefix(raw, "{") {
+		if err := json.Unmarshal([]byte(raw), &parsed); err == nil {
+			upstreamCode = firstNonEmptyStringMap(parsed, "error_code", "code")
+			message = firstNonEmptyStringMap(parsed, "error_description", "error", "message")
+			if message != "" {
+				return message, upstreamCode, parsed
+			}
+		}
+	}
+	message, parsed = commExtractAPIErrorMessage(body)
+	upstreamCode = firstNonEmptyStringMap(parsed, "error_code", "code")
+	return message, upstreamCode, parsed
+}
+
+func soulReadPrivateToolErrorCode(status int, upstreamCode string) string {
+	switch strings.ToUpper(strings.TrimSpace(upstreamCode)) {
+	case "SOUL_PRIVATE_RATE_LIMITED":
+		return "rate_limited"
+	case "SOUL_PRIVATE_RESPONSE_TOO_LARGE":
+		return "response_too_large"
+	case "SOUL_PRIVATE_TRUST_NOT_CONFIGURED":
+		return "not_configured"
+	case "SOUL_PRIVATE_INSTANCE_TRUST_REJECTED":
+		return "conflict"
+	case "SOUL_BOUND_AGENT_NOT_FOUND", "SOUL_BOUND_AGENT_NOT_AVAILABLE", "SOUL_PRIVATE_CONVERSATION_NOT_FOUND":
+		return "not_found"
+	case "SOUL_PRIVATE_LIMIT_INVALID", "SOUL_PRIVATE_QUERY_UNSUPPORTED", "SOUL_PRIVATE_CURSOR_UNSUPPORTED", "SOUL_PRIVATE_CONVERSATION_ID_REQUIRED", "SOUL_PRIVATE_CONVERSATION_ID_INVALID", "SOUL_PRIVATE_REQUEST_BODY_UNSUPPORTED", "SOUL_PRIVATE_INVALID_REQUEST":
+		return "invalid_request"
+	}
+	switch status {
+	case 400, 422:
+		return "invalid_request"
+	case 404:
+		return "not_found"
+	case 409:
+		return "conflict"
+	case 413:
+		return "response_too_large"
+	case 429:
+		return "rate_limited"
+	default:
+		if status >= 500 {
+			return "upstream_error"
+		}
+		return "unknown_error"
+	}
+}
+
+func normalizeSoulReadMintConversationList(raw any) map[string]any {
+	m, _ := raw.(map[string]any)
+	out := map[string]any{}
+	putFirstAny(out, "version", m, "version")
+	putFirstAny(out, "count", m, "count")
+	putFirstAny(out, "limit", m, "limit")
+	putFirstAny(out, "nextCursor", m, "next_cursor", "nextCursor")
+	items := firstArrayFromAny(raw, "conversations", "items", "results")
+	conversations := make([]any, 0, len(items))
+	for _, item := range items {
+		conversation, _ := item.(map[string]any)
+		if conversation == nil {
+			continue
+		}
+		conversations = append(conversations, normalizeSoulReadMintConversation(conversation, false))
+	}
+	out["conversations"] = conversations
+	return out
+}
+
+func normalizeSoulReadMintConversationSingle(raw any) map[string]any {
+	m, _ := raw.(map[string]any)
+	conversation := firstMap(m, "conversation")
+	if conversation == nil {
+		conversation = m
+	}
+	out := map[string]any{}
+	putFirstAny(out, "version", m, "version")
+	out["conversation"] = normalizeSoulReadMintConversation(conversation, true)
+	return out
+}
+
+func normalizeSoulReadMintConversation(raw map[string]any, includePrivateContent bool) map[string]any {
+	out := map[string]any{}
+	putFirstAny(out, "agentId", raw, "agent_id", "agentId")
+	putFirstAny(out, "conversationId", raw, "conversation_id", "conversationId")
+	putFirstAny(out, "model", raw, "model")
+	putFirstAny(out, "status", raw, "status")
+	putFirstAny(out, "usage", raw, "usage")
+	putFirstAny(out, "chargedCredits", raw, "charged_credits", "chargedCredits")
+	putFirstAny(out, "createdAt", raw, "created_at", "createdAt")
+	putFirstAny(out, "completedAt", raw, "completed_at", "completedAt")
+	if includePrivateContent {
+		putFirstAny(out, "messages", raw, "messages")
+		putFirstAny(out, "producedDeclarations", raw, "produced_declarations", "producedDeclarations")
 	}
 	return out
 }


### PR DESCRIPTION
## Milestone
Project 21 M2 — private self-scope mint-conversation reads for `soul_read` plus #134 threat-model coverage.

Closes #134.
Closes #135.

## Classification
MCP-contract / tool-surface / scope-profile / lesser-integration / security regression coverage.

## Surfaces affected
- `soul_read` MCP tool schema: additive optional `include_private`, `mintConversationLimit`, and `mintConversationId` fields.
- `soul_read` MCP tool response: additive `private.mintConversations` block and private expansion metadata in `access`.
- Lesser REST API consumption: new calls to Lesser self routes only:
  - `GET /api/v1/souls/bound/me/mint-conversations`
  - `GET /api/v1/souls/bound/me/mint-conversations/{conversationId}`
- Docs: `docs/mcp.md`, `docs/security.md`.

## Specialist walks referenced
- Tool surface: modifies existing read-only `soul_read`; scope remains `read`; profile remains both drone and souled; no side effects; static registration preserved.
- MCP contract: additive/backward-compatible optional request fields and response fields; no JSON-RPC envelope, OAuth metadata, endpoint path, or existing public-read behavior changed.
- Lesser integration: Body forwards the MCP caller bearer only to Lesser's `/api/v1/souls/bound/me/...` routes; no direct Host call; no `LESSER_HOST_INSTANCE_KEY` use for private soul reads.
- Host delegation: not used by Body for this path; Host is reached only by Lesser #697 with managed instance trust.
- Framework: idiomatic AppTheory MCP registration; no framework patch.

## Consumer impact
Existing `soul_read` calls keep M1 behavior. `self=true` remains public-only unless clients explicitly request `include_private:["mintConversations"]`. Private list reads return compact summaries only; explicit single-conversation reads return the bounded private record.

## Tasks
- [x] #135 — Extend `soul_read` for authenticated self-scope mint-conversation reads.
- [x] #134 — Add threat-model docs and regression coverage for private soul access.

## Validation
- `go test ./internal/mcpserver ./internal/mcpapp`
- `go test ./...`
- `go vet ./...`
- `gofmt -l .` (empty)
- `git diff --check`
- `scripts/build.sh`

## Stage rollout plan (handoff to deploy-body)
- [ ] Merged to main
- [ ] Coupled Lesser #697 + Body deploy to lab/dev
- [ ] Full MCP → Body → Lesser → Host probe passes
- [ ] Lab soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
- Depends on equaltoai/lesser#697 for the Lesser self-scope proxy routes.
- Host gate equaltoai/lesser-host#265 is closed/passed.
- This PR is draft until Lesser #697 route/DTO/error contract is stable enough for final review/merge coordination.

## Advisor-brief authorization
Pilot's assignment email lacked a well-formed provenance signature, but Aron explicitly authorized proceeding in-session. Scope carried forward: narrow M2 mint-conversation private self reads only; no channels/preferences/contactability/private mailbox, no mint mutations, no caller-provided Host `agentId`, and no direct Body → Host path.
