### PR TITLE
fix(soul): bound private single-read delivery

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -375,6 +375,11 @@ Notes:
   `mintConversationId` (opaque safe path value, maximum `128`) and call
   `/api/v1/souls/bound/me/mint-conversations/{conversationId}`. The list block returns compact summaries and never
   exposes `messages` or `producedDeclarations`; those are only returned by explicit single-conversation reads.
+  For explicit single reads, `structuredContent.data` is the authoritative location for full private fields. The text
+  `content` block omits verbose private fields and points clients to `structuredContent.data` so MCP stream events do
+  not duplicate private conversation payloads. If the measured MCP delivery envelope still exceeds Body's delivery
+  budget (derived from `MCP_STREAM_MAX_EVENT_BYTES` with headroom), `soul_read` returns a `response_too_large` tool
+  error before asking the MCP stream store to persist the event.
 - For private expansion, `soul_read.access` returns `mode:"self"`, `callerRelation:"self"`, `publicOnly:false`,
   `privateExpansion:true`, `authorization:"lesser_self_scope_instance_trust"`, and
   `privateBlocks:["mintConversations"]`.

--- a/docs/security.md
+++ b/docs/security.md
@@ -84,9 +84,13 @@ soul/body binding proof from that token. Lesser owns that self-scope proof, deri
 uses managed instance trust to call Host.
 
 Private mint-conversation list responses are compact summaries only. Full `messages` and `producedDeclarations` content
-is returned only by explicit single-conversation reads and must not be logged. Error details preserve machine-readable
-upstream reason codes without logging tokens, instance keys, message bodies, produced declarations, or raw private
-conversation content.
+is returned only by explicit single-conversation reads and must not be logged. For explicit single reads, full private
+fields are preserved in `structuredContent.data`; the text `content` block omits those verbose fields to avoid
+duplicating private content into MCP stream events. Body measures the resulting MCP delivery envelope against a budget
+derived from `MCP_STREAM_MAX_EVENT_BYTES` with headroom and returns a small `response_too_large` tool error before
+stream-store persistence if the private single-read response exceeds the delivery budget. Error details preserve
+machine-readable upstream reason codes without logging tokens, instance keys, message bodies, produced declarations, or
+raw private conversation content.
 
 ## IAM (least privilege)
 

--- a/internal/mcpapp/identity_surfaces_test.go
+++ b/internal/mcpapp/identity_surfaces_test.go
@@ -1763,6 +1763,7 @@ func TestLBM2_SoulReadPrivateMintConversationSingleIncludesExplicitContent(t *te
 
 	const agentID = "0x9999999999999999999999999999999999999999999999999999999999999999"
 	const conversationID = "conv:single.1"
+	largePrivateMessage := "private-lab-fixture " + strings.Repeat("private ", 9000)
 	installSoulBindingLookup(t, "Agent1", agentID)
 
 	var privateGetAuth string
@@ -1782,21 +1783,21 @@ func TestLBM2_SoulReadPrivateMintConversationSingleIncludesExplicitContent(t *te
 		case "/api/v1/souls/bound/me/mint-conversations/" + conversationID:
 			privateGetAuth = r.Header.Get("Authorization")
 			privateGetQuery = r.URL.RawQuery
-			_, _ = w.Write([]byte(`{
-				"version":"1",
-				"conversation":{
-					"agent_id":"` + agentID + `",
-					"conversation_id":"` + conversationID + `",
-					"model":"gpt-test",
-					"messages":"[{\"role\":\"user\",\"content\":\"private\"}]",
-					"produced_declarations":"{\"capabilities\":[]}",
-					"status":"completed",
-					"usage":{"output_tokens":2},
-					"charged_credits":7,
-					"created_at":"2026-05-11T21:00:00Z",
-					"completed_at":"2026-05-11T21:01:00Z"
-				}
-			}`))
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"version": "1",
+				"conversation": map[string]any{
+					"agent_id":              agentID,
+					"conversation_id":       conversationID,
+					"model":                 "gpt-test",
+					"messages":              largePrivateMessage,
+					"produced_declarations": map[string]any{"capabilities": []any{}},
+					"status":                "completed",
+					"usage":                 map[string]any{"output_tokens": 2},
+					"charged_credits":       7,
+					"created_at":            "2026-05-11T21:00:00Z",
+					"completed_at":          "2026-05-11T21:01:00Z",
+				},
+			})
 		default:
 			w.WriteHeader(http.StatusNotFound)
 			_, _ = w.Write([]byte(`{"error":{"message":"not found"}}`))
@@ -1853,6 +1854,15 @@ func TestLBM2_SoulReadPrivateMintConversationSingleIncludesExplicitContent(t *te
 		b, _ := json.Marshal(rpc.Result)
 		_ = json.Unmarshal(b, &toolOut)
 	}
