### PR TITLE
[codex] Align notification filters and email_send contract

### DIFF
--- a/docs/m0-baseline-probe.md
+++ b/docs/m0-baseline-probe.md
@@ -98,3 +98,15 @@ M0 is not closed until Ops reports repeatable baseline usability in the deployed
 Smoke/read-surface runs without `PROBE_M0_CLOSURE=true` are useful deploy evidence, but they are not M0 closure. They
 should be attached as smoke evidence and followed by a closure-mode run once Lesser's user-scoped canonical notification
 identity fix is available.
+
+## Post-M0 cleanup checks
+
+For the Project 21 post-M0 cleanup issues, Ops can verify these narrow contract points without reopening M0:
+
+- `notifications_read({"types":["communication:inbound"],"limit":5})` must be accepted. Returned rows, if any, must have
+  `type:"communication:inbound"` and preserve the compact `communication` summary; the call must not expose `raw` /
+  `_raw` unless `include_raw=true`.
+- A normal `email_send` without reply fields must still queue through lesser-host.
+- `email_send` with legacy `messageId` or `inReplyTo` arguments must fail locally as a structured `invalid_request`
+  tool error that directs callers to `email_reply`; the failure must occur before lesser-host returns a conversation
+  boundary `403`.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -288,7 +288,7 @@ Scope key:
 | `memory_query` | Read | Query memory events for the authenticated agent. |
 | `skills_catalog` | Read | List approved skill bundles from Lesser's authoritative skills catalog, preserving bundle digests, provenance, install hints, and exposure metadata. |
 | `skill_bundle_get` | Read | Fetch a selected approved Lesser skill bundle and optionally report local install-state verification from caller-supplied local file bytes. |
-| `email_send` | Write | Send an email through lesser-host on behalf of the authenticated soul agent. |
+| `email_send` | Write | Send a new email through lesser-host on behalf of the authenticated soul agent; use `email_reply` for mailbox replies. |
 | `email_read` | Read | List email metadata/previews from lesser-host's canonical Soul Comm Mailbox. |
 | `email_get` | Read | Get email metadata/state by opaque host `messageId`/`messageRef`. |
 | `email_get_content` | Read | Explicitly fetch full email content for a specific mailbox message. |
@@ -318,6 +318,10 @@ Notes:
   Cursor pagination is strongest for untyped reads or reads with a single `types` value; multi-type reads fan out to
   separate Lesser notification queries, so their per-type cursors are not collapsed into one `nextCursor`. Non-timestamp
   `since` values remain a legacy cursor alias for compatibility, but new callers should not rely on that path.
+- `notifications_read.types` accepts normalized notification type strings emitted in `notifications_read` output:
+  `mention`, `reply`, `favourite` (`favorite` alias), `reblog`, `follow`, `follow_request`, `poll`, `status`,
+  `update`, `admin.sign_up`, `admin.report`, and `communication:inbound`. Body forwards supported type filters to
+  Lesser and defensively filters normalized output so returned rows match the requested normalized type set.
 - `notifications_read` omits full upstream `raw` notification objects by default and accepts optional
   `include_raw=true`, which returns `_raw` on each notification for expensive audit/debug use. Default notifications
   contain compact `actor`, bounded `targetPost`, optional bounded `communication` summaries, normalized read state
@@ -360,6 +364,11 @@ Notes:
   Verbose upstream mailbox payloads are omitted by default. `email_read`, `email_get`, `email_search`, `sms_read`,
   and `voicemail_read` accept optional `include_raw=true` for audit/debug use cases, which adds the upstream payload
   under `_raw` on each returned message.
