### PR TITLE
feat(mcp): add skills bundle tools

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -286,6 +286,8 @@ Scope key:
 | `profile_update` | Write | Update display name, bio, and avatar (best-effort). |
 | `memory_append` | Write | Append a memory event to the authenticated agent's memory timeline. |
 | `memory_query` | Read | Query memory events for the authenticated agent. |
+| `skills_catalog` | Read | List approved skill bundles from Lesser's authoritative skills catalog, preserving bundle digests, provenance, install hints, and exposure metadata. |
+| `skill_bundle_get` | Read | Fetch a selected approved Lesser skill bundle and optionally report local install-state verification from caller-supplied local file bytes. |
 | `email_send` | Write | Send an email through lesser-host on behalf of the authenticated soul agent. |
 | `email_read` | Read | List email metadata/previews from lesser-host's canonical Soul Comm Mailbox. |
 | `email_get` | Read | Get email metadata/state by opaque host `messageId`/`messageRef`. |
@@ -324,6 +326,21 @@ Notes:
 - `conversations_read` defaults to `limit=20` (maximum `80`) and returns compact conversation summaries: id, unread
   state, updated timestamp, compact participants, and bounded `lastPost`. It accepts optional `include_raw=true`, which
   returns `_raw` for audit/debug use.
+- `skills_catalog` and `skill_bundle_get` are read-only Project 21 M4 skills tools backed by Lesser's authoritative
+  skill publication contract. `skills_catalog` calls `GET /api/v1/skills/catalog`; `skill_bundle_get` calls
+  `GET /api/v1/skills/{skillId}/revisions/{revisionNumber}/bundle` and accepts either `skill_id` + `revision_number`
+  or a catalog `bundle.bundle_id` such as `skill:<skillId>:revision:00000001`. It passes `include_content=true` only
+  when the MCP caller asks for inline bundle content. Responses preserve Lesser's `bundle.bundle_id`, `schema_version`,
+  `digests` (`bundle_digest`, `publication_digest`, `manifest_digest`, `content_digest`, `approval_digest`),
+  `files[].path`, `files[].digest`, `files[].install_path`, `files[].content` / `encoding` / `content_included`,
+  `install_hints`, `provenance`, approval fields, principal fields, and exposure context. lesser-body is not a
+  catalog authority and does not mutate the client's workspace.
+- `skill_bundle_get.verification` is an honest local install-state report. When `local_files` is omitted, body returns
+  `unknown_local_state` because the remote Lambda cannot inspect the MCP client's workspace. When `local_files: []` is
+  supplied, body reports `not_installed`. When caller-supplied local file bytes are present, body hashes those bytes and
+  compares them to Lesser's `bundle.files[].digest`, returning `verified_match` only when every bundle file was actually
+  byte-compared and matched, or `modified_local_copy` when observed local bytes or missing files differ from the bundle.
+  Metadata-only bundles without local file bytes remain `unknown_local_state`.
 - Communication and identity tools also require an **OAuth JWT** bearer token for agent-context reads such as `identity_whoami`
   and inbox-backed verification. For self-identity checks, lesser-body passes that bearer to Lesser's
   `GET /api/v1/souls/bound/me` endpoint and fails closed if Lesser does not confirm an active bound soul for the
@@ -345,10 +362,11 @@ Notes:
 - `timeline_read` remains bounded by caller `limit`/cursor and upstream-shaped in M0 because current baseline evidence
   points to mailbox and notification bloat, not timeline unusability. If Ops probes show timeline truncation/timeout,
   timeline compacting should be scoped as a follow-up MCP-contract change rather than silently changed inside M0.
-- Mailbox and memory tools publish MCP annotations in `tools/list`: read-only hints for mailbox reads/search/content
-  fetches and `memory_query`, destructive hints for send/reply/delete tools, and idempotent hints for mailbox read-state
-  mutation tools. `memory_append` remains an additive write and is only idempotent when callers provide `event_id`, so
-  it is not advertised as unconditionally idempotent.
+- Mailbox, memory, and skills read tools publish MCP annotations in `tools/list`: read-only hints for mailbox
+  reads/search/content fetches, `memory_query`, `soul_read`, `skills_catalog`, and `skill_bundle_get`; destructive hints
+  for send/reply/delete tools; and idempotent hints for mailbox read-state mutation tools. `memory_append` remains an
+  additive write and is only idempotent when callers provide `event_id`, so it is not advertised as unconditionally
+  idempotent.
 - Mailbox read/search tools pass host-side filters through instead of client-side filtering: `channelType`,
   `direction`, `threadId`, bounded `query`, `unreadOnly`/`read`, `includeArchived`/`archived`, and
   `includeDeleted`/`deleted`.

