### PR TITLE
fix(mcp): bound read tools and sanitize probes

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -85,4 +85,5 @@ scripts/canary_host_mailbox_mcp.py
 
 The canary checks `tools/list`, `email_read`, `email_get`, `email_get_content`, `email_search`,
 `email_mark_read`, `email_mark_unread`, `sms_read`, `voicemail_read`, and a not-found error path. It never prints
-full message bodies, full recipient addresses, or bearer tokens.
+full message bodies, full recipient addresses, bearer tokens, or raw upstream error payloads; error logs keep only
+stable codes/status plus hashed payload summaries where details are needed.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -321,7 +321,9 @@ Notes:
 - `notifications_read.types` accepts normalized notification type strings emitted in `notifications_read` output:
   `mention`, `reply`, `favourite` (`favorite` alias), `reblog`, `follow`, `follow_request`, `poll`, `status`,
   `update`, `admin.sign_up`, `admin.report`, and `communication:inbound`. Body forwards supported type filters to
-  Lesser and defensively filters normalized output so returned rows match the requested normalized type set.
+  Lesser and defensively filters normalized output so returned rows match the requested normalized type set. The request
+  is capped at 8 supplied type entries and `limit` is capped at 80 before any Lesser fanout so duplicate or oversized
+  read requests cannot amplify one MCP call into an unbounded backend query set.
 - `notifications_read` omits full upstream `raw` notification objects by default and accepts optional
   `include_raw=true`, which returns `_raw` on each notification for expensive audit/debug use. Default notifications
   contain compact `actor`, bounded `targetPost`, optional bounded `communication` summaries, normalized read state
@@ -338,8 +340,9 @@ Notes:
   `digests` (`bundle_digest`, `publication_digest`, `manifest_digest`, `content_digest`, `approval_digest`),
   `files[].path`, `files[].digest`, `files[].install_path`, `files[].content` / `encoding` / `content_included`,
   `install_hints`, `provenance`, approval fields, principal fields, and exposure context. lesser-body is not a
-  catalog authority and does not mutate the client's workspace. See `docs/skills-mcp.md` for the client install flow,
-  trust model, and Codex/generic runtime examples.
+  catalog authority and does not mutate the client's workspace. `skills_catalog.limit` is enforced server-side and
+  capped at 100 before delegation to Lesser; clients must not treat the discovery schema maximum as the only boundary.
+  See `docs/skills-mcp.md` for the client install flow, trust model, and Codex/generic runtime examples.
 - `skill_bundle_get.content.mode` is one of `inline`, `metadata_only`, `mixed`, or `no_files`, depending on whether
   Lesser returned inline bytes for all, none, some, or zero bundle files. `include_content=true` asks Lesser for inline
   bytes when available; it does not guarantee that every file is installable from the MCP response.

--- a/docs/security.md
+++ b/docs/security.md
@@ -115,3 +115,6 @@ At a minimum, the MCP Lambda needs:
 - Treat hardcoded bearer tokens and runtime credentials as temporary migration aids, not the canonical integration path.
 - Treat operator automation as a separate OAuth client design problem; the replacement direction is documented in
   `docs/operator-auth-replacement.md`.
+- Operator probes and canaries must not follow authenticated HTTP redirects. Redirects are treated as failures so bearer
+  tokens are never replayed to a different endpoint. Diagnostic output must redact bearer tokens and summarize upstream
+  mailbox/RPC error payloads without logging raw message bodies, addresses, phone numbers, or provider details.