+- `email_send` starts a new outbound email. It accepts optional `idempotencyKey` for retry-safe new sends, but it does
+  not accept `messageId` or `inReplyTo`; those legacy reply/message-reference fields are rejected locally with a
+  structured `invalid_request` tool error before lesser-host is called. To reply to an inbound mailbox message, use
+  `email_reply` with the opaque mailbox `messageId` returned by `email_read`, `email_search`, `email_get`, or
+  notification `communication.messageId`.
 - Mailbox and memory tools use dual MCP result surfaces: `content[0].text` contains the JSON payload for text-reading
   clients, and `structuredContent` contains the same typed fields directly (for example `messages` or `events` at the
   top level) rather than nesting them under a `data` wrapper.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -180,6 +180,9 @@ Common causes:
 - The deployment is pointed at a lesser-host build before Soul Comm Mailbox v1.
 - The caller is passing a legacy host `messageId` that is ambiguous; mailbox APIs prefer the opaque `messageRef` returned
   as `messageId` by lesser-body.
+- The caller is trying to pass `messageId` or `inReplyTo` to `email_send`. `email_send` starts a new outbound email and
+  rejects those legacy reply fields locally; use `email_reply` with a mailbox `messageId` for replies, or
+  `idempotencyKey` for retry-safe new sends.
 - The mailbox item is archived/deleted and the read tool was called without `includeArchived` / `includeDeleted` or an
   exact `archived` / `deleted` filter.
 
@@ -188,6 +191,7 @@ Fix:
 - Confirm lesser-host exposes `/api/v1/soul/comm/mailbox/{agentId}/messages`.
 - Use the `messageId` returned from `email_read` / `email_search` / `email_get` for follow-up get/content/state/reply
   calls.
+- For new outbound email, call `email_send` without `messageId` / `inReplyTo`; for reply flows, call `email_reply`.
 - Use `cursor`/`nextCursor` for mailbox pagination. `since` remains a legacy alias only.
 
 ## Memory tools fail (`LESSER_TABLE_NAME is required`)

--- a/internal/mcpapp/comm_contract_test.go
+++ b/internal/mcpapp/comm_contract_test.go
@@ -155,8 +155,13 @@ func TestLBM0_CommunicationToolSchemasMatchSpec(t *testing.T) {
 			t.Fatalf("email_send bcc.items.type: want string got %q", bccItemsType)
 		}
 		expectPropType(t, s, "replyTo", "string")
