### PR TITLE
fix(mcp): enforce private read runtime boundaries

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -175,6 +175,8 @@ Runtime resolution is based on soul binding:
 
 When the active profile is `drone`, lesser-body filters `tools/list`, `resources/list`, and `prompts/list`, and rejects
 direct calls to communication-only surfaces such as `sms_send`, `agent://channels`, and `compose_email`.
+The drone boundary also applies inside mixed read tools: `notifications_read` rejects explicit
+`communication:inbound` filters for drone actors and filters communication-shaped rows from untyped notification reads.
 
 ## Examples (curl)
 
@@ -321,7 +323,9 @@ Notes:
 - `notifications_read.types` accepts normalized notification type strings emitted in `notifications_read` output:
   `mention`, `reply`, `favourite` (`favorite` alias), `reblog`, `follow`, `follow_request`, `poll`, `status`,
   `update`, `admin.sign_up`, `admin.report`, and `communication:inbound`. Body forwards supported type filters to
-  Lesser and defensively filters normalized output so returned rows match the requested normalized type set.
+  Lesser and defensively filters normalized output so returned rows match the requested normalized type set. The
+  `communication:inbound` type is available only in the `souled` runtime profile; drone-profile callers receive a
+  runtime-boundary tool error for explicit communication filters, and untyped drone reads omit communication rows.
 - `notifications_read` omits full upstream `raw` notification objects by default and accepts optional
   `include_raw=true`, which returns `_raw` on each notification for expensive audit/debug use. Default notifications
   contain compact `actor`, bounded `targetPost`, optional bounded `communication` summaries, normalized read state
@@ -387,7 +391,9 @@ Notes:
 - `soul_read` is the Project 21 public soul read-model tool. It accepts either `self=true` (the caller's
   OAuth-bound soul), or one of `agentId`, `ensName`, or `query` (full soul agent ID, ENS name, current-instance local
   ID, explicit `@user@domain` ActivityPub handle, or canonical actor URL), plus optional `limit` for search-backed
-  matches and `include_raw=true` for audit/debug. `self=true` conflicts with `agentId`, `ensName`, and `query`.
+  matches and `include_raw=true` for audit/debug. Raw audit payloads are sanitized before being returned; private
+  reachability fields such as email/phone channels and contact preferences are redacted even when `include_raw=true`.
+  `self=true` conflicts with `agentId`, `ensName`, and `query`.
   Bare current-instance local IDs require trustworthy current-instance domain context; use a full soul `agentId`,
   ENS name, explicit handle, canonical actor URL, or `self=true` when that context is unavailable. The default response
   is compact and returns `access` metadata plus `souls[]`, each with stable MCP blocks: `identity`, `registration`,

--- a/docs/security.md
+++ b/docs/security.md
@@ -77,6 +77,8 @@ Lesser -> lesser-host with managed instance trust
 `include_private:["mintConversations"]`. `self=true` alone remains public-only. For this path, lesser-body forwards the
 MCP caller bearer only to Lesser's self-scope routes. It does **not** call lesser-host directly, does **not** use
 `LESSER_HOST_INSTANCE_KEY`, and does **not** pass MCP caller bearer tokens to lesser-host control-plane auth.
+When callers request `include_raw=true`, raw public Host/Soul endpoint payloads are sanitized before they are returned;
+private reachability fields such as email/phone channels and contact preferences remain redacted.
 
 The rejected unsafe pattern is direct MCP bearer forwarding to lesser-host. MCP bearers are issued by Lesser for an
 actor-scoped MCP resource; lesser-host control-plane auth cannot derive the local account, current instance domain, or

--- a/internal/mcpapp/identity_surfaces_test.go
+++ b/internal/mcpapp/identity_surfaces_test.go
@@ -1345,6 +1345,135 @@ func TestLBM1_SoulReadPublicMVPUsesPublicEndpoints(t *testing.T) {
 	}
 }
 