+	if len(toolOut.Content) != 1 {
+		t.Fatalf("expected one text content block, got %+v", toolOut.Content)
+	}
+	if strings.Contains(toolOut.Content[0].Text, "private-lab-fixture") {
+		t.Fatalf("text content must not duplicate explicit private single-read content")
+	}
+	if !strings.Contains(toolOut.Content[0].Text, "available_in_structured_content") {
+		t.Fatalf("text content should point clients to structuredContent for private fields, got %s", toolOut.Content[0].Text)
+	}
 	data, _ := toolOut.StructuredContent["data"].(map[string]any)
 	souls, _ := data["souls"].([]any)
 	soul, _ := souls[0].(map[string]any)
@@ -1862,8 +1872,11 @@ func TestLBM2_SoulReadPrivateMintConversationSingleIncludesExplicitContent(t *te
 		t.Fatalf("expected single private mode, got %+v", mint)
 	}
 	conversation, _ := mint["conversation"].(map[string]any)
-	if conversation["conversationId"] != conversationID || !strings.Contains(conversation["messages"].(string), "private") || conversation["producedDeclarations"] == "" {
+	if conversation["conversationId"] != conversationID || !strings.Contains(conversation["messages"].(string), "private-lab-fixture") {
 		t.Fatalf("unexpected single private conversation: %+v", conversation)
+	}
+	if _, ok := conversation["producedDeclarations"]; !ok {
+		t.Fatalf("expected produced declarations in explicit single read: %+v", conversation)
 	}
 }
 

--- a/internal/mcpserver/soul_read_tools.go
+++ b/internal/mcpserver/soul_read_tools.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -22,6 +24,11 @@ const (
 	soulReadPrivateDefaultConversationLimit = 20
 	soulReadPrivateMaxConversationLimit     = 50
 	soulReadPrivateConversationIDMaxLen     = 128
+	// Keep Body's private single-read MCP response below AppTheory's stream
+	// event limit so callers receive a stable tool error before the MCP stream
+	// store is asked to persist an undeliverable event.
+	soulReadPrivateSingleDefaultMaxStreamEventBytes = 10 * 1024 * 1024
+	soulReadPrivateSingleDeliveryHeadroomBytes      = 64 * 1024
 )
 
 var soulReadPrivateConversationIDPattern = regexp.MustCompile(`^[A-Za-z0-9._:-]{1,128}$`)
@@ -123,12 +130,104 @@ func handleSoulRead(ctx context.Context, args json.RawMessage) (*mcpruntime.Tool
 		souls = append(souls, soul)
 	}
 