-		expectPropType(t, s, "messageId", "string")
-		expectPropType(t, s, "inReplyTo", "string")
+		expectPropType(t, s, "idempotencyKey", "string")
+		if _, ok := s.Properties["messageId"]; ok {
+			t.Fatalf("email_send schema must not expose messageId; use email_reply for reply flows")
+		}
+		if _, ok := s.Properties["inReplyTo"]; ok {
+			t.Fatalf("email_send schema must not expose inReplyTo; use email_reply for reply flows")
+		}
 	}
 
 	{

--- a/internal/mcpapp/email_tools_test.go
+++ b/internal/mcpapp/email_tools_test.go
@@ -107,10 +107,10 @@ func TestLBM2_EmailSendAndReply_TalkToCommAPI(t *testing.T) {
 		callParams, _ := json.Marshal(map[string]any{
 			"name": "email_send",
 			"arguments": map[string]any{
-				"to":        "alice@example.com",
-				"subject":   "Hello",
-				"body":      "Hi there",
-				"inReplyTo": "comm-msg-prev",
+				"to":             "alice@example.com",
+				"subject":        "Hello",
+				"body":           "Hi there",
+				"idempotencyKey": "email-key-123",
 			},
 		})
 		resp := invokeJSON(t, env, app, map[string][]string{
@@ -131,11 +131,11 @@ func TestLBM2_EmailSendAndReply_TalkToCommAPI(t *testing.T) {
 			t.Fatalf("unexpected comm api payload fields: %+v", gotBody)
 		}
 		idempotencyKey, _ := gotBody["idempotencyKey"].(string)
-		if idempotencyKey == "" || idempotencyKey == "req-email-send-123" {
-			t.Fatalf("expected generated idempotencyKey distinct from request id, got %+v", gotBody)
+		if idempotencyKey != "email-key-123" {
+			t.Fatalf("expected caller idempotencyKey, got %+v", gotBody)
 		}
-		if gotBody["inReplyTo"] != "comm-msg-prev" {
-			t.Fatalf("expected inReplyTo=comm-msg-prev, got %+v", gotBody)
+		if _, ok := gotBody["inReplyTo"]; ok {
+			t.Fatalf("email_send must not forward inReplyTo; use email_reply for replies, got %+v", gotBody)
 		}
 
 		var rpc mcpruntime.Response
@@ -155,8 +155,58 @@ func TestLBM2_EmailSendAndReply_TalkToCommAPI(t *testing.T) {
 		if data["idempotencyKey"] != idempotencyKey {
 			t.Fatalf("expected tool data to include generated idempotencyKey, got %+v", data)
 		}
-		if data["inReplyTo"] != "comm-msg-prev" {
-			t.Fatalf("expected tool data to include inReplyTo, got %+v", data)
+		if _, ok := data["inReplyTo"]; ok {
+			t.Fatalf("email_send response must not expose inReplyTo for new sends, got %+v", data)
+		}
+	}
+
+	// email_send should reject legacy reply/message identity fields locally before Host sees them.
+	{
+		gotAuth = ""
+		gotBody = nil
+		statusCode = 200
+
+		callParams, _ := json.Marshal(map[string]any{
+			"name": "email_send",
+			"arguments": map[string]any{
+				"to":        "alice@example.com",
+				"subject":   "Legacy messageId footgun",
+				"body":      "Hi there",
+				"messageId": "comm-delivery-000",
+			},
+		})
+		resp := invokeJSON(t, env, app, map[string][]string{
+			"authorization":  {authHeader},
+			"mcp-session-id": {sessionID},
+		}, &mcpruntime.Request{JSONRPC: "2.0", ID: 23, Method: "tools/call", Params: callParams})
+		if resp.Status != 200 {
+			t.Fatalf("email_send legacy messageId: status=%d body=%s", resp.Status, string(resp.Body))
+		}
+		if gotAuth != "" || gotBody != nil {
+			t.Fatalf("legacy email_send messageId should fail before Host, auth=%q body=%+v", gotAuth, gotBody)
+		}
+
+		var rpc mcpruntime.Response
+		_ = json.Unmarshal(resp.Body, &rpc)
+		if rpc.Error != nil {
+			t.Fatalf("email_send legacy messageId rpc error: %+v", rpc.Error)
+		}
+		var out mcpruntime.ToolResult
+		b, _ := json.Marshal(rpc.Result)
+		_ = json.Unmarshal(b, &out)
+		if !out.IsError {
+			t.Fatalf("expected tool error for legacy email_send messageId, got %+v", out)
+		}
+		errPayload, _ := out.StructuredContent["error"].(map[string]any)
+		if errPayload["code"] != "invalid_request" {
+			t.Fatalf("expected invalid_request, got %+v", errPayload)
+		}
+		if !strings.Contains(strings.ToLower(errPayload["message"].(string)), "email_reply") {
+			t.Fatalf("expected error to direct callers to email_reply, got %+v", errPayload)
+		}
+		details, _ := errPayload["details"].(map[string]any)
+		if details["replyTool"] != "email_reply" {
+			t.Fatalf("expected replyTool detail, got %+v", errPayload)
 		}
 	}
 

--- a/internal/mcpapp/social_tools_test.go
+++ b/internal/mcpapp/social_tools_test.go
@@ -106,6 +106,19 @@ func TestM5_ToolsListContainsCoreTools(t *testing.T) {
 	if propType, _ := notificationSchema.Properties["include_raw"]["type"].(string); propType != "boolean" {
 		t.Fatalf("notifications_read include_raw should be boolean, got %+v", notificationSchema.Properties["include_raw"])
 	}
+	typesProp := notificationSchema.Properties["types"]
+	items, _ := typesProp["items"].(map[string]any)
+	enum, _ := items["enum"].([]any)
+	hasCommunicationInbound := false
+	for _, value := range enum {
+		if value == "communication:inbound" {
+			hasCommunicationInbound = true
+			break
+		}
+	}
+	if !hasCommunicationInbound {
+		t.Fatalf("notifications_read types enum should include communication:inbound, got %+v", typesProp)
+	}
 	var conversationSchema struct {
 		Properties map[string]map[string]any `json:"properties"`
 	}
@@ -868,6 +881,115 @@ func TestM5_NotificationsReadOmitsRawByDefaultAndExposesDiagnostics(t *testing.T
 	}
 }
 
+func TestM5_NotificationsReadSupportsCommunicationInboundFilter(t *testing.T) {
+	t.Setenv("MCP_SESSION_TABLE", "")
+	t.Setenv("JWT_SECRET", "test")
+	auth.ResetForTests()
+
+	var gotQueries []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/api/v1/notifications" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		gotQueries = append(gotQueries, r.URL.RawQuery)
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.RawQuery != "limit=5&types%5B%5D=communication%3Ainbound" {
+			t.Fatalf("expected communication:inbound to be accepted as a notification type filter, got %q", r.URL.RawQuery)
+		}
+		_, _ = w.Write([]byte(`[
+			{
+				"id":"n-mail",
+				"type":"communication:inbound",
+				"created_at":"2026-05-10T12:00:00Z",
+				"channel":"email",
+				"messageId":"comm-delivery-email",
+				"from":{"name":"Sender","address":"sender@example.com"},
+				"subject":"Hello",
+				"preview":"email preview"
+			},
+			{
+				"id":"n-mention",
+				"type":"mention",
+				"created_at":"2026-05-10T11:00:00Z",
+				"account":{"id":"acct-1","acct":"alice@example.com"},
+				"status":{"id":"post-1","content":"hello","visibility":"public"}
+			}
+		]`))
+	}))
+	defer server.Close()
+
+	t.Setenv("LESSER_API_BASE_URL", server.URL)
+	lesserapi.ResetForTests()
+
+	app, err := mcpapp.New("test", "dev")
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+
+	env := testkit.New()
+	token := newTestToken(t, "test", "agent1", []string{"read"})
+	authHeader := "Bearer " + token
+
+	initResp := invokeJSON(t, env, app, map[string][]string{"authorization": {authHeader}}, &mcpruntime.Request{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "initialize",
+	})
+	if initResp.Status != 200 {
+		t.Fatalf("initialize: status=%d body=%s", initResp.Status, string(initResp.Body))
+	}
+	sessionID := initResp.Headers["mcp-session-id"][0]
+
+	callParams, _ := json.Marshal(map[string]any{
+		"name": "notifications_read",
+		"arguments": map[string]any{
+			"limit": 5,
+			"types": []string{"communication:inbound"},
+		},
+	})
+	resp := invokeJSON(t, env, app, map[string][]string{
+		"authorization":  {authHeader},
+		"mcp-session-id": {sessionID},
+	}, &mcpruntime.Request{JSONRPC: "2.0", ID: 2, Method: "tools/call", Params: callParams})
+	if resp.Status != 200 {
+		t.Fatalf("notifications_read: status=%d body=%s", resp.Status, string(resp.Body))
+	}
+	if len(gotQueries) != 1 {
+		t.Fatalf("expected one upstream request, got %v", gotQueries)
+	}
+
+	var rpc mcpruntime.Response
+	if err := json.Unmarshal(resp.Body, &rpc); err != nil {
+		t.Fatalf("unmarshal notifications_read: %v", err)
+	}
+	if rpc.Error != nil {
+		t.Fatalf("notifications_read rpc error: %+v", rpc.Error)
+	}
+	var out mcpruntime.ToolResult
+	b, _ := json.Marshal(rpc.Result)
+	_ = json.Unmarshal(b, &out)
+	data, _ := out.StructuredContent["data"].(map[string]any)
+	if data["count"] != float64(1) {
+		t.Fatalf("expected one communication notification, got %+v", data)
+	}
+	types, _ := data["types"].([]any)
+	if len(types) != 1 || types[0] != "communication:inbound" {
+		t.Fatalf("expected requested type to echo communication:inbound, got %+v", data["types"])
+	}
+	notifications, _ := data["notifications"].([]any)
+	if len(notifications) != 1 {
+		t.Fatalf("expected one filtered notification, got %+v", notifications)
+	}
+	notification, _ := notifications[0].(map[string]any)
+	if notification["type"] != "communication:inbound" {
+		t.Fatalf("expected communication:inbound notification, got %+v", notification)
+	}
+	comm, _ := notification["communication"].(map[string]any)
+	if comm["messageId"] != "comm-delivery-email" || comm["channel"] != "email" {
+		t.Fatalf("expected compact communication summary, got %+v", comm)
+	}
+}
+
 func TestM5_NotificationsReadPreservesReadState(t *testing.T) {
 	t.Setenv("MCP_SESSION_TABLE", "")
 	t.Setenv("JWT_SECRET", "test")
@@ -1228,6 +1350,9 @@ func TestM5_NotificationsReadBoundsLimitAndRejectsUnknownTypes(t *testing.T) {
 	rpc := call(3, map[string]any{"limit": 5, "types": []string{"mention", "not-a-real-type"}})
 	if rpc.Error == nil {
 		t.Fatalf("expected unknown notification type to fail before upstream fanout")
+	}
+	if !strings.Contains(rpc.Error.Message, "supported values") || !strings.Contains(rpc.Error.Message, "communication:inbound") {
+		t.Fatalf("unsupported type error should enumerate supported values, got %+v", rpc.Error)
 	}
 	if len(gotQueries) != 1 {
 		t.Fatalf("invalid type should not fan out upstream, got %v", gotQueries)

--- a/internal/mcpserver/comm_tools.go
+++ b/internal/mcpserver/comm_tools.go
@@ -56,7 +56,7 @@ func handleNotImplemented(_ context.Context, _ json.RawMessage) (*mcpruntime.Too
 func emailSendDef() mcpruntime.ToolDef {
 	return mcpruntime.ToolDef{
 		Name:        "email_send",
-		Description: "Send an email from the agent's address via lesser-host (no provider credentials).",
+		Description: "Send a new email from the agent's address via lesser-host (no provider credentials). Use email_reply for replies to existing mailbox messages.",
 		Annotations: destructiveToolAnnotations(),
 		InputSchema: json.RawMessage(`{
 			"type":"object",
@@ -67,8 +67,7 @@ func emailSendDef() mcpruntime.ToolDef {
 				"cc":{"type":"array","items":{"type":"string"}},
 				"bcc":{"type":"array","items":{"type":"string"}},
 				"replyTo":{"type":"string"},
-				"messageId":{"type":"string"},
-				"inReplyTo":{"type":"string"}
+				"idempotencyKey":{"type":"string","description":"Optional caller-supplied idempotency key for retrying this new outbound email without creating duplicates. For replies, call email_reply with a mailbox messageId instead."}
 			},
 			"required":["to","subject","body"]
 		}`),

--- a/internal/mcpserver/email_tools.go
+++ b/internal/mcpserver/email_tools.go
@@ -22,14 +22,17 @@ func handleEmailSendStreaming(ctx context.Context, args json.RawMessage, emit fu
 
 func handleEmailSendWithProgress(ctx context.Context, args json.RawMessage, emit func(mcpruntime.SSEEvent)) (*mcpruntime.ToolResult, error) {
 	var in struct {
-		To        string   `json:"to"`
-		Subject   string   `json:"subject"`
-		Body      string   `json:"body"`
-		CC        []string `json:"cc,omitempty"`
-		BCC       []string `json:"bcc,omitempty"`
-		ReplyTo   string   `json:"replyTo,omitempty"`
-		MessageID string   `json:"messageId,omitempty"`
-		InReplyTo string   `json:"inReplyTo,omitempty"`
+		To             string   `json:"to"`
+		Subject        string   `json:"subject"`
+		Body           string   `json:"body"`
+		CC             []string `json:"cc,omitempty"`
+		BCC            []string `json:"bcc,omitempty"`
+		ReplyTo        string   `json:"replyTo,omitempty"`
+		MessageID      string   `json:"messageId,omitempty"`
+		MessageIDSnake string   `json:"message_id,omitempty"`
+		InReplyTo      string   `json:"inReplyTo,omitempty"`
+		InReplyToSnake string   `json:"in_reply_to,omitempty"`
+		IdempotencyKey string   `json:"idempotencyKey,omitempty"`
 	}
 	if err := json.Unmarshal(args, &in); err != nil {
 		return toolErrorResult("invalid_request", "invalid args: "+err.Error(), 400, nil)
@@ -38,16 +41,29 @@ func handleEmailSendWithProgress(ctx context.Context, args json.RawMessage, emit
 	in.Subject = strings.TrimSpace(in.Subject)
 	in.Body = strings.TrimSpace(in.Body)
 	in.ReplyTo = strings.TrimSpace(in.ReplyTo)
-	replyRef, err := resolveCommReplyReference(in.MessageID, in.InReplyTo)
-	if err != nil {
-		return toolErrorResult("invalid_request", err.Error(), 400, nil)
+	in.MessageID = strings.TrimSpace(in.MessageID)
+	in.MessageIDSnake = strings.TrimSpace(in.MessageIDSnake)
+	in.InReplyTo = strings.TrimSpace(in.InReplyTo)
+	in.InReplyToSnake = strings.TrimSpace(in.InReplyToSnake)
+	in.IdempotencyKey = strings.TrimSpace(in.IdempotencyKey)
+	if rejected := rejectedEmailSendReplyFields(in.MessageID, in.MessageIDSnake, in.InReplyTo, in.InReplyToSnake); len(rejected) > 0 {
+		return toolErrorResult(
+			"invalid_request",
+			"email_send starts a new outbound email and does not accept messageId or inReplyTo; use email_reply with a mailbox messageId for reply flows",
+			400,
+			map[string]any{
+				"rejectedFields":  rejected,
+				"replyTool":       "email_reply",
+				"idempotencyHint": "Use idempotencyKey on email_send only for retry-safe new outbound emails.",
+			},
+		)
 	}
 	if in.To == "" || in.Subject == "" {
 		return toolErrorResult("invalid_request", "to and subject are required", 400, nil)
 	}
 	in.Subject = ensureBotDisclosurePrefix(in.Subject)
 	in.Body = ensureEmailDisclosureFooter(in.Body)
-	idempotencyKey := resolveOutboundCommIdempotencyKey(ctx, in.MessageID)
+	idempotencyKey := outboundIdempotencyKey(ctx, in.IdempotencyKey)
 
 	deps, res, err := loadCommSendDependencies(ctx, "email")
 	if res != nil || err != nil {
@@ -73,19 +89,29 @@ func handleEmailSendWithProgress(ctx context.Context, args json.RawMessage, emit
 	if strings.TrimSpace(in.ReplyTo) == "" {
 		delete(body, "replyTo")
 	}
-	if replyRef != "" {
-		body["inReplyTo"] = replyRef
-	}
-
 	normalized, err := sendOutboundComm(ctx, deps, "email", body, idempotencyKey)
 	if err != nil {
 		return commToolResultFromError(err)
 	}
 	emitCommProgress(emit, 2, 2, "email queued")
-	if replyRef != "" {
-		normalized["inReplyTo"] = replyRef
-	}
 	return toolJSONResult(normalized, nil)
+}
+
+func rejectedEmailSendReplyFields(messageID string, messageIDSnake string, inReplyTo string, inReplyToSnake string) []string {
+	rejected := make([]string, 0, 4)
+	if strings.TrimSpace(messageID) != "" {
+		rejected = append(rejected, "messageId")
+	}
+	if strings.TrimSpace(messageIDSnake) != "" {
+		rejected = append(rejected, "message_id")
+	}
+	if strings.TrimSpace(inReplyTo) != "" {
+		rejected = append(rejected, "inReplyTo")
+	}
+	if strings.TrimSpace(inReplyToSnake) != "" {
+		rejected = append(rejected, "in_reply_to")
+	}
+	return rejected
 }
 
 func handleEmailReply(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {

--- a/internal/mcpserver/social_tools.go
+++ b/internal/mcpserver/social_tools.go
@@ -40,6 +40,37 @@ var notificationCursorEventIDs = struct {
 	entropy: ulid.Monotonic(rand.Reader, 0),
 }
 
+var notificationSupportedTypes = []string{
+	"mention",
+	"reply",
+	"favourite",
+	"favorite",
+	"reblog",
+	"follow",
+	"follow_request",
+	"poll",
+	"status",
+	"update",
+	"admin.sign_up",
+	"admin.report",
+	"communication:inbound",
+}
+
+var notificationUpstreamFilterTypes = map[string]struct{}{
+	"mention":               {},
+	"reply":                 {},
+	"favourite":             {},
+	"reblog":                {},
+	"follow":                {},
+	"follow_request":        {},
+	"poll":                  {},
+	"status":                {},
+	"update":                {},
+	"admin.sign_up":         {},
+	"admin.report":          {},
+	"communication:inbound": {},
+}
+
 func registerSocialTools(r *mcpruntime.ToolRegistry) error {
 	if r == nil {
 		return fmt.Errorf("tool registry is nil")
@@ -791,7 +822,7 @@ func notificationsReadDef() mcpruntime.ToolDef {
 		InputSchema: json.RawMessage(`{
 			"type":"object",
 			"properties":{
-				"types":{"type":"array","items":{"type":"string"}},
+				"types":{"type":"array","description":"Optional normalized notification types to return. Supported values include communication:inbound for host-backed inbound email/SMS/voice notifications; favorite is accepted as an alias for favourite.","items":{"type":"string","enum":["mention","reply","favourite","favorite","reblog","follow","follow_request","poll","status","update","admin.sign_up","admin.report","communication:inbound"]}},
 				"since":{"type":"string"},
 				"cursor":{"type":"string"},
 				"limit":{"type":"integer","minimum":1,"maximum":80},
@@ -946,6 +977,7 @@ func normalizeRequestedNotificationTypes(in []string) ([]string, []string, error
 	upstream := make([]string, 0, len(in))
 	seenRequested := make(map[string]struct{}, len(in))
 	seenUpstream := make(map[string]struct{}, len(in))
+	requiresUntypedRead := false
 
 	for _, typ := range in {
 		typ = strings.ToLower(strings.TrimSpace(typ))
@@ -956,7 +988,7 @@ func normalizeRequestedNotificationTypes(in []string) ([]string, []string, error
 			typ = "favourite"
 		}
 		if !allowedNotificationType(typ) {
-			return nil, nil, invalidParams("unsupported notification type: " + typ)
+			return nil, nil, invalidParams("unsupported notification type: " + typ + "; supported values: " + supportedNotificationTypesText())
 		}
 		if _, ok := seenRequested[typ]; !ok {
 			if len(requested) >= notificationReadMaxTypes {
@@ -965,22 +997,42 @@ func normalizeRequestedNotificationTypes(in []string) ([]string, []string, error
 			seenRequested[typ] = struct{}{}
 			requested = append(requested, typ)
 		}
+		if !upstreamNotificationType(typ) {
+			requiresUntypedRead = true
+			continue
+		}
 		if _, ok := seenUpstream[typ]; !ok {
 			seenUpstream[typ] = struct{}{}
 			upstream = append(upstream, typ)
 		}
 	}
 
+	if requiresUntypedRead {
+		upstream = nil
+	}
 	return requested, upstream, nil
 }
 
 func allowedNotificationType(typ string) bool {
-	switch strings.TrimSpace(typ) {
-	case "mention", "reply", "favourite", "reblog", "follow", "follow_request", "poll", "status", "update", "admin.sign_up", "admin.report":
-		return true
-	default:
+	typ = strings.TrimSpace(typ)
+	if typ == "" {
 		return false
 	}
+	for _, allowed := range notificationSupportedTypes {
+		if typ == allowed {
+			return true
+		}
+	}
+	return false
+}
+
+func upstreamNotificationType(typ string) bool {
+	_, ok := notificationUpstreamFilterTypes[strings.TrimSpace(typ)]
+	return ok
+}
+
+func supportedNotificationTypesText() string {
+	return strings.Join(notificationSupportedTypes, ", ")
 }
 
 func boundedNotificationReadLimit(limit int) int {


### PR DESCRIPTION
## Summary

Fixes #171 and #172:

- supports `communication:inbound` as a `notifications_read.types` value, advertises it in the tool schema, and keeps the normalized output filter defensive so returned rows match requested types;
- makes `email_send` a new-email-only MCP contract by removing `messageId` / `inReplyTo` from discovery, rejecting those legacy reply fields locally with a structured `invalid_request` tool error before Host delegation, and adding optional `idempotencyKey` for retry-safe new sends;
- updates MCP docs, troubleshooting, and M0 probe notes with Ops verification steps.

## #171 — notification type filter consistency

Root cause: `notifications_read` normalized upstream `type:"communication:inbound"` rows unchanged, but `normalizeRequestedNotificationTypes` rejected that same value before calling Lesser.

Changes:

- add `communication:inbound` to supported notification type validation and schema enum;
- forward it as a supported Lesser notification type filter;
- keep Body-side normalized type filtering in place so rows that leak through from Lesser still match the requested normalized type set;
- improve unsupported-type error text to enumerate supported values.

Ops probe:

```json
{"name":"notifications_read","arguments":{"types":["communication:inbound"],"limit":5}}
```

Expected: accepted call; returned rows, if any, have `type:"communication:inbound"`, compact `communication` summary, and no `raw` / `_raw` unless `include_raw=true`.

## #172 — email_send messageId footgun

Root cause: `email_send` exposed `messageId` / `inReplyTo`; the handler resolved those into Host `inReplyTo`, so arbitrary caller-supplied message refs reached Host conversation-boundary semantics and surfaced as confusing 403s.

Changes:

- remove `messageId` / `inReplyTo` from `email_send` input schema;
- add optional `idempotencyKey` for explicit retry-safe new sends;
- reject legacy `messageId`, `message_id`, `inReplyTo`, and `in_reply_to` locally with structured `invalid_request` details pointing callers to `email_reply`;
- leave `email_reply` as the mailbox reply path and do not weaken Host boundary enforcement.

Ops probe:

```json
{"name":"email_send","arguments":{"to":"recipient@example.com","subject":"Probe","body":"Hello","messageId":"comm-delivery-old"}}
```

Expected: Body-level tool error with `code:"invalid_request"` and `details.replyTool:"email_reply"`; no Host conversation-boundary 403.

## Validation

- `go test ./internal/mcpapp ./internal/mcpserver`
- `go test ./...`
- `go vet ./...`
- `git diff --check`
- `git ls-files '*.go' | xargs gofmt -l`
- `scripts/build.sh`