+func TestM2_SoulReadIncludeRawRedactsPrivateReachability(t *testing.T) {
+	t.Setenv("MCP_SESSION_TABLE", "")
+	t.Setenv("JWT_SECRET", "test")
+	installMissingSoulBindingLookup(t)
+	auth.ResetForTests()
+	lesserapi.ResetForTests()
+	soulapi.ResetForTests()
+	t.Cleanup(soulapi.ResetForTests)
+
+	const agentID = "0xcacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacaca"
+	const privateEmail = "private-reachability@example.test"
+	const privatePhone = "+15550197000"
+	const privatePreference = "prefer-private-email"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/soul/agents/" + agentID:
+			_, _ = w.Write([]byte(`{
+				"agent":{
+					"agent_id":"` + agentID + `",
+					"domain":"test.example.com",
+					"local_id":"agent-raw",
+					"ens_name":"agent-raw.lessersoul.eth",
+					"email":"` + privateEmail + `",
+					"phone":"` + privatePhone + `",
+					"status":"active"
+				}
+			}`))
+		case "/api/v1/soul/agents/" + agentID + "/registration":
+			_, _ = w.Write([]byte(`{
+				"version":"3",
+				"channels":{
+					"ens":{"name":"agent-raw.lessersoul.eth"},
+					"email":{"address":"` + privateEmail + `"},
+					"phone":{"number":"` + privatePhone + `"}
+				},
+				"contactPreferences":{"preferred":"` + privatePreference + `"},
+				"nested":{"emailAddress":"` + privateEmail + `","phoneNumber":"` + privatePhone + `"}
+			}`))
+		case "/api/v1/soul/agents/" + agentID + "/capabilities",
+			"/api/v1/soul/agents/" + agentID + "/boundaries",
+			"/api/v1/soul/agents/" + agentID + "/transparency":
+			_, _ = w.Write([]byte(`{}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":{"message":"not found"}}`))
+		}
+	}))
+	defer server.Close()
+
+	t.Setenv("LESSER_SOUL_API_BASE_URL", server.URL)
+	soulapi.ResetForTests()
+
+	app, err := mcpapp.New("test", "dev")
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+	env := testkit.New()
+	token := newTestToken(t, "test", "agent1", []string{"read"})
+	authHeader := "Bearer " + token
+
+	initResp := invokeJSON(t, env, app, map[string][]string{
+		"authorization": {authHeader},
+	}, &mcpruntime.Request{JSONRPC: "2.0", ID: 1, Method: "initialize"})
+	if initResp.Status != 200 {
+		t.Fatalf("initialize: status=%d body=%s", initResp.Status, string(initResp.Body))
+	}
+	sessionID := initResp.Headers["mcp-session-id"][0]
+
+	callParams, _ := json.Marshal(map[string]any{
+		"name": "soul_read",
+		"arguments": map[string]any{
+			"agentId":     agentID,
+			"include_raw": true,
+		},
+	})
+	resp := invokeJSON(t, env, app, map[string][]string{
+		"authorization":  {authHeader},
+		"mcp-session-id": {sessionID},
+	}, &mcpruntime.Request{JSONRPC: "2.0", ID: 2, Method: "tools/call", Params: callParams})
+	if resp.Status != 200 {
+		t.Fatalf("soul_read raw: status=%d body=%s", resp.Status, string(resp.Body))
+	}
+
+	var rpc mcpruntime.Response
+	if err := json.Unmarshal(resp.Body, &rpc); err != nil {
+		t.Fatalf("unmarshal soul_read raw response: %v", err)
+	}
+	if rpc.Error != nil {
+		t.Fatalf("soul_read raw rpc error: %+v", rpc.Error)
+	}
+	var toolOut mcpruntime.ToolResult
+	{
+		b, _ := json.Marshal(rpc.Result)
+		_ = json.Unmarshal(b, &toolOut)
+	}
+	data, _ := toolOut.StructuredContent["data"].(map[string]any)
+	souls, _ := data["souls"].([]any)
+	if len(souls) != 1 {
+		t.Fatalf("expected one soul, got %+v", data)
+	}
+	soul, _ := souls[0].(map[string]any)
+	channels, _ := soul["channels"].(map[string]any)
+	ens, _ := channels["ens"].(map[string]any)
+	if ens["name"] != "agent-raw.lessersoul.eth" {
+		t.Fatalf("normalized public ENS channel should remain available, got %+v", channels)
+	}
+	raw, _ := soul["_raw"].(map[string]any)
+	if raw == nil {
+		t.Fatalf("expected sanitized _raw payload")
+	}
+	rawJSON, _ := json.Marshal(raw)
+	for _, forbidden := range []string{privateEmail, privatePhone, privatePreference} {
+		if strings.Contains(string(rawJSON), forbidden) {
+			t.Fatalf("sanitized _raw leaked private reachability value %q: %s", forbidden, string(rawJSON))
+		}
+	}
+	registrationRaw, _ := raw["registration"].(map[string]any)
+	channelsRedaction, _ := registrationRaw["channels"].(map[string]any)
+	if channelsRedaction["redacted"] != true || channelsRedaction["reason"] != "private_reachability" {
+		t.Fatalf("expected raw registration channels redaction, got %+v", registrationRaw["channels"])
+	}
+	prefsRedaction, _ := registrationRaw["contactPreferences"].(map[string]any)
+	if prefsRedaction["redacted"] != true || prefsRedaction["reason"] != "private_reachability" {
+		t.Fatalf("expected raw registration preferences redaction, got %+v", registrationRaw["contactPreferences"])
+	}
+}
+
 func TestLBM1_SoulReadSelfModeVerifiesBoundCaller(t *testing.T) {
 	t.Setenv("MCP_SESSION_TABLE", "")
 	t.Setenv("JWT_SECRET", "test")

--- a/internal/mcpapp/social_tools_test.go
+++ b/internal/mcpapp/social_tools_test.go
@@ -764,6 +764,7 @@ func TestM5_NotificationsReadReturnsStructuredNotifications(t *testing.T) {
 func TestM5_NotificationsReadOmitsRawByDefaultAndExposesDiagnostics(t *testing.T) {
 	t.Setenv("MCP_SESSION_TABLE", "")
 	t.Setenv("JWT_SECRET", "test")
+	installSoulBindingLookup(t, "agent1", "0x1111111111111111111111111111111111111111111111111111111111111111")
 	auth.ResetForTests()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -884,6 +885,7 @@ func TestM5_NotificationsReadOmitsRawByDefaultAndExposesDiagnostics(t *testing.T
 func TestM5_NotificationsReadSupportsCommunicationInboundFilter(t *testing.T) {
 	t.Setenv("MCP_SESSION_TABLE", "")
 	t.Setenv("JWT_SECRET", "test")
+	installSoulBindingLookup(t, "agent1", "0x2222222222222222222222222222222222222222222222222222222222222222")
 	auth.ResetForTests()
 
 	var gotQueries []string
@@ -987,6 +989,121 @@ func TestM5_NotificationsReadSupportsCommunicationInboundFilter(t *testing.T) {
 	comm, _ := notification["communication"].(map[string]any)
 	if comm["messageId"] != "comm-delivery-email" || comm["channel"] != "email" {
 		t.Fatalf("expected compact communication summary, got %+v", comm)
+	}
+}
+
+func TestM2_DroneNotificationsReadBlocksCommunicationNotifications(t *testing.T) {
+	t.Setenv("MCP_SESSION_TABLE", "")
+	t.Setenv("JWT_SECRET", "test")
+	installMissingSoulBindingLookup(t)
+	auth.ResetForTests()
+
+	const privateSentinel = "private-drone-comm-sentinel@example.test"
+	var gotQueries []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/api/v1/notifications" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		gotQueries = append(gotQueries, r.URL.RawQuery)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[
+			{
+				"id":"n-mail",
+				"type":"communication:inbound",
+				"created_at":"2026-05-10T12:00:00Z",
+				"channel":"email",
+				"messageId":"comm-delivery-email",
+				"from":{"address":"` + privateSentinel + `"},
+				"subject":"Private",
+				"preview":"private preview"
+			},
+			{
+				"id":"n-mention",
+				"type":"mention",
+				"created_at":"2026-05-10T11:00:00Z",
+				"account":{"id":"acct-1","acct":"alice@example.com"},
+				"status":{"id":"post-1","content":"hello","visibility":"public"}
+			}
+		]`))
+	}))
+	defer server.Close()
+
+	t.Setenv("LESSER_API_BASE_URL", server.URL)
+	lesserapi.ResetForTests()
+
+	app, err := mcpapp.New("test", "dev")
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+
+	env := testkit.New()
+	token := newTestToken(t, "test", "agent1", []string{"read"})
+	authHeader := "Bearer " + token
+
+	initResp := invokeJSON(t, env, app, map[string][]string{"authorization": {authHeader}}, &mcpruntime.Request{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "initialize",
+	})
+	if initResp.Status != 200 {
+		t.Fatalf("initialize: status=%d body=%s", initResp.Status, string(initResp.Body))
+	}
+	sessionID := initResp.Headers["mcp-session-id"][0]
+
+	call := func(id int, args map[string]any) mcpruntime.ToolResult {
+		t.Helper()
+		callParams, _ := json.Marshal(map[string]any{"name": "notifications_read", "arguments": args})
+		resp := invokeJSON(t, env, app, map[string][]string{
+			"authorization":  {authHeader},
+			"mcp-session-id": {sessionID},
+		}, &mcpruntime.Request{JSONRPC: "2.0", ID: id, Method: "tools/call", Params: callParams})
+		if resp.Status != 200 {
+			t.Fatalf("notifications_read: status=%d body=%s", resp.Status, string(resp.Body))
+		}
+
+		var rpc mcpruntime.Response
+		if err := json.Unmarshal(resp.Body, &rpc); err != nil {
+			t.Fatalf("unmarshal notifications_read: %v", err)
+		}
+		if rpc.Error != nil {
+			t.Fatalf("notifications_read rpc error: %+v", rpc.Error)
+		}
+		var out mcpruntime.ToolResult
+		b, _ := json.Marshal(rpc.Result)
+		if err := json.Unmarshal(b, &out); err != nil {
+			t.Fatalf("unmarshal tool result: %v", err)
+		}
+		return out
+	}
+
+	blocked := call(2, map[string]any{"limit": 5, "types": []string{"communication:inbound"}})
+	if !blocked.IsError {
+		t.Fatalf("expected communication notification filter to be rejected for drone runtime")
+	}
+	errPayload, _ := blocked.StructuredContent["error"].(map[string]any)
+	if errPayload["code"] != "runtime_boundary" || errPayload["status"] != float64(403) {
+		t.Fatalf("unexpected runtime-boundary error: %+v", errPayload)
+	}
+	if len(gotQueries) != 0 {
+		t.Fatalf("explicit communication filter should be rejected before Lesser call, got queries %v", gotQueries)
+	}
+
+	filtered := call(3, map[string]any{"limit": 5, "include_raw": true})
+	if filtered.IsError {
+		t.Fatalf("unexpected tool error filtering untyped notifications: %+v", filtered.StructuredContent)
+	}
+	data, _ := filtered.StructuredContent["data"].(map[string]any)
+	notifications, _ := data["notifications"].([]any)
+	if len(notifications) != 1 {
+		t.Fatalf("expected only social notification for drone runtime, got %+v", data)
+	}
+	notification, _ := notifications[0].(map[string]any)
+	if notification["type"] != "mention" {
+		t.Fatalf("expected communication notification to be filtered, got %+v", notification)
+	}
+	b, _ := json.Marshal(filtered)
+	if strings.Contains(string(b), privateSentinel) || strings.Contains(string(b), "private preview") {
+		t.Fatalf("drone notification response leaked communication metadata: %s", string(b))
 	}
 }
 

--- a/internal/mcpserver/comm_tools.go
+++ b/internal/mcpserver/comm_tools.go
@@ -324,7 +324,7 @@ func soulReadDef() mcpruntime.ToolDef {
 				"mintConversationId":{"type":"string","maxLength":128,"description":"Opaque mint-conversation ID for an explicit single-conversation private self read. Requires include_private=[\"mintConversations\"]."},
 				"mintConversationLimit":{"type":"integer","minimum":1,"maximum":50,"description":"Maximum compact mint-conversation summaries for private self list reads. Defaults to 20 and does not affect public search match limit."},
 				"limit":{"type":"integer","minimum":1,"maximum":3,"description":"Maximum matches to compose when query resolves through search. Defaults to 1."},
-				"include_raw":{"type":"boolean","description":"Include raw public Host/Soul endpoint payloads under _raw for audit/debug use. Defaults to false."}
+				"include_raw":{"type":"boolean","description":"Include sanitized raw public Host/Soul endpoint payloads under _raw for audit/debug use. Private reachability fields are redacted. Defaults to false."}
 			}
 		}`),
 	}

--- a/internal/mcpserver/social_tools.go
+++ b/internal/mcpserver/social_tools.go
@@ -17,20 +17,22 @@ import (
 	"github.com/equaltoai/lesser-body/internal/auth"
 	"github.com/equaltoai/lesser-body/internal/lesserapi"
 	"github.com/equaltoai/lesser-body/internal/memory"
+	"github.com/equaltoai/lesser-body/internal/runtimepolicy"
 	"github.com/oklog/ulid/v2"
 	mcpruntime "github.com/theory-cloud/apptheory/runtime/mcp"
 )
 
 const (
-	notificationCursorMemoryPrefix  = "notification_cursor:"
-	notificationCursorMemoryTag     = "notification_cursor"
-	notificationReadDefaultLimit    = 30
-	notificationReadMaxLimit        = 80
-	notificationReadMaxTypes        = 8
-	notificationContentPreviewRunes = 500
-	notificationCommPreviewRunes    = 240
-	conversationReadDefaultLimit    = 20
-	conversationReadMaxLimit        = 80
+	notificationCursorMemoryPrefix   = "notification_cursor:"
+	notificationCursorMemoryTag      = "notification_cursor"
+	notificationCommunicationInbound = "communication:inbound"
+	notificationReadDefaultLimit     = 30
+	notificationReadMaxLimit         = 80
+	notificationReadMaxTypes         = 8
+	notificationContentPreviewRunes  = 500
+	notificationCommPreviewRunes     = 240
+	conversationReadDefaultLimit     = 20
+	conversationReadMaxLimit         = 80
 )
 
 var notificationCursorEventIDs = struct {
@@ -53,22 +55,22 @@ var notificationSupportedTypes = []string{
 	"update",
 	"admin.sign_up",
 	"admin.report",
-	"communication:inbound",
+	notificationCommunicationInbound,
 }
 
 var notificationUpstreamFilterTypes = map[string]struct{}{
-	"mention":               {},
-	"reply":                 {},
-	"favourite":             {},
-	"reblog":                {},
-	"follow":                {},
-	"follow_request":        {},
-	"poll":                  {},
-	"status":                {},
-	"update":                {},
-	"admin.sign_up":         {},
-	"admin.report":          {},
-	"communication:inbound": {},
+	"mention":                        {},
+	"reply":                          {},
+	"favourite":                      {},
+	"reblog":                         {},
+	"follow":                         {},
+	"follow_request":                 {},
+	"poll":                           {},
+	"status":                         {},
+	"update":                         {},
+	"admin.sign_up":                  {},
+	"admin.report":                   {},
+	notificationCommunicationInbound: {},
 }
 
 func registerSocialTools(r *mcpruntime.ToolRegistry) error {
@@ -425,6 +427,14 @@ func handleNotificationsRead(ctx context.Context, args json.RawMessage) (*mcprun
 	if err != nil {
 		return nil, err
 	}
+	if !runtimeAllowsCommunicationNotifications(ctx) && notificationTypesIncludeCommunication(requestedTypes) {
+		return toolErrorResult("runtime_boundary", "communication notification types are unavailable to this runtime profile", 403, map[string]any{
+			"surface":               "notifications_read.types",
+			"type":                  notificationCommunicationInbound,
+			"profile":               runtimeProfileName(ctx),
+			"communicationsEnabled": false,
+		})
+	}
 	limit := boundedNotificationReadLimit(in.Limit)
 	explicitSince := in.Since != nil
 	requestedSince := trimDeref(in.Since)
@@ -453,6 +463,9 @@ func handleNotificationsRead(ctx context.Context, args json.RawMessage) (*mcprun
 	}
 
 	normalizeStartedAt := time.Now()
+	if !runtimeAllowsCommunicationNotifications(ctx) {
+		list = filterRawCommunicationNotifications(list)
+	}
 	notifications := socialNotificationsFromAPI(list, in.IncludeRaw)
 	if hasTemporalSince {
 		notifications = filterSocialNotificationsAfter(notifications, sinceTime)
@@ -1029,6 +1042,66 @@ func allowedNotificationType(typ string) bool {
 func upstreamNotificationType(typ string) bool {
 	_, ok := notificationUpstreamFilterTypes[strings.TrimSpace(typ)]
 	return ok
+}
+
+func notificationTypesIncludeCommunication(types []string) bool {
+	for _, typ := range types {
+		if isCommunicationNotificationType(typ) {
+			return true
+		}
+	}
+	return false
+}
+
+func isCommunicationNotificationType(typ string) bool {
+	typ = strings.ToLower(strings.TrimSpace(typ))
+	return typ == notificationCommunicationInbound || strings.HasPrefix(typ, "communication:")
+}
+
+func runtimeAllowsCommunicationNotifications(ctx context.Context) bool {
+	resolved, ok := runtimepolicy.FromContext(ctx)
+	if !ok {
+		return false
+	}
+	return resolved.CommunicationsEnabled
+}
+
+func runtimeProfileName(ctx context.Context) string {
+	resolved, ok := runtimepolicy.FromContext(ctx)
+	if !ok || strings.TrimSpace(string(resolved.Profile)) == "" {
+		return "unknown"
+	}
+	return string(resolved.Profile)
+}
+
+func filterRawCommunicationNotifications(items []any) []any {
+	if len(items) == 0 {
+		return items
+	}
+
+	filtered := make([]any, 0, len(items))
+	for _, item := range items {
+		raw, ok := item.(map[string]any)
+		if !ok || raw == nil {
+			filtered = append(filtered, item)
+			continue
+		}
+		if isRawCommunicationNotification(raw) {
+			continue
+		}
+		filtered = append(filtered, item)
+	}
+	return filtered
+}
+
+func isRawCommunicationNotification(raw map[string]any) bool {
+	if raw == nil {
+		return false
+	}
+	if isCommunicationNotificationType(normalizeSocialNotificationType(raw)) {
+		return true
+	}
+	return notificationChannel(raw) != ""
 }
 
 func supportedNotificationTypesText() string {

--- a/internal/mcpserver/soul_read_tools.go
+++ b/internal/mcpserver/soul_read_tools.go
@@ -393,11 +393,11 @@ func soulReadPayload(ctx context.Context, client *soulapi.Client, agentID string
 	}
 	if includeRaw {
 		payload["_raw"] = map[string]any{
-			"identity":     agentRaw,
-			"registration": registrationRaw,
-			"capabilities": capabilitiesRaw,
-			"boundaries":   boundariesRaw,
-			"transparency": transparencyRaw,
+			"identity":     sanitizeSoulReadRawPayload(agentRaw),
+			"registration": sanitizeSoulReadRawPayload(registrationRaw),
+			"capabilities": sanitizeSoulReadRawPayload(capabilitiesRaw),
+			"boundaries":   sanitizeSoulReadRawPayload(boundariesRaw),
+			"transparency": sanitizeSoulReadRawPayload(transparencyRaw),
 		}
 	}
 	if privateReq.IncludeMintConversations {
@@ -410,6 +410,54 @@ func soulReadPayload(ctx context.Context, client *soulapi.Client, agentID string
 		}
 	}
 	return payload, nil
+}
+
+func sanitizeSoulReadRawPayload(raw any) any {
+	switch typed := raw.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(typed))
+		for key, value := range typed {
+			if soulReadRawFieldIsPrivateReachability(key) {
+				out[key] = soulReadPrivateReachabilityRedaction(key)
+				continue
+			}
+			out[key] = sanitizeSoulReadRawPayload(value)
+		}
+		return out
+	case []any:
+		out := make([]any, 0, len(typed))
+		for _, item := range typed {
+			out = append(out, sanitizeSoulReadRawPayload(item))
+		}
+		return out
+	default:
+		return raw
+	}
+}
+
+func soulReadRawFieldIsPrivateReachability(key string) bool {
+	key = strings.ToLower(strings.TrimSpace(key))
+	key = strings.NewReplacer("_", "", "-", "").Replace(key)
+	switch {
+	case key == "channels":
+		return true
+	case strings.Contains(key, "contactpreference"):
+		return true
+	case strings.Contains(key, "email"):
+		return true
+	case strings.Contains(key, "phone"):
+		return true
+	default:
+		return false
+	}
+}
+
+func soulReadPrivateReachabilityRedaction(key string) map[string]any {
+	return map[string]any{
+		"redacted": true,
+		"reason":   "private_reachability",
+		"field":    strings.TrimSpace(key),
+	}
 }
 
 func soulReadPrivateMintConversations(ctx context.Context, privateReq soulReadPrivateRequest) (map[string]any, error) {


### PR DESCRIPTION
## Milestone
Security Remediation M2 — Private content and public discovery

Fixes #197.

## Classification
security / scope-profile / MCP-contract semantic tightening / tool-surface hardening / lesser-integration consumer filtering

## Surfaces affected
- `notifications_read` runtime-profile handling for communication-shaped notifications
- `soul_read include_raw` raw audit payload sanitization
- MCP/security docs for the tightened private-read boundary

## Specialist walks referenced
- Tool surface: existing read tools stay registered with existing scopes/profiles; behavior tightens mixed read surfaces so drone callers cannot receive communication metadata through `notifications_read`, and `soul_read` raw output remains public-safe.
- MCP contract: semantic refinement only; no tool added/removed and no request/response envelope change. Clients relying on drone access to communication notification rows now receive a runtime-boundary tool error or filtered untyped results.
- Lesser integration: no Lesser API shape change, no new endpoint, no SSM/JWT/DynamoDB impact. Body filters/sanitizes responses from existing Lesser/Soul endpoints.
- Host delegation: no delivery-path change and no `LESSER_HOST_INSTANCE_KEY` handling change.

## Consumer impact
- Souled actors retain `notifications_read({ types: ["communication:inbound"] })` support.
- Drone actors keep social `notifications_read`, but explicit communication filters fail closed and untyped reads omit communication-shaped rows.
- `soul_read(include_raw=true)` still returns `_raw`, but private reachability fields are redacted.

## Tasks
- [x] `body.csv:1` — prevent drone runtime from reading inbound communication notifications through `notifications_read`.
- [x] `body.csv:3` — prevent `soul_read include_raw` from exposing private reachability/channel fields.
- [x] Add regression coverage for both security boundaries.
- [x] Update MCP/security docs for the tightened semantics.

## Validation
- `go test ./internal/mcpapp ./internal/mcpserver`
- `go test ./...`
- `go vet ./...`
- `git ls-files '*.go' | xargs gofmt -l` (empty)
- `git diff --check`
- `scripts/build.sh`

## Stage rollout plan (handoff to deploy-body)
- [ ] Merged to main through PR/review
- [ ] Deployed to lab / dev
- [ ] Lab soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
None required for this patch: body preserves existing Lesser/Soul endpoint shapes and only tightens Body-side filtering/sanitization.
