### PR TITLE
fix(identity): fail closed on sender field provenance

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -303,7 +303,7 @@ Scope key:
 | `identity_whoami` | Read | Return the current soul agent identity, channels, and contact preferences. |
 | `soul_read` | Read | Read a public soul identity bundle and, with explicit self-scope opt-in, bounded private mint-conversation data through Lesser. |
 | `identity_lookup` | Read | Resolve a public soul identity by full agent ID, ENS name, a current-instance local ID such as `medic`, an explicit remote ActivityPub handle such as `@steward@remote.example`, or a canonical actor URL such as `https://remote.example/users/steward`; returns public identity summary only. |
-| `identity_verify` | Read | Verify that a recent communication matches a resolved soul identity using public ENS resolution plus authoritative message provenance. Private email/phone reachability verification fails closed until lesser-host exposes a body-facing resolver. |
+| `identity_verify` | Read | Verify that a recent communication matches a resolved soul identity using public ENS resolution plus authoritative message provenance. Private email/phone verification fails closed unless Host supplies authoritative sender-identifier provenance. |
 
 Notes:
 
@@ -432,12 +432,15 @@ Notes:
   - remote ActivityPub handles in `@user@domain` form
   - canonical remote actor URLs in `https://domain/users/user` form
 - Managed email and phone reverse lookup are private reachability surfaces in lesser-host. Until lesser-host exposes a
-  body-facing, instance-authenticated resolver, `identity_lookup` and `identity_verify` fail closed for private
-  email/phone identifiers with `private_reachability_unavailable` instead of probing those routes anonymously.
+  body-facing, instance-authenticated resolver, `identity_lookup` and identifier-scoped `identity_verify` fail closed
+  for private email/phone identifiers with `private_reachability_unavailable` instead of probing those routes
+  anonymously.
 - `identity_verify(..., messageId=<host messageRef>)` uses lesser-host mailbox metadata as the canonical provenance
   source for `comm-delivery-*` message refs. ENS verification resolves ENS publicly and compares the resolved agent ID
-  to `message.from.soulAgentId`; email/phone message-scoped verification requires both a sender address/number match
-  and authoritative `message.from.soulAgentId`. Sender display/address fields alone are not trusted.
+  to `message.from.soulAgentId`. Email/phone message-scoped verification does **not** trust `from.address` or
+  `from.number` as proof that the requested identifier belongs to `from.soulAgentId`; it returns `verified:false` with
+  `reason:"sender_identifier_not_authoritatively_bound"` unless Host supplies explicit authoritative sender-identifier
+  binding provenance. Sender display/address fields alone are never trusted for a positive verification.
 - `identity_lookup` intentionally returns only public identity summary fields (`agentId`, `domain`, `localId`,
   `status`). It does not expose arbitrary agents' private `channels` or `contactPreferences`; use
   `identity_whoami` or `agent://channels` only for the authenticated agent's own channel data.