--- a/internal/mcpapp/drone_capabilities_test.go
+++ b/internal/mcpapp/drone_capabilities_test.go
@@ -69,8 +69,8 @@ func TestDroneRuntimeCapabilityContractIsExplicit(t *testing.T) {
 		for _, tool := range out.Tools {
 			have[tool.Name] = true
 		}
-		if !have["post_create"] || !have["memory_query"] || !have["soul_read"] {
-			t.Fatalf("expected social, memory, and public soul tools for drone runtime, got %+v", out.Tools)
+		if !have["post_create"] || !have["memory_query"] || !have["soul_read"] || !have["skills_catalog"] || !have["skill_bundle_get"] {
+			t.Fatalf("expected social, memory, public soul, and skills tools for drone runtime, got %+v", out.Tools)
 		}
 		for _, blocked := range []string{
 			"email_send", "email_read", "email_get", "email_get_content", "email_search", "email_reply",
@@ -243,7 +243,7 @@ func TestDroneRuntimeCapabilityContractIsExplicit(t *testing.T) {
 		if droneProfile.CommunicationsEnabled || droneProfile.WalletAccessEnabled {
 			t.Fatalf("expected drone discovery profile to disable comms and wallet access, got %+v", droneProfile)
 		}
-		if !containsString(droneProfile.Tools, "post_create") || !containsString(droneProfile.Tools, "soul_read") {
+		if !containsString(droneProfile.Tools, "post_create") || !containsString(droneProfile.Tools, "soul_read") || !containsString(droneProfile.Tools, "skills_catalog") || !containsString(droneProfile.Tools, "skill_bundle_get") {
 			t.Fatalf("unexpected drone discovery tools: %+v", droneProfile.Tools)
 		}
 		for _, blocked := range []string{

--- a/internal/mcpapp/skills_tools_test.go
+++ b/internal/mcpapp/skills_tools_test.go
@@ -1,0 +1,240 @@
+package mcpapp_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	mcpruntime "github.com/theory-cloud/apptheory/runtime/mcp"
+	"github.com/theory-cloud/apptheory/testkit"
+
+	"github.com/equaltoai/lesser-body/internal/auth"
+	"github.com/equaltoai/lesser-body/internal/lesserapi"
+	"github.com/equaltoai/lesser-body/internal/mcpapp"
+)
+
+func TestProject21M4SkillsCatalogAndBundleTools(t *testing.T) {
+	t.Setenv("MCP_SESSION_TABLE", "")
+	t.Setenv("JWT_SECRET", "test")
+	auth.ResetForTests()
+
+	type recorded struct {
+		Method string
+		Path   string
+		Query  string
+		Auth   string
+	}
+	var got []recorded
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = append(got, recorded{Method: r.Method, Path: r.URL.Path, Query: r.URL.RawQuery, Auth: r.Header.Get("Authorization")})
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/skills/catalog":
+			if r.Method != http.MethodGet {
+				t.Fatalf("catalog method got %s", r.Method)
+			}
+			_, _ = w.Write([]byte(`{
+				"entries":[{
+					"skill":{"id":"skill-a","slug":"skill-a","name":"Skill A","default_exposure":"public","status":"approved"},
+					"revision":{"id":"skill-a-r1","skill_id":"skill-a","revision_number":1,"status":"approved","bundle_digest":"sha256:bundle","approval_digest":"sha256:approval","principal_id":"principal-1"},
+					"bundle":{"schema_version":"lesser.skill.bundle.v1","bundle_id":"skill:skill-a:revision:00000001","source":"canonical_skill_revision","published":true,"skill_id":"skill-a","revision_id":"skill-a-r1","revision_number":1,"default_exposure":"public","digests":{"bundle_digest":"sha256:bundle","publication_digest":"sha256:publication","manifest_digest":"sha256:manifest","content_digest":"sha256:content","approval_digest":"sha256:approval"},"files":[{"path":"SKILL.md","digest":"sha256:file","install_path":"skill-a/SKILL.md","content_included":false}],"install_hints":{"layout":"codex-skill","directory_name":"skill-a","entrypoint":"SKILL.md"},"provenance":[{"source_type":"proposal","digest":"sha256:proposal"}],"approval_id":"approval-1","principal_id":"principal-1"}
+				}],
+				"count":1,
+				"next_cursor":"next-catalog"
+			}`))
+		case "/api/v1/skills/skill-a/revisions/1/bundle":
+			if r.Method != http.MethodGet {
+				t.Fatalf("bundle method got %s", r.Method)
+			}
+			contentIncluded := r.URL.Query().Get("include_content") == "true"
+			content := ""
+			if contentIncluded {
+				content = `,"content":"# Skill A\n","encoding":"utf-8"`
+			}
+			_, _ = w.Write([]byte(`{
+				"bundle":{"schema_version":"lesser.skill.bundle.v1","bundle_id":"skill:skill-a:revision:00000001","source":"canonical_skill_revision","published":true,"skill_id":"skill-a","revision_id":"skill-a-r1","revision_number":1,"default_exposure":"public","digests":{"bundle_digest":"sha256:bundle","publication_digest":"sha256:publication","manifest_digest":"sha256:manifest","content_digest":"sha256:content","approval_digest":"sha256:approval"},"files":[{"path":"SKILL.md","digest":"sha256:3fc349d92cca36c2326da54076558a5d94b76d815cfe2bd1a0ce0ec284d53935","install_path":"skill-a/SKILL.md","content_included":` + boolJSON(contentIncluded) + content + `}],"install_hints":{"layout":"codex-skill","directory_name":"skill-a","entrypoint":"SKILL.md","required_files":["SKILL.md"]},"provenance":[{"source_type":"proposal","digest":"sha256:proposal"}],"approval_id":"approval-1","approval_authority_type":"pilot","approval_authority_id":"pilot@lessersoul.ai","approved_by":"Pilot","principal_id":"principal-1","principal_approval_id":"pa-1"}
+			}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":"not found"}`))
+		}
+	}))
+	defer server.Close()
+
+	t.Setenv("LESSER_API_BASE_URL", server.URL)
+	lesserapi.ResetForTests()
+
+	app, err := mcpapp.New("test", "dev")
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+	env := testkit.New()
+	token := newTestToken(t, "test", "agent1", []string{"read"})
+	authHeader := "Bearer " + token
+
+	initResp := invokeJSON(t, env, app, map[string][]string{"authorization": {authHeader}}, &mcpruntime.Request{JSONRPC: "2.0", ID: 1, Method: "initialize"})
+	if initResp.Status != 200 {
+		t.Fatalf("initialize: status=%d body=%s", initResp.Status, string(initResp.Body))
+	}
+	sessionID := initResp.Headers["mcp-session-id"][0]
+
+	callTool := func(id int, name string, args map[string]any) mcpruntime.ToolResult {
+		t.Helper()
+		callParams, _ := json.Marshal(map[string]any{"name": name, "arguments": args})
+		resp := invokeJSON(t, env, app, map[string][]string{"authorization": {authHeader}, "mcp-session-id": {sessionID}}, &mcpruntime.Request{JSONRPC: "2.0", ID: id, Method: "tools/call", Params: callParams})
+		if resp.Status != 200 {
+			t.Fatalf("%s: status=%d body=%s", name, resp.Status, string(resp.Body))
+		}
+		var rpc mcpruntime.Response
+		if err := json.Unmarshal(resp.Body, &rpc); err != nil {
+			t.Fatalf("unmarshal %s rpc: %v", name, err)
+		}
+		if rpc.Error != nil {
+			t.Fatalf("%s rpc error: %+v", name, rpc.Error)
+		}
+		var out mcpruntime.ToolResult
+		b, _ := json.Marshal(rpc.Result)
+		if err := json.Unmarshal(b, &out); err != nil {
+			t.Fatalf("unmarshal %s tool result: %v", name, err)
+		}
+		return out
+	}
+
+	catalog := callTool(2, "skills_catalog", map[string]any{"limit": 1, "cursor": "c1", "exposure": "public"})
+	catalogData, _ := catalog.StructuredContent["data"].(map[string]any)
+	if catalogData == nil {
+		t.Fatalf("expected catalog structured data, got %+v", catalog.StructuredContent)
+	}
+	if got[0].Path != "/api/v1/skills/catalog" || got[0].Query != "cursor=c1&exposure=public&limit=1" || got[0].Auth != authHeader {
+		t.Fatalf("unexpected catalog request: %+v", got[0])
+	}
+	entries, _ := catalogData["entries"].([]any)
+	if len(entries) != 1 || catalogData["next_cursor"] != "next-catalog" {
+		t.Fatalf("catalog response did not preserve Lesser shape: %+v", catalogData)
+	}
+	entry := entries[0].(map[string]any)
+	bundle := entry["bundle"].(map[string]any)
+	digests := bundle["digests"].(map[string]any)
+	if digests["publication_digest"] != "sha256:publication" || bundle["install_hints"] == nil || bundle["provenance"] == nil {
+		t.Fatalf("catalog did not preserve trust metadata: %+v", bundle)
+	}
+
+	bundleResult := callTool(3, "skill_bundle_get", map[string]any{
+		"skill_id":        "skill-a",
+		"revision_number": 1,
+		"include_content": true,
+		"local_files": []map[string]any{{
+			"path":     "SKILL.md",
+			"content":  "# Skill A\n",
+			"encoding": "utf-8",
+		}},
+	})
+	bundleData, _ := bundleResult.StructuredContent["data"].(map[string]any)
+	if bundleData == nil {
+		t.Fatalf("expected bundle structured data, got %+v", bundleResult.StructuredContent)
+	}
+	if got[1].Path != "/api/v1/skills/skill-a/revisions/1/bundle" || got[1].Query != "include_content=true" || got[1].Auth != authHeader {
+		t.Fatalf("unexpected bundle request: %+v", got[1])
+	}
+	content, _ := bundleData["content"].(map[string]any)
+	if content["mode"] != "inline" {
+		t.Fatalf("expected inline content summary, got %+v", content)
+	}
+	verification, _ := bundleData["verification"].(map[string]any)
+	if verification["state"] != "verified_match" || verification["checked_files"] != float64(1) {
+		t.Fatalf("expected verified local bundle, got %+v", verification)
+	}
+	authority, _ := bundleData["authority"].(map[string]any)
+	if authority["workspace_mutated"] != false || authority["source"] != "lesser" {
+		t.Fatalf("unexpected authority metadata: %+v", authority)
+	}
+	bundleObj, _ := bundleData["bundle"].(map[string]any)
+	if bundleObj["approval_id"] != "approval-1" || bundleObj["principal_id"] != "principal-1" {
+		t.Fatalf("bundle did not preserve approval/principal metadata: %+v", bundleObj)
+	}
+
+	metadataOnly := callTool(4, "skill_bundle_get", map[string]any{"bundle_id": "skill:skill-a:revision:00000001"})
+	metadataData, _ := metadataOnly.StructuredContent["data"].(map[string]any)
+	metadataContent, _ := metadataData["content"].(map[string]any)
+	metadataVerification, _ := metadataData["verification"].(map[string]any)
+	if metadataContent["mode"] != "metadata_only" || metadataVerification["state"] != "unknown_local_state" {
+		t.Fatalf("metadata-only bundle should report unknown local state, content=%+v verification=%+v", metadataContent, metadataVerification)
+	}
+}
+
+func TestProject21M4SkillBundleReportsModifiedAndUpstreamFailure(t *testing.T) {
+	t.Setenv("MCP_SESSION_TABLE", "")
+	t.Setenv("JWT_SECRET", "test")
+	auth.ResetForTests()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.Contains(r.URL.Path, "/fail/"):
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte(`{"error":"temporarily unavailable"}`))
+		default:
+			_, _ = w.Write([]byte(`{"bundle":{"digests":{"bundle_digest":"sha256:bundle","publication_digest":"sha256:publication"},"files":[{"path":"SKILL.md","digest":"sha256:3fc349d92cca36c2326da54076558a5d94b76d815cfe2bd1a0ce0ec284d53935","install_path":"skill-a/SKILL.md","content_included":false}]}}`))
+		}
+	}))
+	defer server.Close()
+
+	t.Setenv("LESSER_API_BASE_URL", server.URL)
+	lesserapi.ResetForTests()
+
+	app, err := mcpapp.New("test", "dev")
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+	env := testkit.New()
+	token := newTestToken(t, "test", "agent1", []string{"read"})
+	authHeader := "Bearer " + token
+	initResp := invokeJSON(t, env, app, map[string][]string{"authorization": {authHeader}}, &mcpruntime.Request{JSONRPC: "2.0", ID: 1, Method: "initialize"})
+	if initResp.Status != 200 {
+		t.Fatalf("initialize: status=%d body=%s", initResp.Status, string(initResp.Body))
+	}
+	sessionID := initResp.Headers["mcp-session-id"][0]
+
+	call := func(id int, args map[string]any) mcpruntime.ToolResult {
+		t.Helper()
+		params, _ := json.Marshal(map[string]any{"name": "skill_bundle_get", "arguments": args})
+		resp := invokeJSON(t, env, app, map[string][]string{"authorization": {authHeader}, "mcp-session-id": {sessionID}}, &mcpruntime.Request{JSONRPC: "2.0", ID: id, Method: "tools/call", Params: params})
+		if resp.Status != 200 {
+			t.Fatalf("skill_bundle_get: status=%d body=%s", resp.Status, string(resp.Body))
+		}
+		var rpc mcpruntime.Response
+		_ = json.Unmarshal(resp.Body, &rpc)
+		if rpc.Error != nil {
+			t.Fatalf("skill_bundle_get rpc error: %+v", rpc.Error)
+		}
+		var out mcpruntime.ToolResult
+		b, _ := json.Marshal(rpc.Result)
+		_ = json.Unmarshal(b, &out)
+		return out
+	}
+
+	modified := call(2, map[string]any{"skill_id": "skill-a", "revision_number": 1, "local_files": []map[string]any{{"path": "SKILL.md", "content": "changed"}}})
+	modifiedData, _ := modified.StructuredContent["data"].(map[string]any)
+	verification, _ := modifiedData["verification"].(map[string]any)
+	if verification["state"] != "modified_local_copy" {
+		t.Fatalf("expected modified_local_copy, got %+v", verification)
+	}
+
+	failure := call(3, map[string]any{"skill_id": "fail", "revision_number": 1})
+	if !failure.IsError {
+		t.Fatalf("expected tool-level error for Lesser failure, got %+v", failure)
+	}
+	errPayload, _ := failure.StructuredContent["error"].(map[string]any)
+	if errPayload["code"] != "upstream_error" || errPayload["status"] != float64(http.StatusServiceUnavailable) {
+		t.Fatalf("unexpected error payload: %+v", errPayload)
+	}
+}
+
+func boolJSON(value bool) string {
+	if value {
+		return "true"
+	}
+	return "false"
+}

