### PR TITLE
fix(mcp): harden v1.6 capability and cancellation semantics

### DIFF
--- a/internal/mcpapp/cancellation_test.go
+++ b/internal/mcpapp/cancellation_test.go
@@ -1,0 +1,256 @@
+package mcpapp_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+	mcpruntime "github.com/theory-cloud/apptheory/runtime/mcp"
+	"github.com/theory-cloud/apptheory/testkit"
+
+	"github.com/equaltoai/lesser-body/internal/auth"
+	"github.com/equaltoai/lesser-body/internal/lesserapi"
+	"github.com/equaltoai/lesser-body/internal/mcpapp"
+	"github.com/equaltoai/lesser-body/internal/soulapi"
+)
+
+func TestCancellationNotificationCancelsLesserReadTool(t *testing.T) {
+	t.Setenv("MCP_SESSION_TABLE", "")
+	t.Setenv("JWT_SECRET", "test")
+	auth.ResetForTests()
+	lesserapi.ResetForTests()
+	soulapi.ResetForTests()
+
+	started := make(chan struct{})
+	canceled := make(chan struct{})
+	var closeStarted sync.Once
+	var closeCanceled sync.Once
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/timelines/home":
+			closeStarted.Do(func() { close(started) })
+			<-r.Context().Done()
+			closeCanceled.Do(func() { close(canceled) })
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":"not found"}`))
+		}
+	}))
+	defer server.Close()
+
+	t.Setenv("LESSER_API_BASE_URL", server.URL)
+	lesserapi.ResetForTests()
+
+	app, err := mcpapp.New("test", "dev")
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+	env := testkit.New()
+	authHeader := "Bearer " + newTestToken(t, "test", "agent1", []string{"read"})
+	sessionID := initializeCancellationSession(t, env, app, authHeader)
+
+	callParams, _ := json.Marshal(map[string]any{
+		"name": "timeline_read",
+		"arguments": map[string]any{
+			"timeline": "home",
+			"limit":    20,
+		},
+	})
+
+	resultCh := make(chan apptheory.Response, 1)
+	go func() {
+		resultCh <- env.Invoke(context.Background(), app, apptheory.Request{
+			Method: "POST",
+			Path:   "/mcp/agent1",
+			Headers: map[string][]string{
+				"authorization":  {authHeader},
+				"content-type":   {"application/json"},
+				"accept":         {"application/json, text/event-stream"},
+				"mcp-session-id": {sessionID},
+			},
+			Body: mustMarshalJSONForTest(t, &mcpruntime.Request{
+				JSONRPC: "2.0",
+				ID:      "read-cancel",
+				Method:  "tools/call",
+				Params:  callParams,
+			}),
+		})
+	}()
+
+	waitForSignal(t, started, "timeline_read upstream request to start")
+	sendCancellationNotification(t, env, app, authHeader, sessionID, "read-cancel")
+	waitForSignal(t, canceled, "timeline_read upstream request context to cancel")
+
+	select {
+	case resp := <-resultCh:
+		if resp.Status != http.StatusOK {
+			t.Fatalf("timeline_read response status=%d body=%s", resp.Status, string(resp.Body))
+		}
+		var rpc mcpruntime.Response
+		if err := json.Unmarshal(resp.Body, &rpc); err != nil {
+			t.Fatalf("unmarshal timeline_read response: %v body=%s", err, string(resp.Body))
+		}
+		if rpc.Error == nil {
+			t.Fatalf("expected canceled timeline_read to return JSON-RPC error, got %+v", rpc)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeline_read did not return promptly after cancellation")
+	}
+}
+
+func TestCancellationNotificationCancelsStreamingSmsSend(t *testing.T) {
+	t.Setenv("MCP_SESSION_TABLE", "")
+	t.Setenv("JWT_SECRET", "test")
+	t.Setenv("LESSER_HOST_INSTANCE_KEY", "instance-key-123")
+	installSoulBindingLookup(t, "agent1", "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")
+	auth.ResetForTests()
+	lesserapi.ResetForTests()
+	soulapi.ResetForTests()
+
+	const agentID = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+	started := make(chan struct{})
+	canceled := make(chan struct{})
+	release := make(chan struct{})
+	var closeStarted sync.Once
+	var closeCanceled sync.Once
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/souls/bound/me":
+			_, _ = w.Write([]byte(boundSelfResponse(agentID, "agent1", "test.example.com", "agent-eve")))
+		case "/api/v1/soul/agents/" + agentID:
+			_, _ = w.Write([]byte(`{"version":"1","agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-eve","status":"active"}}`))
+		case "/api/v1/soul/agents/" + agentID + "/registration":
+			_, _ = w.Write([]byte(`{"version":"3","channels":{"phone":{"number":"+15550142","capabilities":["sms-send"],"verified":true}},"contactPreferences":{}}`))
+		case "/api/v1/soul/comm/send":
+			_, _ = io.ReadAll(r.Body)
+			closeStarted.Do(func() { close(started) })
+			select {
+			case <-r.Context().Done():
+				closeCanceled.Do(func() { close(canceled) })
+			case <-release:
+			}
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":{"message":"not found"}}`))
+		}
+	}))
+	defer server.Close()
+	defer close(release)
+
+	t.Setenv("LESSER_API_BASE_URL", server.URL)
+	t.Setenv("LESSER_SOUL_API_BASE_URL", server.URL)
+	lesserapi.ResetForTests()
+	soulapi.ResetForTests()
+
+	app, err := mcpapp.New("test", "dev")
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+	env := testkit.New()
+	authHeader := "Bearer " + newTestToken(t, "test", "agent1", []string{"write"})
+	sessionID := initializeCancellationSession(t, env, app, authHeader)
+
+	callParams, _ := json.Marshal(map[string]any{
+		"name": "sms_send",
+		"arguments": map[string]any{
+			"to":        "+1 (555) 0143",
+			"body":      "Cancel this send.",
+			"messageId": "comm-msg-cancel",
+		},
+		"_meta": map[string]any{"progressToken": "pt-cancel"},
+	})
+
+	resp := env.Invoke(context.Background(), app, apptheory.Request{
+		Method: "POST",
+		Path:   "/mcp/agent1",
+		Headers: map[string][]string{
+			"authorization":  {authHeader},
+			"content-type":   {"application/json"},
+			"accept":         {"application/json, text/event-stream"},
+			"mcp-session-id": {sessionID},
+		},
+		Body: mustMarshalJSONForTest(t, &mcpruntime.Request{
+			JSONRPC: "2.0",
+			ID:      "sms-cancel",
+			Method:  "tools/call",
+			Params:  callParams,
+		}),
+	})
+	if resp.Status != http.StatusOK {
+		t.Fatalf("sms_send response status=%d body=%s", resp.Status, string(resp.Body))
+	}
+	if resp.BodyReader == nil {
+		t.Fatal("expected streaming response body")
+	}
+
+	streamDone := make(chan struct{})
+	go func() {
+		_, _ = io.ReadAll(resp.BodyReader)
+		close(streamDone)
+	}()
+
+	waitForSignal(t, started, "sms_send host request to start")
+	sendCancellationNotification(t, env, app, authHeader, sessionID, "sms-cancel")
+	waitForSignal(t, canceled, "sms_send host request context to cancel")
+	waitForSignal(t, streamDone, "sms_send stream to close after cancellation")
+}
+
+func initializeCancellationSession(t testing.TB, env *testkit.Env, app *apptheory.App, authHeader string) string {
+	t.Helper()
+	initResp := invokeJSONAtPath(t, env, app, "/mcp/agent1", map[string][]string{
+		"authorization": {authHeader},
+	}, &mcpruntime.Request{JSONRPC: "2.0", ID: 1, Method: "initialize"})
+	if initResp.Status != http.StatusOK {
+		t.Fatalf("initialize: status=%d body=%s", initResp.Status, string(initResp.Body))
+	}
+	ids := initResp.Headers["mcp-session-id"]
+	if len(ids) == 0 || ids[0] == "" {
+		t.Fatalf("initialize did not return mcp-session-id")
+	}
+	return ids[0]
+}
+
+func sendCancellationNotification(t testing.TB, env *testkit.Env, app *apptheory.App, authHeader string, sessionID string, requestID string) {
+	t.Helper()
+	params, _ := json.Marshal(map[string]any{
+		"requestId": requestID,
+		"reason":    "test cancellation",
+	})
+	resp := env.Invoke(context.Background(), app, apptheory.Request{
+		Method: "POST",
+		Path:   "/mcp/agent1",
+		Headers: map[string][]string{
+			"authorization":  {authHeader},
+			"content-type":   {"application/json"},
+			"accept":         {"application/json, text/event-stream"},
+			"mcp-session-id": {sessionID},
+		},
+		Body: mustMarshalJSONForTest(t, &mcpruntime.Request{
+			JSONRPC: "2.0",
+			Method:  "notifications/cancelled",
+			Params:  params,
+		}),
+	})
+	if resp.Status != http.StatusAccepted {
+		t.Fatalf("notifications/cancelled status=%d body=%s", resp.Status, string(resp.Body))
+	}
+}
+
+func waitForSignal(t testing.TB, ch <-chan struct{}, name string) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatalf("timed out waiting for %s", name)
+	}
+}