--- a/internal/mcpapp/identity_surfaces_test.go
+++ b/internal/mcpapp/identity_surfaces_test.go
@@ -711,11 +711,11 @@ func TestLBM1_IdentityToolsAndChannelResources(t *testing.T) {
 	{
 		emailResolveQueries = nil
 		data := callIdentityVerify(60, "email", "agent-alice@lessersoul.ai", "comm-delivery-email")
-		if data["verified"] != true {
-			t.Fatalf("expected host email message verification to succeed, got %+v", data)
+		if data["verified"] != false || data["reason"] != "sender_identifier_not_authoritatively_bound" {
+			t.Fatalf("expected host email message verification to fail closed without authoritative identifier binding, got %+v", data)
 		}
-		if data["matchedBy"] != "message.from.email+sender.soulAgentId" {
-			t.Fatalf("expected email sender provenance match, got %+v", data)
+		if data["identityResolved"] != false {
+			t.Fatalf("email message-scoped verify must not treat sender agent provenance as identifier resolution, got %+v", data)
 		}
 		message, _ := data["message"].(map[string]any)
 		if message["source"] != "lesser-host-mailbox" || message["messageRef"] != "comm-delivery-email" {
@@ -726,8 +726,8 @@ func TestLBM1_IdentityToolsAndChannelResources(t *testing.T) {
 		}
 
 		data = callIdentityVerify(61, "phone", "+1 (555) 0142", "comm-delivery-phone")
-		if data["verified"] != true || data["matchedBy"] != "message.from.phone+sender.soulAgentId" {
-			t.Fatalf("expected host phone message verification to succeed, got %+v", data)
+		if data["verified"] != false || data["reason"] != "sender_identifier_not_authoritatively_bound" {
+			t.Fatalf("expected host phone message verification to fail closed without authoritative identifier binding, got %+v", data)
 		}
 
 		data = callIdentityVerify(62, "ens", "agent-alice.lessersoul.eth", "comm-delivery-ens")

--- a/internal/mcpserver/comm_tools.go
+++ b/internal/mcpserver/comm_tools.go
@@ -355,7 +355,7 @@ func identityLookupDef() mcpruntime.ToolDef {
 func identityVerifyDef() mcpruntime.ToolDef {
 	return mcpruntime.ToolDef{
 		Name:        "identity_verify",
-		Description: "Verify that a communication came from a specific soul identity. ENS verification uses public resolution plus authoritative message provenance; private email/phone verification fails closed until lesser-host exposes a body-facing resolver.",
+		Description: "Verify that a communication came from a specific soul identity. ENS verification uses public resolution plus authoritative message provenance; private email/phone verification fails closed unless Host supplies authoritative sender-identifier provenance.",
 		InputSchema: json.RawMessage(`{
 			"type":"object",
 			"properties":{

--- a/internal/mcpserver/identity_verify_tools.go
+++ b/internal/mcpserver/identity_verify_tools.go
@@ -118,16 +118,13 @@ func handleMessageScopedIdentityVerify(ctx context.Context, client *soulapi.Clie
 			result["reason"] = "message_lacks_authoritative_sender_provenance"
 			return toolJSONResult(result, nil)
 		}
+		result["agent"] = map[string]any{"agentId": agentID}
 		if !senderIdentifierMatches(channel, identifier, from) {
-			result["reason"] = "sender_does_not_match_resolved_identity"
-			result["agent"] = map[string]any{"agentId": agentID}
-			result["identityResolved"] = true
+			result["reason"] = "sender_does_not_match_requested_identifier"
 			return toolJSONResult(result, nil)
 		}
-		result["verified"] = true
-		result["identityResolved"] = true
-		result["agent"] = map[string]any{"agentId": agentID}
-		result["matchedBy"] = "message.from." + channel + "+sender.soulAgentId"
+		result["reason"] = "sender_identifier_not_authoritatively_bound"
+		result["provenanceRequired"] = "host_authoritative_sender_identifier_binding"
 		return toolJSONResult(result, nil)
 	}
 


### PR DESCRIPTION
## Milestone
Security Remediation M4 — Comms ingress and billing

Fixes #198.

## Classification
security / host-delegation contract / MCP-contract semantic tightening / identity tool hardening

## Surfaces affected
- `identity_verify` message-scoped email/phone verification
- MCP docs for Host mailbox provenance semantics

## Specialist walks referenced
- Tool surface: existing `identity_verify` read tool remains registered with the same scope/profile; behavior tightens positive verification conditions.
- MCP contract: semantic refinement only; no schema/envelope change. Clients that expected email/phone positive verification from sender address/number plus `soulAgentId` now receive `verified:false` until authoritative sender-identifier provenance is available.
- Lesser integration: no Lesser endpoint or JWT/SSM/DynamoDB impact.
- Host delegation: preserves Host canonical mailbox lookup for `comm-delivery-*` refs, but does not treat spoofable sender address/number fields as private identifier binding proof.

## Consumer impact
- ENS message-scoped verification continues to resolve ENS publicly and compare to `message.from.soulAgentId`.
- Email/phone message-scoped verification remains safe: Host mailbox messages are summarized, but positive verification fails closed without authoritative sender-identifier binding provenance.

## Tasks
- [x] `body.csv:5` — stop trusting sender address/number fields as proof of email/phone identity binding.
- [x] Preserve Host mailbox message lookup and explicit negative reasons.
- [x] Add/update regression coverage for email/phone fail-closed behavior.
- [x] Update MCP docs for the tightened provenance semantics.

## Validation
- `go test ./internal/mcpapp ./internal/mcpserver`
- `go test ./...`
- `go vet ./...`
- `git ls-files '*.go' | xargs gofmt -l` (empty)
- `git diff --check`
- `scripts/build.sh`

## Stage rollout plan (handoff to deploy-body)
- [ ] Merged to main through PR/review
- [ ] Deployed to lab / dev
- [ ] Lab soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
No body-side dependency on a new Host field in this patch. Affirmative email/phone message-scoped verification will need a future lesser-host provenance contract if Host exposes explicit sender-identifier binding authority.