--- a/internal/mcpapp/tool_annotations_test.go
+++ b/internal/mcpapp/tool_annotations_test.go
@@ -100,7 +100,7 @@ func TestMCPToolAnnotationsForMailboxAndMemory(t *testing.T) {
 	truth := true
 	falsehood := false
 
-	for _, name := range []string{"email_read", "email_get", "email_get_content", "email_search", "sms_read", "voicemail_read", "memory_query", "soul_read"} {
+	for _, name := range []string{"email_read", "email_get", "email_get_content", "email_search", "sms_read", "voicemail_read", "memory_query", "soul_read", "skills_catalog", "skill_bundle_get"} {
 		assertHint(name, &truth, nil, nil)
 	}
 	for _, name := range []string{"email_send", "email_reply", "email_delete", "sms_send"} {

--- a/internal/mcpapp/well_known_test.go
+++ b/internal/mcpapp/well_known_test.go
@@ -66,10 +66,18 @@ func TestM7_WellKnownMcpJSON(t *testing.T) {
 	}
 
 	foundEcho := false
+	foundSkillsCatalog := false
+	foundSkillBundleGet := false
 	foundPhoneCall := false
 	for _, tool := range out.Tools {
 		if tool["name"] == "echo" {
 			foundEcho = true
+		}
+		if tool["name"] == "skills_catalog" {
+			foundSkillsCatalog = true
+		}
+		if tool["name"] == "skill_bundle_get" {
+			foundSkillBundleGet = true
 		}
 		if tool["name"] == "phone_call" {
 			foundPhoneCall = true
@@ -77,6 +85,9 @@ func TestM7_WellKnownMcpJSON(t *testing.T) {
 	}
 	if !foundEcho {
 		t.Fatalf("expected echo tool in well-known doc")
+	}
+	if !foundSkillsCatalog || !foundSkillBundleGet {
+		t.Fatalf("expected skills tools in well-known doc")
 	}
 	if foundPhoneCall {
 		t.Fatalf("phone_call should not appear in well-known doc")

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -152,5 +152,9 @@ func registerTools(r *mcpruntime.ToolRegistry) error {
 		return err
 	}
 
+	if err := registerSkillsTools(r); err != nil {
+		return err
+	}
+
 	return registerCommunicationTools(r)
 }

--- a/internal/mcpserver/skills_tools.go
+++ b/internal/mcpserver/skills_tools.go
@@ -1,0 +1,643 @@
+package mcpserver
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/equaltoai/lesser-body/internal/lesserapi"
+	mcpruntime "github.com/theory-cloud/apptheory/runtime/mcp"
+)
+
+const (
+	skillLocalFileMaxDecodedBytes = 1 << 20
+	skillLocalFilesMaxCount       = 200
+
+	skillInstallStateNotInstalled  = "not_installed"
+	skillInstallStateVerifiedMatch = "verified_match"
+	skillInstallStateModifiedCopy  = "modified_local_copy"
+	skillInstallStateUnknownLocal  = "unknown_local_state"
+)
+
+type skillCatalogArgs struct {
+	Exposure string `json:"exposure,omitempty"`
+	Limit    int    `json:"limit,omitempty"`
+	Cursor   string `json:"cursor,omitempty"`
+}
+
+type skillBundleArgs struct {
+	SkillID        string          `json:"skill_id"`
+	RevisionNumber int             `json:"revision_number"`
+	BundleID       string          `json:"bundle_id,omitempty"`
+	IncludeContent bool            `json:"include_content,omitempty"`
+	LocalFiles     json.RawMessage `json:"local_files,omitempty"`
+}
+
+type skillLocalFileObservation struct {
+	Path        string
+	InstallPath string
+	Content     string
+	Encoding    string
+	HasContent  bool
+}
+
+type skillBundleContentSummary struct {
+	Mode              string `json:"mode"`
+	FilesTotal        int    `json:"files_total"`
+	InlineFiles       int    `json:"inline_files"`
+	MetadataOnlyFiles int    `json:"metadata_only_files"`
+}
+
+type skillBundleVerification struct {
+	State             string                        `json:"state"`
+	Reason            string                        `json:"reason,omitempty"`
+	Source            string                        `json:"source"`
+	BundleDigest      string                        `json:"bundle_digest,omitempty"`
+	PublicationDigest string                        `json:"publication_digest,omitempty"`
+	CheckedFiles      int                           `json:"checked_files"`
+	Files             []skillBundleFileVerification `json:"files,omitempty"`
+}
+
+type skillBundleFileVerification struct {
+	Path            string `json:"path"`
+	InstallPath     string `json:"install_path,omitempty"`
+	ExpectedDigest  string `json:"expected_digest,omitempty"`
+	ComputedDigest  string `json:"computed_digest,omitempty"`
+	State           string `json:"state"`
+	Reason          string `json:"reason,omitempty"`
+	ContentCompared bool   `json:"content_compared"`
+}
+
+func registerSkillsTools(r *mcpruntime.ToolRegistry) error {
+	if r == nil {
+		return fmt.Errorf("tool registry is nil")
+	}
+
+	for _, tool := range []struct {
+		Def     mcpruntime.ToolDef
+		Handler mcpruntime.ToolHandler
+	}{
+		{Def: skillsCatalogDef(), Handler: handleSkillsCatalog},
+		{Def: skillBundleGetDef(), Handler: handleSkillBundleGet},
+	} {
+		if err := r.RegisterTool(tool.Def, tool.Handler); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func skillsCatalogDef() mcpruntime.ToolDef {
+	return mcpruntime.ToolDef{
+		Name:        "skills_catalog",
+		Description: "List approved skill bundles from Lesser's authoritative skills catalog without mutating the client workspace.",
+		Annotations: readOnlyToolAnnotations(),
+		InputSchema: json.RawMessage(`{
+			"type":"object",
+			"properties":{
+				"exposure":{"type":"string","description":"Optional Lesser exposure filter."},
+				"limit":{"type":"integer","minimum":1,"maximum":100,"description":"Maximum catalog entries to ask Lesser for."},
+				"cursor":{"type":"string","description":"Opaque Lesser pagination cursor from a previous catalog response."}
+			}
+		}`),
+	}
+}
+
+func skillBundleGetDef() mcpruntime.ToolDef {
+	return mcpruntime.ToolDef{
+		Name:        "skill_bundle_get",
+		Description: "Fetch a selected approved Lesser skill bundle and optionally compare caller-supplied local file bytes to the published digests.",
+		Annotations: readOnlyToolAnnotations(),
+		InputSchema: json.RawMessage(`{
+			"type":"object",
+			"properties":{
+				"skill_id":{"type":"string","description":"Lesser skill id from skills_catalog."},
+				"revision_number":{"type":"integer","minimum":1,"description":"Approved revision number to fetch."},
+				"bundle_id":{"type":"string","description":"Optional catalog bundle.bundle_id selection such as skill:<skillId>:revision:00000001. Used when skill_id/revision_number are not provided."},
+				"include_content":{"type":"boolean","description":"Ask Lesser to include inline bundle file content when available. Defaults to false."},
+				"local_files":{
+					"type":"array",
+					"description":"Optional caller-observed local files for read-only verification. Omit when the client cannot inspect local files; an empty array means the client inspected and found no installed files.",
+					"items":{
+						"type":"object",
+						"properties":{
+							"path":{"type":"string","description":"Bundle-relative file path."},
+							"install_path":{"type":"string","description":"Suggested install path from the bundle."},
+							"content":{"type":"string","description":"Observed local file bytes as UTF-8 text or base64, used only for digest comparison and not echoed back."},
+							"encoding":{"type":"string","enum":["utf-8","text","base64"],"description":"Encoding for content. Defaults to utf-8."}
+						}
+					}
+				}
+			},
+			"anyOf":[
+				{"required":["skill_id","revision_number"]},
+				{"required":["bundle_id"]}
+			]
+		}`),
+	}
+}
+
+func handleSkillsCatalog(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
+	var in skillCatalogArgs
+	if err := unmarshalOptionalObject(args, &in); err != nil {
+		return nil, invalidParams("invalid args: " + err.Error())
+	}
+
+	token, err := requireOAuthBearer(ctx)
+	if err != nil {
+		return skillToolResultFromError(err, "/api/v1/skills/catalog")
+	}
+	client, err := lesser(ctx)
+	if err != nil {
+		return skillToolResultFromError(err, "/api/v1/skills/catalog")
+	}
+
+	query := url.Values{}
+	if exposure := strings.TrimSpace(in.Exposure); exposure != "" {
+		query.Set("exposure", exposure)
+	}
+	if in.Limit > 0 {
+		query.Set("limit", fmt.Sprintf("%d", in.Limit))
+	}
+	if cursor := strings.TrimSpace(in.Cursor); cursor != "" {
+		query.Set("cursor", cursor)
+	}
+
+	raw, err := client.DoJSON(ctx, http.MethodGet, "/api/v1/skills/catalog", query, token, nil)
+	if err != nil {
+		return skillToolResultFromError(err, "/api/v1/skills/catalog")
+	}
+
+	payload := objectFromRaw(raw)
+	payload["authority"] = map[string]any{
+		"source":                "lesser",
+		"endpoint":              "/api/v1/skills/catalog",
+		"catalog_authoritative": true,
+		"body_cache_authority":  false,
+	}
+
+	return toolJSONResult(payload, nil)
+}
+
+func handleSkillBundleGet(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
+	var in skillBundleArgs
+	if err := unmarshalOptionalObject(args, &in); err != nil {
+		return nil, invalidParams("invalid args: " + err.Error())
+	}
+	in.SkillID = strings.TrimSpace(in.SkillID)
+	in.BundleID = strings.TrimSpace(in.BundleID)
+	if in.BundleID != "" {
+		parsedSkillID, parsedRevision, parseErr := parseSkillBundleID(in.BundleID)
+		if parseErr != nil {
+			return nil, invalidParams(parseErr.Error())
+		}
+		if in.SkillID != "" && in.SkillID != parsedSkillID {
+			return nil, invalidParams("bundle_id does not match skill_id")
+		}
+		if in.RevisionNumber > 0 && in.RevisionNumber != parsedRevision {
+			return nil, invalidParams("bundle_id does not match revision_number")
+		}
+		if in.SkillID == "" {
+			in.SkillID = parsedSkillID
+		}
+		if in.RevisionNumber <= 0 {
+			in.RevisionNumber = parsedRevision
+		}
+	}
+	if in.SkillID == "" {
+		return nil, invalidParams("skill_id is required unless bundle_id is provided")
+	}
+	if in.RevisionNumber <= 0 {
+		return nil, invalidParams("revision_number must be greater than zero unless bundle_id is provided")
+	}
+	localFiles, localFilesProvided, err := parseSkillLocalFiles(in.LocalFiles)
+	if err != nil {
+		return nil, invalidParams(err.Error())
+	}
+
+	token, err := requireOAuthBearer(ctx)
+	endpointPath := skillBundleEndpointPath(in.SkillID, in.RevisionNumber)
+	if err != nil {
+		return skillToolResultFromError(err, endpointPath)
+	}
+	client, err := lesser(ctx)
+	if err != nil {
+		return skillToolResultFromError(err, endpointPath)
+	}
+
+	query := url.Values{}
+	if in.IncludeContent {
+		query.Set("include_content", "true")
+	}
+	raw, err := client.DoJSON(ctx, http.MethodGet, endpointPath, query, token, nil)
+	if err != nil {
+		return skillToolResultFromError(err, endpointPath)
+	}
+
+	payload := objectFromRaw(raw)
+	bundle, _ := payload["bundle"].(map[string]any)
+	content := summarizeSkillBundleContent(bundle)
+	verification := verifySkillBundleLocalState(bundle, localFiles, localFilesProvided)
+	payload["content"] = content
+	payload["verification"] = verification
+	payload["authority"] = map[string]any{
+		"source":               "lesser",
+		"endpoint":             endpointPath,
+		"bundle_authoritative": true,
+		"body_cache_authority": false,
+		"workspace_mutated":    false,
+	}
+
+	return toolJSONResult(payload, nil)
+}
+
+func unmarshalOptionalObject(args json.RawMessage, out any) error {
+	raw := bytes.TrimSpace(args)
+	if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
+		return nil
+	}
+	if len(raw) > 0 && raw[0] != '{' {
+		return fmt.Errorf("arguments must be an object")
+	}
+	return json.Unmarshal(raw, out)
+}
+
+func skillBundleEndpointPath(skillID string, revisionNumber int) string {
+	return fmt.Sprintf("/api/v1/skills/%s/revisions/%d/bundle", url.PathEscape(strings.TrimSpace(skillID)), revisionNumber)
+}
+
+func parseSkillBundleID(bundleID string) (string, int, error) {
+	bundleID = strings.TrimSpace(bundleID)
+	if bundleID == "" {
+		return "", 0, fmt.Errorf("skill_id and revision_number are required unless bundle_id is provided")
+	}
+	const revisionMarker = ":revision:"
+	if !strings.HasPrefix(bundleID, "skill:") || !strings.Contains(bundleID, revisionMarker) {
+		return "", 0, fmt.Errorf("bundle_id must use skill:<skillId>:revision:<revisionNumber>")
+	}
+	parts := strings.SplitN(strings.TrimPrefix(bundleID, "skill:"), revisionMarker, 2)
+	if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" {
+		return "", 0, fmt.Errorf("bundle_id must include skill id and revision number")
+	}
+	revision, err := strconv.Atoi(strings.TrimLeft(strings.TrimSpace(parts[1]), "0"))
+	if err != nil || revision <= 0 {
+		// A revision of all zeros is not valid; Atoi("") is also invalid.
+		return "", 0, fmt.Errorf("bundle_id revision number is invalid")
+	}
+	return strings.TrimSpace(parts[0]), revision, nil
+}
+
+func objectFromRaw(raw any) map[string]any {
+	if obj, ok := raw.(map[string]any); ok && obj != nil {
+		out := make(map[string]any, len(obj)+2)
+		for k, v := range obj {
+			out[k] = v
+		}
+		return out
+	}
+	return map[string]any{"data": raw}
+}
+
+func parseSkillLocalFiles(raw json.RawMessage) ([]skillLocalFileObservation, bool, error) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return nil, false, nil
+	}
+
+	var entries []map[string]any
+	if err := json.Unmarshal(trimmed, &entries); err != nil {
+		return nil, true, fmt.Errorf("local_files must be an array of objects")
+	}
+	if len(entries) > skillLocalFilesMaxCount {
+		return nil, true, fmt.Errorf("local_files cannot contain more than %d entries", skillLocalFilesMaxCount)
+	}
+
+	out := make([]skillLocalFileObservation, 0, len(entries))
+	for i, entry := range entries {
+		if entry == nil {
+			return nil, true, fmt.Errorf("local_files[%d] must be an object", i)
+		}
+		path, err := optionalStringField(entry, "path")
+		if err != nil {
+			return nil, true, fmt.Errorf("local_files[%d].path must be a string", i)
+		}
+		installPath, err := optionalStringField(entry, "install_path")
+		if err != nil {
+			return nil, true, fmt.Errorf("local_files[%d].install_path must be a string", i)
+		}
+		content, hasContent, err := optionalPresentStringField(entry, "content")
+		if err != nil {
+			return nil, true, fmt.Errorf("local_files[%d].content must be a string", i)
+		}
+		encoding, err := optionalStringField(entry, "encoding")
+		if err != nil {
+			return nil, true, fmt.Errorf("local_files[%d].encoding must be a string", i)
+		}
+		if strings.TrimSpace(path) == "" && strings.TrimSpace(installPath) == "" {
+			return nil, true, fmt.Errorf("local_files[%d] requires path or install_path", i)
+		}
+		if hasContent {
+			if _, err := decodeSkillLocalContent(content, encoding); err != nil {
+				return nil, true, fmt.Errorf("local_files[%d]: %w", i, err)
+			}
+		}
+		out = append(out, skillLocalFileObservation{
+			Path:        strings.TrimSpace(path),
+			InstallPath: strings.TrimSpace(installPath),
+			Content:     content,
+			Encoding:    strings.TrimSpace(encoding),
+			HasContent:  hasContent,
+		})
+	}
+	return out, true, nil
+}
+
+func optionalStringField(entry map[string]any, field string) (string, error) {
+	value, ok := entry[field]
+	if !ok || value == nil {
+		return "", nil
+	}
+	out, ok := value.(string)
+	if !ok {
+		return "", fmt.Errorf("not a string")
+	}
+	return out, nil
+}
+
+func optionalPresentStringField(entry map[string]any, field string) (string, bool, error) {
+	value, ok := entry[field]
+	if !ok || value == nil {
+		return "", false, nil
+	}
+	out, ok := value.(string)
+	if !ok {
+		return "", true, fmt.Errorf("not a string")
+	}
+	return out, true, nil
+}
+
+func decodeSkillLocalContent(content string, encoding string) ([]byte, error) {
+	switch strings.ToLower(strings.TrimSpace(encoding)) {
+	case "", "utf-8", "text":
+		decoded := []byte(content)
+		if len(decoded) > skillLocalFileMaxDecodedBytes {
+			return nil, fmt.Errorf("decoded local file content exceeds %d bytes", skillLocalFileMaxDecodedBytes)
+		}
+		return decoded, nil
+	case "base64":
+		decoded, err := base64.StdEncoding.DecodeString(strings.TrimSpace(content))
+		if err != nil {
+			return nil, fmt.Errorf("local file content is invalid base64")
+		}
+		if len(decoded) > skillLocalFileMaxDecodedBytes {
+			return nil, fmt.Errorf("decoded local file content exceeds %d bytes", skillLocalFileMaxDecodedBytes)
+		}
+		return decoded, nil
+	default:
+		return nil, fmt.Errorf("local file encoding must be utf-8, text, or base64")
+	}
+}
+
+func summarizeSkillBundleContent(bundle map[string]any) skillBundleContentSummary {
+	files := skillBundleFiles(bundle)
+	summary := skillBundleContentSummary{FilesTotal: len(files)}
+	for _, file := range files {
+		if boolValue(file["content_included"]) {
+			summary.InlineFiles++
+		} else {
+			summary.MetadataOnlyFiles++
+		}
+	}
+	switch {
+	case summary.FilesTotal == 0:
+		summary.Mode = "no_files"
+	case summary.InlineFiles == summary.FilesTotal:
+		summary.Mode = "inline"
+	case summary.MetadataOnlyFiles == summary.FilesTotal:
+		summary.Mode = "metadata_only"
+	default:
+		summary.Mode = "mixed"
+	}
+	return summary
+}
+
+func verifySkillBundleLocalState(bundle map[string]any, localFiles []skillLocalFileObservation, localFilesProvided bool) skillBundleVerification {
+	verification := skillBundleVerification{
+		State:  skillInstallStateUnknownLocal,
+		Reason: "local_files_not_provided",
+		Source: "caller_supplied_local_file_bytes",
+	}
+	if bundle == nil {
+		verification.Reason = "bundle_missing"
+		return verification
+	}
+	if digests, _ := bundle["digests"].(map[string]any); digests != nil {
+		verification.BundleDigest = stringValue(digests["bundle_digest"])
+		verification.PublicationDigest = stringValue(digests["publication_digest"])
+	}
+
+	files := skillBundleFiles(bundle)
+	if len(files) == 0 {
+		verification.Reason = "bundle_has_no_files"
+		return verification
+	}
+	if !localFilesProvided {
+		return verification
+	}
+	if len(localFiles) == 0 {
+		verification.State = skillInstallStateNotInstalled
+		verification.Reason = "no_local_files_reported"
+		verification.Files = make([]skillBundleFileVerification, 0, len(files))
+		for _, file := range files {
+			verification.Files = append(verification.Files, skillBundleFileVerification{
+				Path:           stringValue(file["path"]),
+				InstallPath:    stringValue(file["install_path"]),
+				ExpectedDigest: strings.ToLower(strings.TrimSpace(stringValue(file["digest"]))),
+				State:          skillInstallStateNotInstalled,
+				Reason:         "local_file_not_observed",
+			})
+		}
+		return verification
+	}
+
+	localByPath := map[string]skillLocalFileObservation{}
+	for _, file := range localFiles {
+		if path := normalizedSkillPath(file.Path); path != "" {
+			localByPath[path] = file
+		}
+		if installPath := normalizedSkillPath(file.InstallPath); installPath != "" {
+			localByPath[installPath] = file
+		}
+	}
+
+	verification.Reason = "verified_against_local_file_bytes"
+	allVerified := true
+	allMissing := true
+	anyDrift := false
+	anyUnknown := false
+	verification.Files = make([]skillBundleFileVerification, 0, len(files))
+	for _, bundleFile := range files {
+		path := stringValue(bundleFile["path"])
+		installPath := stringValue(bundleFile["install_path"])
+		expectedDigest := strings.ToLower(strings.TrimSpace(stringValue(bundleFile["digest"])))
+		fileVerification := skillBundleFileVerification{
+			Path:           path,
+			InstallPath:    installPath,
+			ExpectedDigest: expectedDigest,
+			State:          skillInstallStateUnknownLocal,
+		}
+
+		local, ok := localByPath[normalizedSkillPath(path)]
+		if !ok {
+			local, ok = localByPath[normalizedSkillPath(installPath)]
+		}
+		if !ok {
+			fileVerification.State = skillInstallStateNotInstalled
+			fileVerification.Reason = "local_file_not_observed"
+			allVerified = false
+			anyDrift = true
+			verification.Files = append(verification.Files, fileVerification)
+			continue
+		}
+		allMissing = false
+		if !local.HasContent {
+			fileVerification.Reason = "local_file_content_not_provided"
+			allVerified = false
+			anyUnknown = true
+			verification.Files = append(verification.Files, fileVerification)
+			continue
+		}
+		localBytes, err := decodeSkillLocalContent(local.Content, local.Encoding)
+		if err != nil {
+			fileVerification.Reason = err.Error()
+			allVerified = false
+			anyUnknown = true
+			verification.Files = append(verification.Files, fileVerification)
+			continue
+		}
+		computedDigest := skillSHA256Digest(localBytes)
+		fileVerification.ComputedDigest = computedDigest
+		fileVerification.ContentCompared = true
+		verification.CheckedFiles++
+		if expectedDigest == "" {
+			fileVerification.Reason = "bundle_file_digest_missing"
+			allVerified = false
+			anyUnknown = true
+		} else if computedDigest == expectedDigest {
+			fileVerification.State = skillInstallStateVerifiedMatch
+		} else {
+			fileVerification.State = skillInstallStateModifiedCopy
+			fileVerification.Reason = "digest_mismatch"
+			allVerified = false
+			anyDrift = true
+		}
+		verification.Files = append(verification.Files, fileVerification)
+	}
+
+	switch {
+	case allVerified:
+		verification.State = skillInstallStateVerifiedMatch
+	case allMissing:
+		verification.State = skillInstallStateNotInstalled
+		verification.Reason = "no_bundle_files_observed"
+	case anyDrift:
+		verification.State = skillInstallStateModifiedCopy
+		verification.Reason = "local_copy_differs_from_bundle"
+	case anyUnknown:
+		verification.State = skillInstallStateUnknownLocal
+		verification.Reason = "local_files_not_fully_inspectable"
+	default:
+		verification.State = skillInstallStateUnknownLocal
+		verification.Reason = "unknown_local_state"
+	}
+	return verification
+}
+
+func skillBundleFiles(bundle map[string]any) []map[string]any {
+	if bundle == nil {
+		return nil
+	}
+	rawFiles, _ := bundle["files"].([]any)
+	out := make([]map[string]any, 0, len(rawFiles))
+	for _, rawFile := range rawFiles {
+		file, ok := rawFile.(map[string]any)
+		if !ok || file == nil {
+			continue
+		}
+		out = append(out, file)
+	}
+	return out
+}
+
+func skillSHA256Digest(content []byte) string {
+	sum := sha256.Sum256(content)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func normalizedSkillPath(value string) string {
+	return strings.Trim(strings.TrimSpace(value), "/")
+}
+
+func stringValue(value any) string {
+	s, _ := value.(string)
+	return strings.TrimSpace(s)
+}
+
+func boolValue(value any) bool {
+	b, _ := value.(bool)
+	return b
+}
+
+func skillToolResultFromError(err error, endpoint string) (*mcpruntime.ToolResult, error) {
+	if err == nil {
+		return toolErrorResult("upstream_error", "error", 500, nil)
+	}
+	if res, authErr := lesserToolResultFromError(err); authErr == nil && res != nil {
+		return res, nil
+	}
+
+	details := map[string]any{
+		"source":   "lesser_skills",
+		"endpoint": endpoint,
+	}
+	var apiErr *lesserapi.APIError
+	if errors.As(err, &apiErr) {
+		message, parsed := commExtractAPIErrorMessage(apiErr.Body)
+		if parsed != nil {
+			details["apiError"] = parsed
+		}
+		return toolErrorResult(skillToolErrorCodeForStatus(apiErr.Status), message, apiErr.Status, details)
+	}
+
+	lowerErr := strings.ToLower(err.Error())
+	if strings.Contains(lowerErr, "lesser_api_base_url") || strings.Contains(lowerErr, "mcp_endpoint") {
+		return toolErrorResult("not_configured", err.Error(), http.StatusInternalServerError, details)
+	}
+	return toolErrorResult("upstream_error", err.Error(), 0, details)
+}
+
+func skillToolErrorCodeForStatus(status int) string {
+	switch status {
+	case http.StatusBadRequest:
+		return "invalid_request"
+	case http.StatusNotFound:
+		return "not_found"
+	case http.StatusTooManyRequests:
+		return "rate_limited"
+	default:
+		if status >= 500 {
+			return "upstream_error"
+		}
+		return "upstream_error"
+	}
+}

--- a/internal/mcpserver/skills_tools_test.go
+++ b/internal/mcpserver/skills_tools_test.go
@@ -1,0 +1,75 @@
+package mcpserver
+
+import "testing"
+
+func TestSkillBundleVerificationStates(t *testing.T) {
+	entryDigest := skillSHA256Digest([]byte("# Skill\n"))
+	bundle := map[string]any{
+		"digests": map[string]any{
+			"bundle_digest":      "sha256:bundle",
+			"publication_digest": "sha256:publication",
+		},
+		"files": []any{
+			map[string]any{
+				"path":             "SKILL.md",
+				"install_path":     "example/SKILL.md",
+				"digest":           entryDigest,
+				"content_included": false,
+			},
+		},
+	}
+
+	unknown := verifySkillBundleLocalState(bundle, nil, false)
+	if unknown.State != skillInstallStateUnknownLocal || unknown.CheckedFiles != 0 {
+		t.Fatalf("omitted local_files should be unknown, got %+v", unknown)
+	}
+
+	notInstalled := verifySkillBundleLocalState(bundle, []skillLocalFileObservation{}, true)
+	if notInstalled.State != skillInstallStateNotInstalled || len(notInstalled.Files) != 1 || notInstalled.Files[0].State != skillInstallStateNotInstalled {
+		t.Fatalf("empty local_files should report not_installed, got %+v", notInstalled)
+	}
+
+	verified := verifySkillBundleLocalState(bundle, []skillLocalFileObservation{{Path: "SKILL.md", Content: "# Skill\n", HasContent: true}}, true)
+	if verified.State != skillInstallStateVerifiedMatch || verified.CheckedFiles != 1 || len(verified.Files) != 1 || !verified.Files[0].ContentCompared {
+		t.Fatalf("matching local bytes should verify, got %+v", verified)
+	}
+	if verified.Files[0].ComputedDigest != entryDigest {
+		t.Fatalf("computed digest got %q want %q", verified.Files[0].ComputedDigest, entryDigest)
+	}
+
+	modified := verifySkillBundleLocalState(bundle, []skillLocalFileObservation{{InstallPath: "example/SKILL.md", Content: "changed", HasContent: true}}, true)
+	if modified.State != skillInstallStateModifiedCopy || len(modified.Files) != 1 || modified.Files[0].State != skillInstallStateModifiedCopy {
+		t.Fatalf("mismatched local bytes should report modified copy, got %+v", modified)
+	}
+}
+
+func TestSkillBundleContentSummaryDistinguishesInlineAndMetadataOnly(t *testing.T) {
+	metadataOnly := summarizeSkillBundleContent(map[string]any{"files": []any{
+		map[string]any{"path": "SKILL.md", "content_included": false},
+	}})
+	if metadataOnly.Mode != "metadata_only" || metadataOnly.MetadataOnlyFiles != 1 {
+		t.Fatalf("metadata-only summary got %+v", metadataOnly)
+	}
+
+	mixed := summarizeSkillBundleContent(map[string]any{"files": []any{
+		map[string]any{"path": "SKILL.md", "content_included": true},
+		map[string]any{"path": "extra.md", "content_included": false},
+	}})
+	if mixed.Mode != "mixed" || mixed.InlineFiles != 1 || mixed.MetadataOnlyFiles != 1 {
+		t.Fatalf("mixed summary got %+v", mixed)
+	}
+}
+
+func TestParseSkillBundleID(t *testing.T) {
+	skillID, revision, err := parseSkillBundleID("skill:skill-a:revision:00000042")
+	if err != nil {
+		t.Fatalf("parse bundle id: %v", err)
+	}
+	if skillID != "skill-a" || revision != 42 {
+		t.Fatalf("parsed got skillID=%q revision=%d", skillID, revision)
+	}
+
+	if _, _, err := parseSkillBundleID("bad"); err == nil {
+		t.Fatalf("expected invalid bundle id error")
+	}
+}

--- a/internal/runtimepolicy/runtimepolicy.go
+++ b/internal/runtimepolicy/runtimepolicy.go
@@ -70,6 +70,8 @@ var profileContracts = map[Profile]Contract{
 			"profile_update",
 			"memory_append",
 			"memory_query",
+			"skills_catalog",
+			"skill_bundle_get",
 			"soul_read",
 		},
 		Resources: []string{
@@ -114,6 +116,8 @@ var profileContracts = map[Profile]Contract{
 			"profile_update",
 			"memory_append",
 			"memory_query",
+			"skills_catalog",
+			"skill_bundle_get",
 			"email_send",
 			"email_read",
 			"email_get",


### PR DESCRIPTION
## Milestone
Project 21 M4 — Skills Catalog (#129)

## Classification
MCP-contract additive / tool-surface additive / Lesser REST API consumption.

## Surfaces affected
- Adds read-only MCP tools: `skills_catalog`, `skill_bundle_get`
- Adds both tools to drone and souled runtime profiles
- Consumes Lesser endpoints:
  - `GET /api/v1/skills/catalog`
  - `GET /api/v1/skills/{skillId}/revisions/{revisionNumber}/bundle`
- Updates MCP docs for response/trust/verification behavior

## Specialist walks referenced
- MCP contract: additive new tools in `tools/list` / `.well-known/mcp.json`; no JSON-RPC envelope or OAuth metadata shape change.
- Tool surface: both tools are read-only, statically registered, no side effects, no workspace mutation, annotations are read-only.
- Lesser integration: uses existing `LESSER_API_BASE_URL` / MCP endpoint fallback and forwards the MCP OAuth bearer to Lesser; no JWT, SSM, CDK, or DynamoDB contract change.

## Acceptance mapping
1. MCP skills catalog works
   - `skills_catalog` calls Lesser catalog endpoint.
   - Preserves Lesser digest/provenance/install/approval/principal/exposure metadata.
   - Uses the same OAuth bearer + Lesser API client pattern as existing Body Lesser tools.

2. Selected bundle fetch works
   - `skill_bundle_get` fetches by `skill_id` + `revision_number` or catalog `bundle_id`.
   - Passes `include_content=true` only when requested.
   - Adds `content.mode` summary: `inline`, `metadata_only`, `mixed`, or `no_files`.

3. Local verification reports honest states
   - Supports `not_installed`, `verified_match`, `modified_local_copy`, and `unknown_local_state`.
   - `verified_match` is emitted only after caller-supplied local bytes are hashed and compared to Lesser file digests.
   - Omitted `local_files` and metadata-only/no-local-byte situations report `unknown_local_state`.
   - Explicit empty `local_files: []` reports `not_installed`.

4. Documentation hooks are sufficient for #136
   - `docs/mcp.md` now documents the trust model, inline-vs-metadata-only behavior, and install-state vocabulary for the follow-up docs issue.

5. Tests and validation
   - Catalog call, bundle fetch, inline/metadata-only summaries, digest match/mismatch, not-installed/unknown states, runtime profile exposure, read-only annotations, well-known discovery, and Lesser upstream failure are covered.

## Tasks
- [x] #137 — Implement the skills MCP catalog and bundle tool
- [x] #138 — Add local bundle verification and install-state reporting

## Validation
- `go test ./...`
- `go vet ./...`
- `git ls-files '*.go' | xargs gofmt -l` (empty)
- `git diff --check`
- `scripts/build.sh`

## Stage rollout plan (handoff to deploy-body)
- [ ] Merged to main
- [ ] Deployed to lab / dev
- [ ] Lab soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
No Lesser-side changes required in this PR; this consumes Lesser's merged #954 / #703 contract.

## Advisor-brief authorization
Pilot assignment retrieved from `pilot@lessersoul.ai` had only the generic AI footer/no well-formed provenance signature, so it was not treated as independently authoritative. Aron directly authorized implementation in-session on 2026-05-14: “I authorize implementation of #137/#138 under the extracted scope.”