--- a/internal/mcpserver/cancellation_test.go
+++ b/internal/mcpserver/cancellation_test.go
@@ -1,0 +1,118 @@
+package mcpserver
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/equaltoai/lesser-body/internal/auth"
+	"github.com/equaltoai/lesser-body/internal/lesserapi"
+	"github.com/equaltoai/lesser-body/internal/soulapi"
+	mcpruntime "github.com/theory-cloud/apptheory/runtime/mcp"
+)
+
+func TestSmsSendStreamingHonorsCanceledContext(t *testing.T) {
+	t.Setenv("LESSER_HOST_INSTANCE_KEY", "instance-key-123")
+	t.Setenv("JWT_SECRET", "test")
+	auth.ResetForTests()
+	t.Cleanup(auth.ResetForTests)
+	lesserapi.ResetForTests()
+	t.Cleanup(lesserapi.ResetForTests)
+	soulapi.ResetForTests()
+	t.Cleanup(soulapi.ResetForTests)
+
+	const agentID = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+	installSoulBindingLookup(t, "agent1", agentID)
+
+	started := make(chan struct{})
+	canceled := make(chan struct{})
+	release := make(chan struct{})
+	var closeStarted sync.Once
+	var closeCanceled sync.Once
+	t.Cleanup(func() { close(release) })
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/souls/bound/me":
+			_, _ = w.Write([]byte(boundSelfResponse(agentID, "agent1", "test.example.com", "agent-eve")))
+		case "/api/v1/soul/agents/" + agentID:
+			_, _ = w.Write([]byte(`{"version":"1","agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-eve","status":"active"}}`))
+		case "/api/v1/soul/agents/" + agentID + "/registration":
+			_, _ = w.Write([]byte(`{"version":"3","channels":{"phone":{"number":"+15550142","capabilities":["sms-send"],"verified":true}},"contactPreferences":{}}`))
+		case "/api/v1/soul/comm/send":
+			_, _ = io.ReadAll(r.Body)
+			closeStarted.Do(func() { close(started) })
+			select {
+			case <-r.Context().Done():
+				closeCanceled.Do(func() { close(canceled) })
+			case <-release:
+			}
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":{"message":"not found"}}`))
+		}
+	}))
+	defer server.Close()
+
+	t.Setenv("LESSER_API_BASE_URL", server.URL)
+	t.Setenv("LESSER_SOUL_API_BASE_URL", server.URL)
+	lesserapi.ResetForTests()
+	soulapi.ResetForTests()
+
+	baseCtx := auth.InjectToolContext(context.Background(), &auth.Principal{
+		Type:     auth.PrincipalTypeOAuthToken,
+		Identity: "agent1",
+		Claims:   &auth.Claims{Username: "agent1", Scopes: []string{"write"}},
+	}, "test-token")
+	ctx, cancel := context.WithCancel(baseCtx)
+
+	args, err := json.Marshal(map[string]any{
+		"to":        "+1 (555) 0143",
+		"body":      "Cancel this send.",
+		"messageId": "comm-msg-cancel",
+	})
+	if err != nil {
+		t.Fatalf("marshal args: %v", err)
+	}
+
+	type callResult struct {
+		res *mcpruntime.ToolResult
+		err error
+	}
+	resultCh := make(chan callResult, 1)
+	go func() {
+		res, err := handleSmsSendStreaming(ctx, args, func(mcpruntime.SSEEvent) {})
+		resultCh <- callResult{res: res, err: err}
+	}()
+
+	waitForMCPServerCancelSignal(t, started, "sms_send host request to start")
+	cancel()
+	waitForMCPServerCancelSignal(t, canceled, "sms_send host request context to cancel")
+
+	select {
+	case result := <-resultCh:
+		if result.err != nil {
+			t.Fatalf("sms_send returned unexpected error: %v", result.err)
+		}
+		if result.res == nil || !result.res.IsError {
+			t.Fatalf("expected canceled sms_send to return tool error result, got %+v", result.res)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("sms_send did not return promptly after context cancellation")
+	}
+}
+
+func waitForMCPServerCancelSignal(t testing.TB, ch <-chan struct{}, name string) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatalf("timed out waiting for %s", name)
+	}
+}

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -51,6 +51,7 @@ func New(name, version string) (*Server, error) {
 
 func buildServerOptionsFromEnv() ([]ServerOption, error) {
 	opts := []ServerOption{
+		mcpruntime.WithCapabilityConfig(bodyCapabilityConfig()),
 		mcpruntime.WithInitialSessionListenerBudget(mcpruntime.InitialSessionListenerBudgetOptions{
 			SafetyBuffer: initialSessionListenerSafetyBuffer,
 			MaxDuration:  initialSessionListenerMaxDuration,
@@ -76,6 +77,16 @@ func buildServerOptionsFromEnv() ([]ServerOption, error) {
 	}
 
 	return opts, nil
+}
+
+func bodyCapabilityConfig() mcpruntime.CapabilityConfig {
+	return mcpruntime.CapabilityConfig{
+		Tools:       true,
+		Resources:   true,
+		Prompts:     true,
+		Completions: false,
+		Tasks:       false,
+	}
 }
 
 func originValidatorFromEnv() mcpruntime.OriginValidator {

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -147,3 +147,65 @@ func TestEchoTool(t *testing.T) {
 		t.Fatalf("unexpected tool result: %+v", toolResult)
 	}
 }
+
+func TestInitializeCapabilitiesArePinnedFailClosed(t *testing.T) {
+	t.Setenv("MCP_SESSION_TABLE", "")
+
+	srv, err := mcpserver.New("test-server", "dev")
+	if err != nil {
+		t.Fatalf("new server: %v", err)
+	}
+
+	env := testkit.New()
+	app := env.App()
+	app.Post("/mcp", srv.Handler())
+
+	params, _ := json.Marshal(map[string]any{"protocolVersion": "2025-11-25"})
+	initResp, _ := invokeRPC(t, env, app, "", &mcpruntime.Request{
+		JSONRPC: "2.0",
+		ID:      "init-capabilities",
+		Method:  "initialize",
+		Params:  params,
+	})
+	if initResp.Error != nil {
+		t.Fatalf("initialize error: %+v", initResp.Error)
+	}
+
+	b, err := json.Marshal(initResp.Result)
+	if err != nil {
+		t.Fatalf("marshal initialize result: %v", err)
+	}
+	var out struct {
+		Capabilities map[string]any `json:"capabilities"`
+	}
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal initialize result: %v", err)
+	}
+
+	for _, name := range []string{"tools", "resources", "prompts"} {
+		if _, ok := out.Capabilities[name]; !ok {
+			t.Fatalf("expected %q capability to remain advertised: %+v", name, out.Capabilities)
+		}
+	}
+	for _, name := range []string{"completions", "tasks", "logging"} {
+		if _, ok := out.Capabilities[name]; ok {
+			t.Fatalf("did not expect fail-closed %q capability to be advertised: %+v", name, out.Capabilities)
+		}
+	}
+	assertNoUnsupportedSubCapabilities(t, "tools", out.Capabilities["tools"])
+	assertNoUnsupportedSubCapabilities(t, "resources", out.Capabilities["resources"])
+	assertNoUnsupportedSubCapabilities(t, "prompts", out.Capabilities["prompts"])
+}
+
+func assertNoUnsupportedSubCapabilities(t testing.TB, name string, raw any) {
+	t.Helper()
+	capability, ok := raw.(map[string]any)
+	if !ok {
+		t.Fatalf("expected %s capability object, got %T", name, raw)
+	}
+	for _, sub := range []string{"listChanged", "subscribe"} {
+		if _, ok := capability[sub]; ok {
+			t.Fatalf("did not expect %s.%s overclaim: %+v", name, sub, capability)
+		}
+	}
+}


### PR DESCRIPTION
## Milestone
Phase 2 — Capability fail-closed hardening for MCP v1.6 adoption.

Closes #205.
Closes #206.

## Classification
MCP-contract semantic hardening, operational reliability, test coverage.

## Surfaces affected
- `internal/mcpserver/mcpserver.go`
- `internal/mcpserver/mcpserver_test.go`
- `internal/mcpserver/cancellation_test.go`
- `internal/mcpapp/cancellation_test.go`

## Specialist walks referenced
- Tool surface: none; no tool additions/removals/scope/profile changes.
- MCP contract: semantic refinement only. `initialize` capability advertisement is pinned fail-closed to current body surfaces, and cancellation semantics are verified for representative request paths.
- Lesser integration: preserves existing REST API calls and validates context cancellation propagation on a lesser-backed read path.
- Host delegation: preserves lesser-host communication API contract and validates `sms_send` host delegation respects context cancellation.
- Framework: idiomatic AppTheory v1.6 MCP runtime consumption via `WithCapabilityConfig` and `notifications/cancelled`; no framework patching.

## Consumer impact
MCP clients should see the same supported body surfaces, advertised more explicitly:
- `tools`, `resources`, and `prompts` remain enabled.
- `completions`, `tasks`, and `logging` remain absent until later adoption phases.
- No `.well-known/mcp.json` or OAuth protected-resource metadata shape changes.
- No JSON-RPC request/response envelope changes.

## Tasks
- [x] #205 — Explicitly configure MCP capability advertisement
- [x] #206 — Harden cancellation handling for long-running MCP requests

## Validation
- `go test ./internal/mcpserver -run TestInitializeCapabilitiesArePinnedFailClosed -count=1`
- `go test ./internal/mcpserver ./internal/mcpapp`
- `go vet ./internal/mcpserver ./internal/mcpapp`
- `go test ./internal/mcpapp -run 'TestCancellationNotificationCancels' -count=1 -timeout 10s -v`
- `go test ./internal/mcpserver -run TestSmsSendStreamingHonorsCanceledContext -count=1 -timeout 5s -v`
- `go test ./...`
- `(cd cdk && go test . ./stacks)`
- `go vet ./...`
- `(cd cdk && go vet . ./stacks)`
- `gofmt -l .` (empty)
- `scripts/build.sh`
- `git diff --check`

## Stage rollout plan (handoff to deploy-body)
- [ ] Merged to main
- [ ] Deployed to lab / dev
- [ ] Lab soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
None required for this phase. This does not change SSM exports, lesser REST API shapes, lesser-host comm API shapes, auth models, or deployment order.

## Advisor-brief authorization
Not applicable; this work was directed by Aron in the active Codex session.