-	return toolJSONResult(map[string]any{
+	payload := map[string]any{
 		"query":  query,
 		"count":  len(souls),
 		"access": soulReadAccess(accessMode, privateReq.privateBlocks()),
 		"souls":  souls,
-	}, nil)
+	}
+	return soulReadToolResult(payload, privateReq)
+}
+
+func soulReadToolResult(payload map[string]any, privateReq soulReadPrivateRequest) (*mcpruntime.ToolResult, error) {
+	textPayload := any(payload)
+	if privateReq.IncludeMintConversations && privateReq.ConversationID != "" {
+		textPayload = soulReadPrivateSingleTextPayload(payload)
+	}
+	b, err := json.Marshal(textPayload)
+	if err != nil {
+		return nil, fmt.Errorf("marshal soul_read tool result: %w", err)
+	}
+	structured := map[string]any{"data": payload}
+	result := &mcpruntime.ToolResult{
+		Content: []mcpruntime.ContentBlock{{
+			Type: "text",
+			Text: string(b),
+		}},
+		StructuredContent: structured,
+	}
+
+	if privateReq.IncludeMintConversations && privateReq.ConversationID != "" {
+		responseBytes, err := mcpruntime.MarshalResponse(mcpruntime.NewResultResponse("soul_read_delivery_probe", result))
+		if err != nil {
+			return nil, fmt.Errorf("marshal soul_read MCP delivery envelope: %w", err)
+		}
+		maxResponseBytes := soulReadPrivateSingleMaxMCPResponseBytes()
+		if len(responseBytes) > maxResponseBytes {
+			return toolErrorResult("response_too_large", "soul_read private mint-conversation response exceeds MCP delivery limit", http.StatusRequestEntityTooLarge, map[string]any{
+				"source":        "lesser_private_self_scope",
+				"privateBlock":  soulReadPrivateMintConversationsBlock,
+				"mode":          "single",
+				"measuredBytes": len(responseBytes),
+				"maxBytes":      maxResponseBytes,
+			})
+		}
+	}
+
+	return result, nil
+}
+
+func soulReadPrivateSingleMaxMCPResponseBytes() int {
+	streamMax := soulReadPrivateSingleDefaultMaxStreamEventBytes
+	if raw := strings.TrimSpace(os.Getenv("MCP_STREAM_MAX_EVENT_BYTES")); raw != "" {
+		if n, err := strconv.Atoi(raw); err == nil && n > 0 {
+			streamMax = n
+		}
+	}
+	if streamMax <= soulReadPrivateSingleDeliveryHeadroomBytes {
+		return streamMax / 2
+	}
+	return streamMax - soulReadPrivateSingleDeliveryHeadroomBytes
+}
+
+func soulReadPrivateSingleTextPayload(payload map[string]any) map[string]any {
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return payload
+	}
+	var out map[string]any
+	if err := json.Unmarshal(b, &out); err != nil || out == nil {
+		return payload
+	}
+
+	souls, _ := out["souls"].([]any)
+	for _, soulAny := range souls {
+		soul, _ := soulAny.(map[string]any)
+		privateBlocks, _ := soul["private"].(map[string]any)
+		mint, _ := privateBlocks[soulReadPrivateMintConversationsBlock].(map[string]any)
+		if mint == nil || mint["mode"] != "single" {
+			continue
+		}
+		conversation, _ := mint["conversation"].(map[string]any)
+		if conversation == nil {
+			continue
+		}
+		omit := map[string]any{
+			"omitted": true,
+			"reason":  "available_in_structured_content",
+		}
+		if _, ok := conversation["messages"]; ok {
+			conversation["messages"] = omit
+		}
+		if _, ok := conversation["producedDeclarations"]; ok {
+			conversation["producedDeclarations"] = omit
+		}
+		mint["textContentPolicy"] = map[string]any{
+			"privateFieldsOmitted": []any{"messages", "producedDeclarations"},
+			"fullContentLocation":  "structuredContent.data",
+		}
+	}
+	return out
 }
 
 func soulReadPrivateRequestFromInput(in soulReadInput) (soulReadPrivateRequest, error) {

--- a/internal/mcpserver/soul_read_tools_test.go
+++ b/internal/mcpserver/soul_read_tools_test.go
@@ -1,0 +1,112 @@
+package mcpserver
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestSoulReadToolResult_PrivateSingleCompactsTextContent(t *testing.T) {
+	payload := soulReadPrivateSingleTestPayload("conv-1", "private-lab-fixture "+strings.Repeat("private ", 9000), map[string]any{"capabilities": []any{}})
+
+	res, err := soulReadToolResult(payload, soulReadPrivateRequest{IncludeMintConversations: true, ConversationID: "conv-1"})
+	if err != nil {
+		t.Fatalf("soulReadToolResult: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("expected successful tool result, got %+v", res)
+	}
+	if len(res.Content) != 1 {
+		t.Fatalf("expected one content block, got %+v", res.Content)
+	}
+	if strings.Contains(res.Content[0].Text, "private-lab-fixture") {
+		t.Fatalf("text content duplicated private single-read messages")
+	}
+	if !strings.Contains(res.Content[0].Text, "available_in_structured_content") {
+		t.Fatalf("text content should point clients to structuredContent, got %s", res.Content[0].Text)
+	}
+
+	data, _ := res.StructuredContent["data"].(map[string]any)
+	conversation := soulReadPrivateSingleConversationFromTestResult(t, data)
+	messages, _ := conversation["messages"].(string)
+	if !strings.Contains(messages, "private-lab-fixture") {
+		t.Fatalf("structured content must preserve explicit private messages, got %+v", conversation)
+	}
+	if _, ok := conversation["producedDeclarations"]; !ok {
+		t.Fatalf("structured content must preserve explicit produced declarations, got %+v", conversation)
+	}
+}
+
+func TestSoulReadToolResult_PrivateSingleRejectsOversizeDelivery(t *testing.T) {
+	t.Setenv("MCP_STREAM_MAX_EVENT_BYTES", "2048")
+
+	const privateSentinel = "oversize-private-sentinel"
+	payload := soulReadPrivateSingleTestPayload("conv-oversize", privateSentinel+strings.Repeat("x", 4096), nil)
+
+	res, err := soulReadToolResult(payload, soulReadPrivateRequest{IncludeMintConversations: true, ConversationID: "conv-oversize"})
+	if err != nil {
+		t.Fatalf("soulReadToolResult: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("expected oversize tool error, got %+v", res)
+	}
+	b, _ := json.Marshal(res)
+	if strings.Contains(string(b), privateSentinel) {
+		t.Fatalf("oversize tool error leaked private conversation content")
+	}
+	errPayload, _ := res.StructuredContent["error"].(map[string]any)
+	if errPayload["code"] != "response_too_large" || errPayload["status"] != http.StatusRequestEntityTooLarge {
+		t.Fatalf("unexpected oversize error payload: %+v", errPayload)
+	}
+	details, _ := errPayload["details"].(map[string]any)
+	if details["source"] != "lesser_private_self_scope" || details["privateBlock"] != soulReadPrivateMintConversationsBlock || details["mode"] != "single" {
+		t.Fatalf("unexpected oversize details: %+v", details)
+	}
+}
+
+func soulReadPrivateSingleTestPayload(conversationID string, messages string, producedDeclarations any) map[string]any {
+	conversation := map[string]any{
+		"agentId":        "0x9999999999999999999999999999999999999999999999999999999999999999",
+		"conversationId": conversationID,
+		"model":          "gpt-test",
+		"messages":       messages,
+		"status":         "completed",
+		"createdAt":      "2026-05-11T21:00:00Z",
+	}
+	if producedDeclarations != nil {
+		conversation["producedDeclarations"] = producedDeclarations
+	}
+	return map[string]any{
+		"query":  "self",
+		"count":  1,
+		"access": soulReadAccess("self", []any{soulReadPrivateMintConversationsBlock}),
+		"souls": []any{
+			map[string]any{
+				"agentId": "0x9999999999999999999999999999999999999999999999999999999999999999",
+				"private": map[string]any{
+					soulReadPrivateMintConversationsBlock: map[string]any{
+						"mode":         "single",
+						"conversation": conversation,
+					},
+				},
+			},
+		},
+	}
+}
+
+func soulReadPrivateSingleConversationFromTestResult(t *testing.T, data map[string]any) map[string]any {
+	t.Helper()
+	souls, _ := data["souls"].([]any)
+	if len(souls) != 1 {
+		t.Fatalf("expected one soul, got %+v", data)
+	}
+	soul, _ := souls[0].(map[string]any)
+	privateBlocks, _ := soul["private"].(map[string]any)
+	mint, _ := privateBlocks[soulReadPrivateMintConversationsBlock].(map[string]any)
+	conversation, _ := mint["conversation"].(map[string]any)
+	if conversation == nil {
+		t.Fatalf("missing private single conversation: %+v", data)
+	}
+	return conversation
+}


### PR DESCRIPTION
## Milestone
lesser-body#176 — deliver explicit private mint-conversation single reads without MCP stream-store overflow.

## Classification
bug-fix / MCP-contract / tool-surface / operational-reliability / security

## Surfaces affected
- `soul_read` `tools/call` response construction for explicit private `mintConversations` single reads only.
- Body-side MCP response delivery preflight for private single reads.
- Regression coverage for private single text compaction, structured-content preservation, and oversize safe error.
- MCP/security docs for private single delivery behavior.

## Specialist walks referenced
- Tool surface: behavior change is limited to existing `soul_read`; no registration, scope, or runtime-profile changes.
- MCP contract: `.well-known/mcp.json` unchanged, OAuth metadata unchanged, JSON-RPC envelope unchanged. The full private payload remains in `structuredContent.data`; the text `content` block no longer duplicates verbose private fields for explicit private single reads.
- Lesser integration: Body still calls Lesser `/api/v1/souls/bound/me/mint-conversations/{conversationId}` with the caller bearer; no direct Host call added.
- Host delegation: none; this path remains Body → Lesser, with Lesser owning Host instance trust.

## Consumer impact
- Explicit private single reads now keep `structuredContent.data` authoritative for `messages` and `producedDeclarations`.
- Text-only clients receive metadata plus omission markers that point to `structuredContent.data` instead of duplicated private content.
- If the measured MCP response envelope exceeds the stream delivery budget derived from `MCP_STREAM_MAX_EVENT_BYTES`, Body returns a small `response_too_large` tool error before AppTheory's stream store append path.
- Public/default `soul_read` and private list reads are unchanged.

## Tasks
- [x] Preserve explicit private single-read content in `structuredContent.data` while compacting text `content`.
- [x] Add Body-side response-size guard before stream-store append can see an undeliverable private single result.
- [x] Add regressions for lab-sized private single payloads, structured content preservation, and private-content-safe oversize errors.
- [x] Update MCP/security docs for private single delivery behavior.

## Validation
- `go test ./internal/mcpserver ./internal/mcpapp -run 'TestSoulReadToolResult|TestLBM2_SoulReadPrivateMintConversationSingle' -count=1`
- `go test ./...`
- `go vet ./...`
- `gofmt -l $(git ls-files '*.go')` (empty)
- `git diff --check`
- `scripts/build.sh`
- CDK synth not run: no CDK changes.

## Stage rollout plan (handoff to deploy-body)
- [ ] Merged to main
- [ ] Deployed to dev/lab
- [ ] Focused Ops reprobe: private single-read delivery plus leak/log scan
- [ ] Staging/live only after Aron authorizes the normal rollout path

## Cross-repo coordination
No sibling repo changes required for this PR. Ops consumer reprobe is still required after Body deploy to close #176 acceptance.

Closes #176.