--- a/docs/skills-mcp.md
+++ b/docs/skills-mcp.md
@@ -66,7 +66,8 @@ Arguments:
 ```
 
 - `exposure` is an optional Lesser exposure filter.
-- `limit` asks Lesser for a bounded page, up to the tool schema maximum of `100`.
+- `limit` asks Lesser for a bounded page. Body enforces the maximum server-side and caps oversized values to `100`
+  before calling Lesser.
 - `cursor` is the opaque `next_cursor` from a previous Lesser catalog response.
 
 Body preserves Lesser's catalog response shape and adds:

--- a/internal/mcpapp/skills_tools_test.go
+++ b/internal/mcpapp/skills_tools_test.go
@@ -121,7 +121,12 @@ func TestProject21M4SkillsCatalogAndBundleTools(t *testing.T) {
 		t.Fatalf("catalog did not preserve trust metadata: %+v", bundle)
 	}
 
-	bundleResult := callTool(3, "skill_bundle_get", map[string]any{
+	_ = callTool(3, "skills_catalog", map[string]any{"limit": 1000})
+	if got[1].Path != "/api/v1/skills/catalog" || got[1].Query != "limit=100" || got[1].Auth != authHeader {
+		t.Fatalf("skills_catalog should cap oversized limits before Lesser, got %+v", got[1])
+	}
+
+	bundleResult := callTool(4, "skill_bundle_get", map[string]any{
 		"skill_id":        "skill-a",
 		"revision_number": 1,
 		"include_content": true,
@@ -135,8 +140,8 @@ func TestProject21M4SkillsCatalogAndBundleTools(t *testing.T) {
 	if bundleData == nil {
 		t.Fatalf("expected bundle structured data, got %+v", bundleResult.StructuredContent)
 	}
-	if got[1].Path != "/api/v1/skills/skill-a/revisions/1/bundle" || got[1].Query != "include_content=true" || got[1].Auth != authHeader {
-		t.Fatalf("unexpected bundle request: %+v", got[1])
+	if got[2].Path != "/api/v1/skills/skill-a/revisions/1/bundle" || got[2].Query != "include_content=true" || got[2].Auth != authHeader {
+		t.Fatalf("unexpected bundle request: %+v", got[2])
 	}
 	content, _ := bundleData["content"].(map[string]any)
 	if content["mode"] != "inline" {
@@ -155,7 +160,7 @@ func TestProject21M4SkillsCatalogAndBundleTools(t *testing.T) {
 		t.Fatalf("bundle did not preserve approval/principal metadata: %+v", bundleObj)
 	}
 
-	metadataOnly := callTool(4, "skill_bundle_get", map[string]any{"bundle_id": "skill:skill-a:revision:00000001"})
+	metadataOnly := callTool(5, "skill_bundle_get", map[string]any{"bundle_id": "skill:skill-a:revision:00000001"})
 	metadataData, _ := metadataOnly.StructuredContent["data"].(map[string]any)
 	metadataContent, _ := metadataData["content"].(map[string]any)
 	metadataVerification, _ := metadataData["verification"].(map[string]any)

--- a/internal/mcpapp/social_tools_test.go
+++ b/internal/mcpapp/social_tools_test.go
@@ -119,6 +119,9 @@ func TestM5_ToolsListContainsCoreTools(t *testing.T) {
 	if !hasCommunicationInbound {
 		t.Fatalf("notifications_read types enum should include communication:inbound, got %+v", typesProp)
 	}
+	if maxItems, _ := typesProp["maxItems"].(float64); maxItems != 8 {
+		t.Fatalf("notifications_read types should advertise maxItems=8, got %+v", typesProp)
+	}
 	var conversationSchema struct {
 		Properties map[string]map[string]any `json:"properties"`
 	}
@@ -1356,6 +1359,18 @@ func TestM5_NotificationsReadBoundsLimitAndRejectsUnknownTypes(t *testing.T) {
 	}
 	if len(gotQueries) != 1 {
 		t.Fatalf("invalid type should not fan out upstream, got %v", gotQueries)
+	}
+
+	tooManyTypes := []string{"mention", "mention", "mention", "mention", "mention", "mention", "mention", "mention", "mention"}
+	rpc = call(4, map[string]any{"limit": 5, "types": tooManyTypes})
+	if rpc.Error == nil {
+		t.Fatalf("expected excess notification type entries to fail before upstream fanout")
+	}
+	if !strings.Contains(rpc.Error.Message, "maximum 8") {
+		t.Fatalf("excess type error should include maximum budget, got %+v", rpc.Error)
+	}
+	if len(gotQueries) != 1 {
+		t.Fatalf("excess type entries should not fan out upstream, got %v", gotQueries)
 	}
 }
 

--- a/internal/mcpserver/skills_tools.go
+++ b/internal/mcpserver/skills_tools.go
@@ -19,6 +19,7 @@ import (
 )
 
 const (
+	skillCatalogMaxLimit          = 100
 	skillLocalFileMaxDecodedBytes = 1 << 20
 	skillLocalFilesMaxCount       = 200
 
@@ -162,8 +163,8 @@ func handleSkillsCatalog(ctx context.Context, args json.RawMessage) (*mcpruntime
 	if exposure := strings.TrimSpace(in.Exposure); exposure != "" {
 		query.Set("exposure", exposure)
 	}
-	if in.Limit > 0 {
-		query.Set("limit", fmt.Sprintf("%d", in.Limit))
+	if limit := boundedSkillCatalogLimit(in.Limit); limit > 0 {
+		query.Set("limit", fmt.Sprintf("%d", limit))
 	}
 	if cursor := strings.TrimSpace(in.Cursor); cursor != "" {
 		query.Set("cursor", cursor)
@@ -183,6 +184,17 @@ func handleSkillsCatalog(ctx context.Context, args json.RawMessage) (*mcpruntime
 	}
 
 	return toolJSONResult(payload, nil)
+}
+
+func boundedSkillCatalogLimit(limit int) int {
+	switch {
+	case limit <= 0:
+		return 0
+	case limit > skillCatalogMaxLimit:
+		return skillCatalogMaxLimit
+	default:
+		return limit
+	}
 }
 
 func handleSkillBundleGet(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {

--- a/internal/mcpserver/social_tools.go
+++ b/internal/mcpserver/social_tools.go
@@ -822,7 +822,7 @@ func notificationsReadDef() mcpruntime.ToolDef {
 		InputSchema: json.RawMessage(`{
 			"type":"object",
 			"properties":{
-				"types":{"type":"array","description":"Optional normalized notification types to return. Supported values include communication:inbound for host-backed inbound email/SMS/voice notifications; favorite is accepted as an alias for favourite.","items":{"type":"string","enum":["mention","reply","favourite","favorite","reblog","follow","follow_request","poll","status","update","admin.sign_up","admin.report","communication:inbound"]}},
+				"types":{"type":"array","maxItems":8,"description":"Optional normalized notification types to return. Supported values include communication:inbound for host-backed inbound email/SMS/voice notifications; favorite is accepted as an alias for favourite. At most 8 values may be supplied; duplicates still count against the request budget.","items":{"type":"string","enum":["mention","reply","favourite","favorite","reblog","follow","follow_request","poll","status","update","admin.sign_up","admin.report","communication:inbound"]}},
 				"since":{"type":"string"},
 				"cursor":{"type":"string"},
 				"limit":{"type":"integer","minimum":1,"maximum":80},
@@ -971,6 +971,9 @@ func ternaryString(cond bool, yes string, no string) string {
 func normalizeRequestedNotificationTypes(in []string) ([]string, []string, error) {
 	if len(in) == 0 {
 		return nil, nil, nil
+	}
+	if len(in) > notificationReadMaxTypes {
+		return nil, nil, invalidParams(fmt.Sprintf("too many notification types requested; maximum %d", notificationReadMaxTypes))
 	}
 
 	requested := make([]string, 0, len(in))

--- a/scripts/canary_host_mailbox_mcp.py
+++ b/scripts/canary_host_mailbox_mcp.py
@@ -64,14 +64,20 @@ def sanitized_error_payload(value: Any) -> dict[str, Any]:
         return {"payload": redacted_payload_summary(value)}
 
     safe: dict[str, Any] = {}
-    for key in ("code", "status", "message"):
+    for key in ("code", "status"):
         if key not in value:
             continue
         item = value.get(key)
-        if isinstance(item, str):
+        if isinstance(item, str) and key == "code" and len(item) <= 80 and all(ch.isalnum() or ch in "._:-" for ch in item):
             safe[key] = item[:160]
         elif isinstance(item, (int, float, bool)) or item is None:
             safe[key] = item
+        else:
+            safe[key] = "<redacted>"
+            safe[f"{key}_summary"] = redacted_payload_summary(item)
+    if isinstance(value.get("message"), str):
+        safe["message"] = "<redacted>"
+        safe["message_summary"] = redacted_payload_summary(value["message"])
     if not safe:
         safe["payload"] = redacted_payload_summary(value)
     return safe
@@ -128,7 +134,8 @@ def tool_call(name: str, arguments: dict[str, Any], *, expect_error: bool = Fals
         if not is_error:
             raise CanaryError(f"{name} expected tool error, got success")
         error_payload = structured.get("error") or {}
-        log(f"ok {name} error_path code={error_payload.get('code', 'unknown')} status={error_payload.get('status', 'n/a')}")
+        safe_error = sanitized_error_payload(error_payload)
+        log(f"ok {name} error_path code={safe_error.get('code', 'unknown')} status={safe_error.get('status', 'n/a')}")
         return error_payload
     if is_error:
         error_payload = structured.get("error") or result

--- a/scripts/canary_host_mailbox_mcp.py
+++ b/scripts/canary_host_mailbox_mcp.py
@@ -29,6 +29,16 @@ class CanaryError(RuntimeError):
     pass
 
 
+class NoAuthenticatedRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Refuse redirects so Authorization never leaves the configured endpoint."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # type: ignore[no-untyped-def]
+        return None
+
+
+NO_REDIRECT_OPENER = urllib.request.build_opener(NoAuthenticatedRedirectHandler)
+
+
 def env_required(name: str) -> str:
     value = os.environ.get(name, "").strip()
     if not value:
@@ -83,6 +93,14 @@ def sanitized_error_payload(value: Any) -> dict[str, Any]:
     return safe
 
 
+def authenticated_open(req: urllib.request.Request, *, timeout: int):  # type: ignore[no-untyped-def]
+    return NO_REDIRECT_OPENER.open(req, timeout=timeout)
+
+
+def is_redirect_status(status: int) -> bool:
+    return 300 <= int(status) <= 399
+
+
 def post_rpc(method: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
     global next_id, session_id
     payload: dict[str, Any] = {"jsonrpc": "2.0", "id": next_id, "method": method}
@@ -105,11 +123,13 @@ def post_rpc(method: str, params: dict[str, Any] | None = None) -> dict[str, Any
         method="POST",
     )
     try:
-        with urllib.request.urlopen(req, timeout=30) as resp:
+        with authenticated_open(req, timeout=30) as resp:
             body = resp.read().decode("utf-8")
             if not session_id:
                 session_id = resp.headers.get("mcp-session-id", "").strip()
     except urllib.error.HTTPError as exc:
+        if is_redirect_status(exc.code):
+            raise CanaryError(f"{method} HTTP redirect {exc.code}: refusing to follow authenticated redirect") from exc
         body = exc.read()
         digest = hashlib.sha256(body).hexdigest()[:12]
         raise CanaryError(f"{method} HTTP {exc.code}: body_len={len(body)} body_sha256_12={digest}") from exc

--- a/scripts/m0_baseline_mcp_probe.py
+++ b/scripts/m0_baseline_mcp_probe.py
@@ -45,6 +45,16 @@ class ProbeError(RuntimeError):
     pass
 
 
+class NoAuthenticatedRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Refuse redirects so Authorization never leaves the configured endpoint."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # type: ignore[no-untyped-def]
+        return None
+
+
+NO_REDIRECT_OPENER = urllib.request.build_opener(NoAuthenticatedRedirectHandler)
+
+
 def env(name: str, default: str = "") -> str:
     return os.environ.get(name, default).strip()
 
@@ -96,6 +106,18 @@ def redact(value: str) -> str:
     return value
 
 
+def authenticated_open(req: urllib.request.Request, *, timeout: int):  # type: ignore[no-untyped-def]
+    return NO_REDIRECT_OPENER.open(req, timeout=timeout)
+
+
+def is_redirect_status(status: int) -> bool:
+    return 300 <= int(status) <= 399
+
+
+def redirect_error(context: str, status: int) -> ProbeError:
+    return ProbeError(f"{context} returned HTTP redirect {status}; refusing to follow authenticated redirect")
+
+
 def rpc(method: str, params: dict[str, Any] | None = None) -> tuple[dict[str, Any], int, int]:
     global _next_id, _session_id
     request_id = _next_id
@@ -114,12 +136,14 @@ def rpc(method: str, params: dict[str, Any] | None = None) -> tuple[dict[str, An
     req = urllib.request.Request(ENDPOINT, data=body, headers=headers, method="POST")
     started = time.perf_counter()
     try:
-        with urllib.request.urlopen(req, timeout=130) as resp:
+        with authenticated_open(req, timeout=130) as resp:
             raw = resp.read()
             if resp.headers.get("Mcp-Session-Id"):
                 _session_id = resp.headers["Mcp-Session-Id"].strip()
             status = resp.status
     except urllib.error.HTTPError as exc:
+        if is_redirect_status(exc.code):
+            raise redirect_error(method, exc.code) from exc
         raw = exc.read()
         status = exc.code
     elapsed_ms = round((time.perf_counter() - started) * 1000)
@@ -155,10 +179,13 @@ def api_json(
     req = urllib.request.Request(base + path, data=body, headers=headers, method=method)
     started = time.perf_counter()
     try:
-        with urllib.request.urlopen(req, timeout=130) as resp:
+        with authenticated_open(req, timeout=130) as resp:
             raw = resp.read()
             status = resp.status
     except urllib.error.HTTPError as exc:
+        if is_redirect_status(exc.code):
+            elapsed_ms = round((time.perf_counter() - started) * 1000)
+            return {}, exc.code, elapsed_ms, 0
         raw = exc.read()
         status = exc.code
     elapsed_ms = round((time.perf_counter() - started) * 1000)


### PR DESCRIPTION
## Summary

Fixes #199.

This PR addresses the Project 28 M7.1 body findings without adding new tools, scopes, profiles, or deployment wiring:

- `body.csv:2` — enforces the documented `skills_catalog.limit` maximum server-side before delegating to Lesser.
- `body.csv:4` — makes the M0 operator probe refuse authenticated redirects so bearer tokens are not replayed away from the configured endpoint.
- `body.csv:6` — hardens `notifications_read.types` with an explicit `maxItems` schema and server-side raw-entry cap before any Lesser fanout; existing `limit` capping remains enforced.
- `body.csv:7` — sanitizes canary error logging so upstream mailbox/RPC details are summarized rather than printed raw.

Docs now call out the read-tool budgets and operator probe/canary hygiene requirements.

## Contract / security notes

- MCP impact is a semantic tightening: read-tool request budgets are now enforced in code as well as discovery metadata.
- No scope/profile loosening, no static registration changes, no OAuth/JWT/SSM/DynamoDB contract changes.
- Lesser integration remains through the existing REST endpoints; this only bounds delegated query parameters/fanout.
- Public PR text intentionally avoids raw scanner URLs or exploit details.

## Validation

- `go test ./internal/mcpapp ./internal/mcpserver`
- `go test ./...`
- `go vet ./...`
- `git ls-files '*.go' | xargs gofmt -l`
- `git diff --check`
- `python3 -m py_compile scripts/m0_baseline_mcp_probe.py scripts/canary_host_mailbox_mcp.py`
- M0 probe redirect dry run: redirecting test endpoint was not followed and fake token was not printed
- Canary sanitizer dry run: synthetic mailbox/RPC detail was redacted and summarized
- `scripts/build.sh`