### PR TITLE
[codex] Fix skill_bundle_get schema for agent clients

### DIFF
--- a/internal/mcpserver/skills_tools.go
+++ b/internal/mcpserver/skills_tools.go
@@ -123,7 +123,7 @@ func skillBundleGetDef() mcpruntime.ToolDef {
 			"properties":{
 				"skill_id":{"type":"string","description":"Lesser skill id from skills_catalog."},
 				"revision_number":{"type":"integer","minimum":1,"description":"Approved revision number to fetch."},
-				"bundle_id":{"type":"string","description":"Optional catalog bundle.bundle_id selection such as skill:<skillId>:revision:00000001. Used when skill_id/revision_number are not provided."},
+				"bundle_id":{"type":"string","description":"Optional catalog bundle.bundle_id selection such as skill:<skillId>:revision:00000001. Provide either bundle_id or both skill_id and revision_number; Body validates that requirement at runtime."},
 				"include_content":{"type":"boolean","description":"Ask Lesser to include inline bundle file content when available. Defaults to false."},
 				"local_files":{
 					"type":"array",
@@ -138,11 +138,7 @@ func skillBundleGetDef() mcpruntime.ToolDef {
 						}
 					}
 				}
-			},
-			"anyOf":[
-				{"required":["skill_id","revision_number"]},
-				{"required":["bundle_id"]}
-			]
+			}
 		}`),
 	}
 }

--- a/internal/mcpserver/skills_tools_test.go
+++ b/internal/mcpserver/skills_tools_test.go
@@ -1,6 +1,41 @@
 package mcpserver
 
-import "testing"
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestSkillBundleGetSchemaAvoidsTopLevelComposition(t *testing.T) {
+	def := skillBundleGetDef()
+	var schema map[string]any
+	if err := json.Unmarshal(def.InputSchema, &schema); err != nil {
+		t.Fatalf("unmarshal skill_bundle_get schema: %v", err)
+	}
+	if schema["type"] != "object" {
+		t.Fatalf("skill_bundle_get schema type: want object got %#v", schema["type"])
+	}
+	for _, keyword := range []string{"oneOf", "anyOf", "allOf", "enum", "not"} {
+		if _, ok := schema[keyword]; ok {
+			t.Fatalf("skill_bundle_get schema must not use top-level %s for MCP client compatibility: %+v", keyword, schema)
+		}
+	}
+	properties, _ := schema["properties"].(map[string]any)
+	if properties["skill_id"] == nil || properties["revision_number"] == nil || properties["bundle_id"] == nil {
+		t.Fatalf("skill_bundle_get schema should advertise both selector forms in properties, got %+v", properties)
+	}
+}
+
+func TestSkillBundleGetStillRequiresSelectorAtRuntime(t *testing.T) {
+	_, err := handleSkillBundleGet(context.Background(), json.RawMessage(`{}`))
+	if err == nil {
+		t.Fatalf("expected missing selector to fail at runtime")
+	}
+	if !strings.Contains(err.Error(), "skill_id is required unless bundle_id is provided") {
+		t.Fatalf("unexpected missing selector error: %v", err)
+	}
+}
 
 func TestSkillBundleVerificationStates(t *testing.T) {
 	entryDigest := skillSHA256Digest([]byte("# Skill\n"))


### PR DESCRIPTION
## Summary

Fixes the MCP discovery schema regression reported by agent clients:

```json
{
  "code": "invalid_function_parameters",
  "message": "Invalid schema for function 'skill_bundle_get': schema must have type 'object' and not have 'oneOf'/'anyOf'/'allOf'/'enum'/'not' at the top level."
}
```

## Root cause

`skill_bundle_get` advertised this top-level JSON Schema composition:

```json
"anyOf": [
  {"required": ["skill_id", "revision_number"]},
  {"required": ["bundle_id"]}
]
```

Some MCP clients convert tool schemas into function-parameter schemas and reject top-level composition keywords before any tool call can run.

## Change

- Remove top-level `anyOf` from the advertised `skill_bundle_get` input schema.
- Keep the schema as a plain top-level `type: "object"` with `skill_id`, `revision_number`, and `bundle_id` properties.
- Clarify the `bundle_id` description: callers must provide either `bundle_id` or both `skill_id` and `revision_number`.
- Preserve the existing runtime validation in `handleSkillBundleGet`, so missing selectors still fail before auth/upstream calls.
- Add tests that guard against top-level `oneOf` / `anyOf` / `allOf` / `enum` / `not` and assert runtime selector validation remains in place.

## MCP contract impact

This is a compatibility fix to the discovery/tool schema. Runtime behavior is unchanged: valid calls still work and invalid selector combinations still fail locally. The advertised schema is slightly less expressive but accepted by stricter agent clients.

## Validation

- `go test ./internal/mcpserver ./internal/mcpapp`
- `go test ./...`
- `go vet ./...`
- `git diff --check`
- `git ls-files '*.go' | xargs gofmt -l`
- `scripts/build.sh`
