### PR TITLE
feat(mcp): add tool output schemas

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -398,7 +398,10 @@ Notes:
 - Selected tools now publish MCP `outputSchema` metadata in `tools/list` and `.well-known/mcp.json`. The schema
   describes the tool's `structuredContent` success shape, not the full JSON-RPC envelope: memory query tools describe
   direct top-level fields such as `events`, while selected identity, soul, and skills tools that use the generic
-  structured wrapper describe `data`.
+  structured wrapper describe `data`. Mailbox list/state tools describe direct fields such as `messages`, `count`,
+  `nextCursor`, and `state`; communication send/reply schemas explicitly include `messageId`, `status`, and
+  caller-visible `idempotencyKey` fields so clients can reconcile host-delegated delivery without bypassing
+  lesser-host idempotency or logging recipient PII.
 - `timeline_read` remains bounded by caller `limit`/cursor and upstream-shaped in M0 because current baseline evidence
   points to mailbox and notification bloat, not timeline unusability. If Ops probes show timeline truncation/timeout,
   timeline compacting should be scoped as a follow-up MCP-contract change rather than silently changed inside M0.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -399,7 +399,7 @@ Notes:
   describes the tool's `structuredContent` success shape, not the full JSON-RPC envelope: memory query tools describe
   direct top-level fields such as `events`, while selected identity, soul, and skills tools that use the generic
   structured wrapper describe `data`. Mailbox list/state tools describe direct fields such as `messages`, `count`,
-  `nextCursor`, and `state`; communication send/reply schemas explicitly include `messageId`, `status`, and
+  `nextCursor`, `notes`, and `state`; communication send/reply schemas explicitly include `messageId`, `status`, and
   caller-visible `idempotencyKey` fields so clients can reconcile host-delegated delivery without bypassing
   lesser-host idempotency or logging recipient PII.
 - `timeline_read` remains bounded by caller `limit`/cursor and upstream-shaped in M0 because current baseline evidence

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -395,6 +395,10 @@ Notes:
 - Mailbox and memory tools use dual MCP result surfaces: `content[0].text` contains the JSON payload for text-reading
   clients, and `structuredContent` contains the same typed fields directly (for example `messages` or `events` at the
   top level) rather than nesting them under a `data` wrapper.
+- Selected tools now publish MCP `outputSchema` metadata in `tools/list` and `.well-known/mcp.json`. The schema
+  describes the tool's `structuredContent` success shape, not the full JSON-RPC envelope: memory query tools describe
+  direct top-level fields such as `events`, while selected identity, soul, and skills tools that use the generic
+  structured wrapper describe `data`.
 - `timeline_read` remains bounded by caller `limit`/cursor and upstream-shaped in M0 because current baseline evidence
   points to mailbox and notification bloat, not timeline unusability. If Ops probes show timeline truncation/timeout,
   timeline compacting should be scoped as a follow-up MCP-contract change rather than silently changed inside M0.

--- a/internal/mcpapp/tool_output_schema_test.go
+++ b/internal/mcpapp/tool_output_schema_test.go
@@ -60,6 +60,46 @@ func TestReadToolOutputSchemasAdvertisedInToolsListAndDiscovery(t *testing.T) {
 	t.Fatalf("memory_query missing from well-known discovery tools: %+v", out.Tools)
 }
 
+func TestCommunicationAndWriteToolOutputSchemasAdvertised(t *testing.T) {
+	t.Setenv("MCP_SESSION_TABLE", "")
+	t.Setenv("JWT_SECRET", "test")
+	installSoulBindingLookup(t, "agent1", "0x1111111111111111111111111111111111111111111111111111111111111111")
+	auth.ResetForTests()
+
+	app, err := mcpapp.New("test", "dev")
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+	env := testkit.New()
+	toolsByName := toolsListByNameForOutputSchemaTest(t, env, app)
+
+	for _, name := range []string{"email_send", "email_reply", "sms_send"} {
+		dataSchema := nestedOutputSchemaObject(t, toolsByName[name], "data")
+		assertSchemaPropertyType(t, dataSchema, "messageId", "string")
+		assertSchemaPropertyType(t, dataSchema, "status", "string")
+		assertSchemaPropertyType(t, dataSchema, "idempotencyKey", "string")
+	}
+	for _, name := range []string{"email_read", "email_search", "sms_read", "voicemail_read"} {
+		schema := outputSchemaObject(t, toolsByName[name])
+		assertSchemaPropertyType(t, schema, "messages", "array")
+		assertSchemaPropertyType(t, schema, "count", "integer")
+		assertSchemaPropertyType(t, schema, "nextCursor", "string")
+	}
+	assertSchemaPropertyType(t, outputSchemaObject(t, toolsByName["email_get"]), "message", "object")
+	assertSchemaPropertyType(t, outputSchemaObject(t, toolsByName["email_get_content"]), "body", "string")
+	for _, name := range []string{"email_delete", "email_mark_read", "email_mark_unread"} {
+		schema := outputSchemaObject(t, toolsByName[name])
+		assertSchemaPropertyType(t, schema, "messageId", "string")
+		assertSchemaPropertyType(t, schema, "action", "string")
+		assertSchemaPropertyType(t, schema, "state", "object")
+	}
+	assertSchemaPropertyType(t, outputSchemaObject(t, toolsByName["memory_append"]), "event", "object")
+
+	for _, name := range []string{"post_create", "post_boost", "post_favorite", "follow", "unfollow", "profile_update", "notification_dismiss"} {
+		assertSchemaPropertyType(t, outputSchemaObject(t, toolsByName[name]), "data", "object")
+	}
+}
+
 func toolsListByNameForOutputSchemaTest(t testing.TB, env *testkit.Env, app *apptheory.App) map[string]mcpruntime.ToolDef {
 	t.Helper()
 

--- a/internal/mcpapp/tool_output_schema_test.go
+++ b/internal/mcpapp/tool_output_schema_test.go
@@ -84,6 +84,11 @@ func TestCommunicationAndWriteToolOutputSchemasAdvertised(t *testing.T) {
 		assertSchemaPropertyType(t, schema, "messages", "array")
 		assertSchemaPropertyType(t, schema, "count", "integer")
 		assertSchemaPropertyType(t, schema, "nextCursor", "string")
+		notesSchema := schemaPropertyObject(t, schema, "notes")
+		assertSchemaPropertyType(t, notesSchema, "authority", "string")
+		assertSchemaPropertyType(t, notesSchema, "bodyField", "string")
+		assertSchemaPropertyType(t, notesSchema, "messageIdRef", "string")
+		assertSchemaPropertyType(t, notesSchema, "legacySinceName", "string")
 	}
 	assertSchemaPropertyType(t, outputSchemaObject(t, toolsByName["email_get"]), "message", "object")
 	assertSchemaPropertyType(t, outputSchemaObject(t, toolsByName["email_get_content"]), "body", "string")
@@ -184,6 +189,15 @@ func nestedOutputSchemaObject(t testing.TB, def mcpruntime.ToolDef, prop string)
 
 func assertSchemaPropertyType(t testing.TB, schema map[string]any, prop string, want string) {
 	t.Helper()
+	m := schemaPropertyObject(t, schema, prop)
+	got, _ := m["type"].(string)
+	if got != want {
+		t.Fatalf("schema property %q type: got %q want %q", prop, got, want)
+	}
+}
+
+func schemaPropertyObject(t testing.TB, schema map[string]any, prop string) map[string]any {
+	t.Helper()
 	props, _ := schema["properties"].(map[string]any)
 	raw, ok := props[prop]
 	if !ok {
@@ -193,8 +207,5 @@ func assertSchemaPropertyType(t testing.TB, schema map[string]any, prop string, 
 	if !ok {
 		t.Fatalf("schema property %q is %T, want object", prop, raw)
 	}
-	got, _ := m["type"].(string)
-	if got != want {
-		t.Fatalf("schema property %q type: got %q want %q", prop, got, want)
-	}
+	return m
 }

--- a/internal/mcpapp/tool_output_schema_test.go
+++ b/internal/mcpapp/tool_output_schema_test.go
@@ -1,0 +1,160 @@
+package mcpapp_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+	mcpruntime "github.com/theory-cloud/apptheory/runtime/mcp"
+	"github.com/theory-cloud/apptheory/testkit"
+
+	"github.com/equaltoai/lesser-body/internal/auth"
+	"github.com/equaltoai/lesser-body/internal/mcpapp"
+)
+
+func TestReadToolOutputSchemasAdvertisedInToolsListAndDiscovery(t *testing.T) {
+	t.Setenv("MCP_SESSION_TABLE", "")
+	t.Setenv("MCP_ENDPOINT", "https://api.example.com/mcp")
+	t.Setenv("JWT_SECRET", "test")
+	installSoulBindingLookup(t, "agent1", "0x1111111111111111111111111111111111111111111111111111111111111111")
+	auth.ResetForTests()
+
+	app, err := mcpapp.New("test", "dev")
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+	env := testkit.New()
+	toolsByName := toolsListByNameForOutputSchemaTest(t, env, app)
+
+	assertSchemaPropertyType(t, outputSchemaObject(t, toolsByName["memory_query"]), "events", "array")
+	assertSchemaPropertyType(t, nestedOutputSchemaObject(t, toolsByName["skills_catalog"], "data"), "authority", "object")
+	assertSchemaPropertyType(t, nestedOutputSchemaObject(t, toolsByName["skill_bundle_get"], "data"), "verification", "object")
+	assertSchemaPropertyType(t, nestedOutputSchemaObject(t, toolsByName["soul_read"], "data"), "souls", "array")
+	assertSchemaPropertyType(t, nestedOutputSchemaObject(t, toolsByName["identity_whoami"], "data"), "channels", "object")
+	assertSchemaPropertyType(t, nestedOutputSchemaObject(t, toolsByName["identity_lookup"], "data"), "matches", "array")
+	assertSchemaPropertyType(t, nestedOutputSchemaObject(t, toolsByName["identity_verify"], "data"), "verified", "boolean")
+
+	resp := env.Invoke(context.Background(), app, apptheory.Request{
+		Method: "GET",
+		Path:   "/.well-known/mcp.json",
+	})
+	if resp.Status != 200 {
+		t.Fatalf("well-known mcp.json: status=%d body=%s", resp.Status, string(resp.Body))
+	}
+	var out struct {
+		Tools []struct {
+			Name         string          `json:"name"`
+			OutputSchema json.RawMessage `json:"outputSchema,omitempty"`
+		} `json:"tools"`
+	}
+	if err := json.Unmarshal(resp.Body, &out); err != nil {
+		t.Fatalf("unmarshal well-known mcp.json: %v", err)
+	}
+	for _, tool := range out.Tools {
+		if tool.Name == "memory_query" {
+			assertSchemaPropertyType(t, parseOutputSchemaRaw(t, "well-known memory_query", tool.OutputSchema), "events", "array")
+			return
+		}
+	}
+	t.Fatalf("memory_query missing from well-known discovery tools: %+v", out.Tools)
+}
+
+func toolsListByNameForOutputSchemaTest(t testing.TB, env *testkit.Env, app *apptheory.App) map[string]mcpruntime.ToolDef {
+	t.Helper()
+
+	token := newTestTokenWithAudience(t, "test", "agent1", []string{"read", "write"}, []string{"https://api.example.com/mcp"})
+	initResp := invokeJSON(t, env, app, map[string][]string{
+		"authorization": {"Bearer " + token},
+	}, &mcpruntime.Request{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "initialize",
+	})
+	if initResp.Status != 200 {
+		t.Fatalf("initialize: status=%d body=%s", initResp.Status, string(initResp.Body))
+	}
+	sessionID := initResp.Headers["mcp-session-id"][0]
+
+	listResp := invokeJSON(t, env, app, map[string][]string{
+		"authorization":  {"Bearer " + token},
+		"mcp-session-id": {sessionID},
+	}, &mcpruntime.Request{
+		JSONRPC: "2.0",
+		ID:      2,
+		Method:  "tools/list",
+	})
+	if listResp.Status != 200 {
+		t.Fatalf("tools/list: status=%d body=%s", listResp.Status, string(listResp.Body))
+	}
+
+	var rpc mcpruntime.Response
+	if err := json.Unmarshal(listResp.Body, &rpc); err != nil {
+		t.Fatalf("unmarshal tools/list: %v", err)
+	}
+	if rpc.Error != nil {
+		t.Fatalf("tools/list error: %+v", rpc.Error)
+	}
+	var result struct {
+		Tools []mcpruntime.ToolDef `json:"tools"`
+	}
+	b, _ := json.Marshal(rpc.Result)
+	if err := json.Unmarshal(b, &result); err != nil {
+		t.Fatalf("unmarshal tools/list result: %v", err)
+	}
+
+	toolsByName := map[string]mcpruntime.ToolDef{}
+	for _, tool := range result.Tools {
+		toolsByName[tool.Name] = tool
+	}
+	return toolsByName
+}
+
+func outputSchemaObject(t testing.TB, def mcpruntime.ToolDef) map[string]any {
+	t.Helper()
+	return parseOutputSchemaRaw(t, def.Name, def.OutputSchema)
+}
+
+func parseOutputSchemaRaw(t testing.TB, name string, raw json.RawMessage) map[string]any {
+	t.Helper()
+	if len(raw) == 0 {
+		t.Fatalf("%s missing outputSchema", name)
+	}
+	var schema map[string]any
+	if err := json.Unmarshal(raw, &schema); err != nil {
+		t.Fatalf("unmarshal %s outputSchema: %v", name, err)
+	}
+	return schema
+}
+
+func nestedOutputSchemaObject(t testing.TB, def mcpruntime.ToolDef, prop string) map[string]any {
+	t.Helper()
+	schema := outputSchemaObject(t, def)
+	props, _ := schema["properties"].(map[string]any)
+	raw, ok := props[prop]
+	if !ok {
+		t.Fatalf("%s outputSchema missing property %q: %+v", def.Name, prop, schema)
+	}
+	nested, ok := raw.(map[string]any)
+	if !ok {
+		t.Fatalf("%s outputSchema property %q is %T, want object", def.Name, prop, raw)
+	}
+	return nested
+}
+
+func assertSchemaPropertyType(t testing.TB, schema map[string]any, prop string, want string) {
+	t.Helper()
+	props, _ := schema["properties"].(map[string]any)
+	raw, ok := props[prop]
+	if !ok {
+		t.Fatalf("schema missing property %q: %+v", prop, schema)
+	}
+	m, ok := raw.(map[string]any)
+	if !ok {
+		t.Fatalf("schema property %q is %T, want object", prop, raw)
+	}
+	got, _ := m["type"].(string)
+	if got != want {
+		t.Fatalf("schema property %q type: got %q want %q", prop, got, want)
+	}
+}

--- a/internal/mcpapp/well_known.go
+++ b/internal/mcpapp/well_known.go
@@ -25,8 +25,9 @@ type mcpWellKnownDoc struct {
 }
 
 type mcpWellKnownToolHint struct {
-	Name        string `json:"name"`
-	Description string `json:"description,omitempty"`
+	Name         string          `json:"name"`
+	Description  string          `json:"description,omitempty"`
+	OutputSchema json.RawMessage `json:"outputSchema,omitempty"`
 }
 
 type protectedResourceMetadataDocument struct {
@@ -68,8 +69,9 @@ func WellKnownMcpHandler(srv *mcpserver.Server, name string, version string) app
 					continue
 				}
 				doc.Tools = append(doc.Tools, mcpWellKnownToolHint{
-					Name:        strings.TrimSpace(tool.Name),
-					Description: strings.TrimSpace(tool.Description),
+					Name:         strings.TrimSpace(tool.Name),
+					Description:  strings.TrimSpace(tool.Description),
+					OutputSchema: append(json.RawMessage(nil), tool.OutputSchema...),
 				})
 			}
 		}

--- a/internal/mcpserver/comm_tools.go
+++ b/internal/mcpserver/comm_tools.go
@@ -310,9 +310,10 @@ func voicemailReadDef() mcpruntime.ToolDef {
 
 func soulReadDef() mcpruntime.ToolDef {
 	return mcpruntime.ToolDef{
-		Name:        "soul_read",
-		Description: "Read a public soul identity bundle and, with explicit self-scope opt-in, bounded private mint-conversation data through Lesser. Private email/phone reachability and contact preferences are omitted or marked unavailable.",
-		Annotations: readOnlyToolAnnotations(),
+		Name:         "soul_read",
+		Description:  "Read a public soul identity bundle and, with explicit self-scope opt-in, bounded private mint-conversation data through Lesser. Private email/phone reachability and contact preferences are omitted or marked unavailable.",
+		Annotations:  readOnlyToolAnnotations(),
+		OutputSchema: soulReadOutputSchema(),
 		InputSchema: json.RawMessage(`{
 			"type":"object",
 			"properties":{
@@ -332,16 +333,18 @@ func soulReadDef() mcpruntime.ToolDef {
 
 func identityWhoamiDef() mcpruntime.ToolDef {
 	return mcpruntime.ToolDef{
-		Name:        "identity_whoami",
-		Description: "Return this agent's full identity including communication channels and preferences.",
-		InputSchema: json.RawMessage(`{"type":"object","properties":{}}`),
+		Name:         "identity_whoami",
+		Description:  "Return this agent's full identity including communication channels and preferences.",
+		OutputSchema: identityWhoamiOutputSchema(),
+		InputSchema:  json.RawMessage(`{"type":"object","properties":{}}`),
 	}
 }
 
 func identityLookupDef() mcpruntime.ToolDef {
 	return mcpruntime.ToolDef{
-		Name:        "identity_lookup",
-		Description: "Look up a public soul identity by full agentId, ENS name, a current-instance local ID such as medic, an explicit remote ActivityPub handle such as @steward@remote.example, or a canonical actor URL such as https://remote.example/users/steward. Private email/phone reachability lookup fails closed until lesser-host exposes a body-facing resolver.",
+		Name:         "identity_lookup",
+		Description:  "Look up a public soul identity by full agentId, ENS name, a current-instance local ID such as medic, an explicit remote ActivityPub handle such as @steward@remote.example, or a canonical actor URL such as https://remote.example/users/steward. Private email/phone reachability lookup fails closed until lesser-host exposes a body-facing resolver.",
+		OutputSchema: identityLookupOutputSchema(),
 		InputSchema: json.RawMessage(`{
 			"type":"object",
 			"properties":{
@@ -354,8 +357,9 @@ func identityLookupDef() mcpruntime.ToolDef {
 
 func identityVerifyDef() mcpruntime.ToolDef {
 	return mcpruntime.ToolDef{
-		Name:        "identity_verify",
-		Description: "Verify that a communication came from a specific soul identity. ENS verification uses public resolution plus authoritative message provenance; private email/phone verification fails closed unless Host supplies authoritative sender-identifier provenance.",
+		Name:         "identity_verify",
+		Description:  "Verify that a communication came from a specific soul identity. ENS verification uses public resolution plus authoritative message provenance; private email/phone verification fails closed unless Host supplies authoritative sender-identifier provenance.",
+		OutputSchema: identityVerifyOutputSchema(),
 		InputSchema: json.RawMessage(`{
 			"type":"object",
 			"properties":{

--- a/internal/mcpserver/comm_tools.go
+++ b/internal/mcpserver/comm_tools.go
@@ -55,9 +55,10 @@ func handleNotImplemented(_ context.Context, _ json.RawMessage) (*mcpruntime.Too
 
 func emailSendDef() mcpruntime.ToolDef {
 	return mcpruntime.ToolDef{
-		Name:        "email_send",
-		Description: "Send a new email from the agent's address via lesser-host (no provider credentials). Use email_reply for replies to existing mailbox messages.",
-		Annotations: destructiveToolAnnotations(),
+		Name:         "email_send",
+		Description:  "Send a new email from the agent's address via lesser-host (no provider credentials). Use email_reply for replies to existing mailbox messages.",
+		Annotations:  destructiveToolAnnotations(),
+		OutputSchema: commSendOutputSchema(),
 		InputSchema: json.RawMessage(`{
 			"type":"object",
 			"properties":{
@@ -76,9 +77,10 @@ func emailSendDef() mcpruntime.ToolDef {
 
 func emailReadDef() mcpruntime.ToolDef {
 	return mcpruntime.ToolDef{
-		Name:        "email_read",
-		Description: "List recent email metadata/previews from lesser-host's canonical mailbox.",
-		Annotations: readOnlyToolAnnotations(),
+		Name:         "email_read",
+		Description:  "List recent email metadata/previews from lesser-host's canonical mailbox.",
+		Annotations:  readOnlyToolAnnotations(),
+		OutputSchema: mailboxListOutputSchema(),
 		InputSchema: json.RawMessage(`{
 			"type":"object",
 			"properties":{
@@ -101,9 +103,10 @@ func emailReadDef() mcpruntime.ToolDef {
 
 func emailGetDef() mcpruntime.ToolDef {
 	return mcpruntime.ToolDef{
-		Name:        "email_get",
-		Description: "Get canonical email metadata/state by opaque host message reference.",
-		Annotations: readOnlyToolAnnotations(),
+		Name:         "email_get",
+		Description:  "Get canonical email metadata/state by opaque host message reference.",
+		Annotations:  readOnlyToolAnnotations(),
+		OutputSchema: mailboxGetOutputSchema(),
 		InputSchema: json.RawMessage(`{
 			"type":"object",
 			"properties":{
@@ -117,9 +120,10 @@ func emailGetDef() mcpruntime.ToolDef {
 
 func emailGetContentDef() mcpruntime.ToolDef {
 	return mcpruntime.ToolDef{
-		Name:        "email_get_content",
-		Description: "Fetch full email content explicitly from lesser-host's canonical mailbox.",
-		Annotations: readOnlyToolAnnotations(),
+		Name:         "email_get_content",
+		Description:  "Fetch full email content explicitly from lesser-host's canonical mailbox.",
+		Annotations:  readOnlyToolAnnotations(),
+		OutputSchema: mailboxContentOutputSchema(),
 		InputSchema: json.RawMessage(`{
 			"type":"object",
 			"properties":{
@@ -132,9 +136,10 @@ func emailGetContentDef() mcpruntime.ToolDef {
 
 func emailSearchDef() mcpruntime.ToolDef {
 	return mcpruntime.ToolDef{
-		Name:        "email_search",
-		Description: "Run a bounded lesser-host metadata/preview search over the agent's email mailbox.",
-		Annotations: readOnlyToolAnnotations(),
+		Name:         "email_search",
+		Description:  "Run a bounded lesser-host metadata/preview search over the agent's email mailbox.",
+		Annotations:  readOnlyToolAnnotations(),
+		OutputSchema: mailboxListOutputSchema(),
 		InputSchema: json.RawMessage(`{
 			"type":"object",
 			"properties":{
@@ -158,9 +163,10 @@ func emailSearchDef() mcpruntime.ToolDef {
 
 func emailReplyDef() mcpruntime.ToolDef {
 	return mcpruntime.ToolDef{
-		Name:        "email_reply",
-		Description: "Reply to a specific email message.",
-		Annotations: destructiveToolAnnotations(),
+		Name:         "email_reply",
+		Description:  "Reply to a specific email message.",
+		Annotations:  destructiveToolAnnotations(),
+		OutputSchema: commSendOutputSchema(),
 		InputSchema: json.RawMessage(`{
 			"type":"object",
 			"properties":{
@@ -181,9 +187,10 @@ func emailReplyDef() mcpruntime.ToolDef {
 
 func emailDeleteDef() mcpruntime.ToolDef {
 	return mcpruntime.ToolDef{
-		Name:        "email_delete",
-		Description: "Delete or archive an email message in lesser-host's canonical mailbox.",
-		Annotations: destructiveToolAnnotations(),
+		Name:         "email_delete",
+		Description:  "Delete or archive an email message in lesser-host's canonical mailbox.",
+		Annotations:  destructiveToolAnnotations(),
+		OutputSchema: mailboxMutationOutputSchema(),
 		InputSchema: json.RawMessage(`{
 			"type":"object",
 			"properties":{
@@ -197,9 +204,10 @@ func emailDeleteDef() mcpruntime.ToolDef {
 
 func emailMarkReadDef() mcpruntime.ToolDef {
 	return mcpruntime.ToolDef{
-		Name:        "email_mark_read",
-		Description: "Mark an email read in lesser-host's canonical mailbox.",
-		Annotations: idempotentMutationToolAnnotations(),
+		Name:         "email_mark_read",
+		Description:  "Mark an email read in lesser-host's canonical mailbox.",
+		Annotations:  idempotentMutationToolAnnotations(),
+		OutputSchema: mailboxMutationOutputSchema(),
 		InputSchema: json.RawMessage(`{
 			"type":"object",
 			"properties":{
@@ -212,9 +220,10 @@ func emailMarkReadDef() mcpruntime.ToolDef {
 
 func emailMarkUnreadDef() mcpruntime.ToolDef {
 	return mcpruntime.ToolDef{
-		Name:        "email_mark_unread",
-		Description: "Mark an email unread in lesser-host's canonical mailbox.",
-		Annotations: idempotentMutationToolAnnotations(),
+		Name:         "email_mark_unread",
+		Description:  "Mark an email unread in lesser-host's canonical mailbox.",
+		Annotations:  idempotentMutationToolAnnotations(),
+		OutputSchema: mailboxMutationOutputSchema(),
 		InputSchema: json.RawMessage(`{
 			"type":"object",
 			"properties":{
@@ -227,9 +236,10 @@ func emailMarkUnreadDef() mcpruntime.ToolDef {
 
 func smsSendDef() mcpruntime.ToolDef {
 	return mcpruntime.ToolDef{
-		Name:        "sms_send",
-		Description: "Send an SMS from the agent's number via lesser-host.",
-		Annotations: destructiveToolAnnotations(),
+		Name:         "sms_send",
+		Description:  "Send an SMS from the agent's number via lesser-host.",
+		Annotations:  destructiveToolAnnotations(),
+		OutputSchema: commSendOutputSchema(),
 		InputSchema: json.RawMessage(`{
 			"type":"object",
 			"properties":{
@@ -245,9 +255,10 @@ func smsSendDef() mcpruntime.ToolDef {
 
 func smsReadDef() mcpruntime.ToolDef {
 	return mcpruntime.ToolDef{
-		Name:        "sms_read",
-		Description: "Read received SMS metadata/previews from lesser-host's canonical mailbox.",
-		Annotations: readOnlyToolAnnotations(),
+		Name:         "sms_read",
+		Description:  "Read received SMS metadata/previews from lesser-host's canonical mailbox.",
+		Annotations:  readOnlyToolAnnotations(),
+		OutputSchema: mailboxListOutputSchema(),
 		InputSchema: json.RawMessage(`{
 			"type":"object",
 			"properties":{
@@ -287,9 +298,10 @@ func phoneCallDef() mcpruntime.ToolDef {
 
 func voicemailReadDef() mcpruntime.ToolDef {
 	return mcpruntime.ToolDef{
-		Name:        "voicemail_read",
-		Description: "Read voicemail metadata/previews from lesser-host's canonical mailbox.",
-		Annotations: readOnlyToolAnnotations(),
+		Name:         "voicemail_read",
+		Description:  "Read voicemail metadata/previews from lesser-host's canonical mailbox.",
+		Annotations:  readOnlyToolAnnotations(),
+		OutputSchema: mailboxListOutputSchema(),
 		InputSchema: json.RawMessage(`{
 			"type":"object",
 			"properties":{

--- a/internal/mcpserver/memory_tools.go
+++ b/internal/mcpserver/memory_tools.go
@@ -180,9 +180,10 @@ func memoryAppendDef() mcpruntime.ToolDef {
 
 func memoryQueryDef() mcpruntime.ToolDef {
 	return mcpruntime.ToolDef{
-		Name:        "memory_query",
-		Description: "Query memory events for the authenticated agent.",
-		Annotations: readOnlyToolAnnotations(),
+		Name:         "memory_query",
+		Description:  "Query memory events for the authenticated agent.",
+		Annotations:  readOnlyToolAnnotations(),
+		OutputSchema: memoryQueryOutputSchema(),
 		InputSchema: json.RawMessage(`{
 			"type":"object",
 			"properties":{

--- a/internal/mcpserver/memory_tools.go
+++ b/internal/mcpserver/memory_tools.go
@@ -161,9 +161,10 @@ func parseRFC3339Optional(raw string) (time.Time, error) {
 
 func memoryAppendDef() mcpruntime.ToolDef {
 	return mcpruntime.ToolDef{
-		Name:        "memory_append",
-		Description: "Append a memory event to the authenticated agent's memory timeline.",
-		Annotations: additiveMutationToolAnnotations(),
+		Name:         "memory_append",
+		Description:  "Append a memory event to the authenticated agent's memory timeline.",
+		Annotations:  additiveMutationToolAnnotations(),
+		OutputSchema: memoryAppendOutputSchema(),
 		InputSchema: json.RawMessage(`{
 			"type":"object",
 			"properties":{

--- a/internal/mcpserver/output_schemas.go
+++ b/internal/mcpserver/output_schemas.go
@@ -260,7 +260,17 @@ func mailboxListOutputSchema() json.RawMessage {
 			"hasMore":{"type":"boolean"},
 			"nextCursor":{"type":"string"},
 			"nextSince":{"type":"string"},
-			"notes":{"type":"array","items":{"type":"string"}},
+			"notes":{
+				"type":"object",
+				"properties":{
+					"authority":{"type":"string"},
+					"bodyField":{"type":"string"},
+					"messageIdRef":{"type":"string"},
+					"legacySinceName":{"type":"string"}
+				},
+				"required":["authority","bodyField","messageIdRef","legacySinceName"],
+				"additionalProperties":true
+			},
 			"folder":{"type":"string"},
 			"query":{"type":"string"},
 			"strategy":{"type":"string"},

--- a/internal/mcpserver/output_schemas.go
+++ b/internal/mcpserver/output_schemas.go
@@ -1,0 +1,328 @@
+package mcpserver
+
+import (
+	"encoding/json"
+)
+
+func genericDataObjectOutputSchema() json.RawMessage {
+	return json.RawMessage(`{
+		"type":"object",
+		"properties":{
+			"data":{"type":"object","additionalProperties":true}
+		},
+		"required":["data"],
+		"additionalProperties":false
+	}`)
+}
+
+func memoryEventOutputSchemaProperties() string {
+	return `"event_id":{"type":"string"},
+		"occurred_at":{"type":"string"},
+		"content":{"type":"string"},
+		"tags":{"type":"array","items":{"type":"string"}},
+		"expires_at":{"type":"string"}`
+}
+
+func memoryAppendOutputSchema() json.RawMessage {
+	return json.RawMessage(`{
+		"type":"object",
+		"properties":{
+			"event":{
+				"type":"object",
+				"properties":{` + memoryEventOutputSchemaProperties() + `},
+				"required":["event_id","occurred_at","content"]
+			},
+			"created":{"type":"boolean"}
+		},
+		"required":["event","created"],
+		"additionalProperties":false
+	}`)
+}
+
+func memoryQueryOutputSchema() json.RawMessage {
+	return json.RawMessage(`{
+		"type":"object",
+		"properties":{
+			"events":{
+				"type":"array",
+				"items":{
+					"type":"object",
+					"properties":{` + memoryEventOutputSchemaProperties() + `},
+					"required":["event_id","occurred_at","content"]
+				}
+			},
+			"next_cursor":{"type":"string"}
+		},
+		"required":["events"],
+		"additionalProperties":false
+	}`)
+}
+
+func skillsCatalogOutputSchema() json.RawMessage {
+	return json.RawMessage(`{
+		"type":"object",
+		"properties":{
+			"data":{
+				"type":"object",
+				"properties":{
+					"authority":{"type":"object","additionalProperties":true},
+					"items":{"type":"array","items":{"type":"object","additionalProperties":true}},
+					"bundles":{"type":"array","items":{"type":"object","additionalProperties":true}},
+					"nextCursor":{"type":"string"}
+				},
+				"additionalProperties":true
+			}
+		},
+		"required":["data"],
+		"additionalProperties":false
+	}`)
+}
+
+func skillBundleGetOutputSchema() json.RawMessage {
+	return json.RawMessage(`{
+		"type":"object",
+		"properties":{
+			"data":{
+				"type":"object",
+				"properties":{
+					"authority":{"type":"object","additionalProperties":true},
+					"bundle":{"type":"object","additionalProperties":true},
+					"content":{"type":"object","additionalProperties":true},
+					"verification":{"type":"object","additionalProperties":true}
+				},
+				"additionalProperties":true
+			}
+		},
+		"required":["data"],
+		"additionalProperties":false
+	}`)
+}
+
+func soulReadOutputSchema() json.RawMessage {
+	return json.RawMessage(`{
+		"type":"object",
+		"properties":{
+			"data":{
+				"type":"object",
+				"properties":{
+					"query":{"type":"string"},
+					"count":{"type":"integer"},
+					"access":{"type":"object","additionalProperties":true},
+					"souls":{"type":"array","items":{"type":"object","additionalProperties":true}}
+				},
+				"required":["query","count","access","souls"],
+				"additionalProperties":true
+			}
+		},
+		"required":["data"],
+		"additionalProperties":false
+	}`)
+}
+
+func identityWhoamiOutputSchema() json.RawMessage {
+	return json.RawMessage(`{
+		"type":"object",
+		"properties":{
+			"data":{
+				"type":"object",
+				"properties":{
+					"agentId":{"type":"string"},
+					"domain":{"type":"string"},
+					"localId":{"type":"string"},
+					"status":{"type":"string"},
+					"channels":{"type":"object","additionalProperties":true},
+					"contactPreferences":{"type":"object","additionalProperties":true}
+				},
+				"additionalProperties":true
+			}
+		},
+		"required":["data"],
+		"additionalProperties":false
+	}`)
+}
+
+func identityLookupOutputSchema() json.RawMessage {
+	return json.RawMessage(`{
+		"type":"object",
+		"properties":{
+			"data":{
+				"type":"object",
+				"properties":{
+					"query":{"type":"string"},
+					"matches":{"type":"array","items":{"type":"object","additionalProperties":true}},
+					"count":{"type":"integer"}
+				},
+				"required":["query","matches","count"],
+				"additionalProperties":true
+			}
+		},
+		"required":["data"],
+		"additionalProperties":false
+	}`)
+}
+
+func identityVerifyOutputSchema() json.RawMessage {
+	return json.RawMessage(`{
+		"type":"object",
+		"properties":{
+			"data":{
+				"type":"object",
+				"properties":{
+					"channel":{"type":"string"},
+					"identifier":{"type":"string"},
+					"verificationScope":{"type":"string"},
+					"identityResolved":{"type":"boolean"},
+					"verified":{"type":"boolean"},
+					"agent":{"type":"object","additionalProperties":true},
+					"reason":{"type":"string"},
+					"messageId":{"type":"string"}
+				},
+				"required":["channel","identifier","verificationScope","identityResolved","verified"],
+				"additionalProperties":true
+			}
+		},
+		"required":["data"],
+		"additionalProperties":false
+	}`)
+}
+
+func commSendOutputSchema() json.RawMessage {
+	return json.RawMessage(`{
+		"type":"object",
+		"properties":{
+			"data":{
+				"type":"object",
+				"properties":{
+					"messageId":{"type":"string"},
+					"messageRef":{"type":"string"},
+					"deliveryId":{"type":"string"},
+					"hostMessageId":{"type":"string"},
+					"idempotencyKey":{"type":"string"},
+					"status":{"type":"string"},
+					"threadId":{"type":"string"},
+					"channel":{"type":"string"},
+					"agentId":{"type":"string"},
+					"to":{"type":"string"},
+					"provider":{"type":"string"},
+					"providerMessageId":{"type":"string"},
+					"createdAt":{"type":"string"},
+					"inReplyTo":{"type":"string"},
+					"replyResolvedByHost":{"type":"boolean"},
+					"advisory":{"type":"object","additionalProperties":true},
+					"delivery":{"type":"object","additionalProperties":true},
+					"result":{"additionalProperties":true}
+				},
+				"required":["messageId","status","idempotencyKey"],
+				"additionalProperties":true
+			}
+		},
+		"required":["data"],
+		"additionalProperties":false
+	}`)
+}
+
+func mailboxMessageSummaryOutputSchema() json.RawMessage {
+	return json.RawMessage(`{
+		"type":"object",
+		"properties":{
+			"messageId":{"type":"string"},
+			"messageRef":{"type":"string"},
+			"deliveryId":{"type":"string"},
+			"hostMessageId":{"type":"string"},
+			"threadId":{"type":"string"},
+			"channel":{"type":"string"},
+			"channelType":{"type":"string"},
+			"direction":{"type":"string"},
+			"status":{"type":"string"},
+			"from":{"type":"object","additionalProperties":true},
+			"to":{"type":"object","additionalProperties":true},
+			"subject":{"type":"string"},
+			"preview":{"type":"string"},
+			"body":{"type":"string"},
+			"bodyIsPreview":{"type":"boolean"},
+			"content":{"type":"object","additionalProperties":true},
+			"state":{"type":"object","additionalProperties":true},
+			"createdAt":{"type":"string"},
+			"receivedAt":{"type":"string"},
+			"updatedAt":{"type":"string"}
+		},
+		"additionalProperties":true
+	}`)
+}
+
+func mailboxListOutputSchema() json.RawMessage {
+	return json.RawMessage(`{
+		"type":"object",
+		"properties":{
+			"source":{"type":"string"},
+			"messages":{"type":"array","items":` + string(mailboxMessageSummaryOutputSchema()) + `},
+			"count":{"type":"integer"},
+			"hasMore":{"type":"boolean"},
+			"nextCursor":{"type":"string"},
+			"nextSince":{"type":"string"},
+			"notes":{"type":"array","items":{"type":"string"}},
+			"folder":{"type":"string"},
+			"query":{"type":"string"},
+			"strategy":{"type":"string"},
+			"unreadOnly":{"type":"boolean"},
+			"read":{"type":"boolean"},
+			"includeArchived":{"type":"boolean"},
+			"archived":{"type":"boolean"},
+			"includeDeleted":{"type":"boolean"},
+			"deleted":{"type":"boolean"},
+			"cursor":{"type":"string"},
+			"since":{"type":"string"}
+		},
+		"required":["source","messages","count","hasMore","nextCursor","nextSince","notes"],
+		"additionalProperties":true
+	}`)
+}
+
+func mailboxGetOutputSchema() json.RawMessage {
+	return json.RawMessage(`{
+		"type":"object",
+		"properties":{
+			"message":` + string(mailboxMessageSummaryOutputSchema()) + `,
+			"source":{"type":"string"}
+		},
+		"required":["message"],
+		"additionalProperties":true
+	}`)
+}
+
+func mailboxContentOutputSchema() json.RawMessage {
+	return json.RawMessage(`{
+		"type":"object",
+		"properties":{
+			"source":{"type":"string"},
+			"messageId":{"type":"string"},
+			"messageRef":{"type":"string"},
+			"deliveryId":{"type":"string"},
+			"hostMessageId":{"type":"string"},
+			"contentType":{"type":"string"},
+			"sha256":{"type":"string"},
+			"bytes":{"type":"integer"},
+			"body":{"type":"string"},
+			"instanceSlug":{"type":"string"},
+			"agentId":{"type":"string"}
+		},
+		"required":["source","messageId","body"],
+		"additionalProperties":true
+	}`)
+}
+
+func mailboxMutationOutputSchema() json.RawMessage {
+	return json.RawMessage(`{
+		"type":"object",
+		"properties":{
+			"messageId":{"type":"string"},
+			"messageRef":{"type":"string"},
+			"action":{"type":"string"},
+			"message":` + string(mailboxMessageSummaryOutputSchema()) + `,
+			"state":{"type":"object","additionalProperties":true},
+			"source":{"type":"string"}
+		},
+		"required":["messageId","messageRef","action","message","state"],
+		"additionalProperties":true
+	}`)
+}

--- a/internal/mcpserver/skills_tools.go
+++ b/internal/mcpserver/skills_tools.go
@@ -100,9 +100,10 @@ func registerSkillsTools(r *mcpruntime.ToolRegistry) error {
 
 func skillsCatalogDef() mcpruntime.ToolDef {
 	return mcpruntime.ToolDef{
-		Name:        "skills_catalog",
-		Description: "List approved skill bundles from Lesser's authoritative skills catalog without mutating the client workspace.",
-		Annotations: readOnlyToolAnnotations(),
+		Name:         "skills_catalog",
+		Description:  "List approved skill bundles from Lesser's authoritative skills catalog without mutating the client workspace.",
+		Annotations:  readOnlyToolAnnotations(),
+		OutputSchema: skillsCatalogOutputSchema(),
 		InputSchema: json.RawMessage(`{
 			"type":"object",
 			"properties":{
@@ -116,9 +117,10 @@ func skillsCatalogDef() mcpruntime.ToolDef {
 
 func skillBundleGetDef() mcpruntime.ToolDef {
 	return mcpruntime.ToolDef{
-		Name:        "skill_bundle_get",
-		Description: "Fetch a selected approved Lesser skill bundle and optionally compare caller-supplied local file bytes to the published digests.",
-		Annotations: readOnlyToolAnnotations(),
+		Name:         "skill_bundle_get",
+		Description:  "Fetch a selected approved Lesser skill bundle and optionally compare caller-supplied local file bytes to the published digests.",
+		Annotations:  readOnlyToolAnnotations(),
+		OutputSchema: skillBundleGetOutputSchema(),
 		InputSchema: json.RawMessage(`{
 			"type":"object",
 			"properties":{

--- a/internal/mcpserver/social_tools.go
+++ b/internal/mcpserver/social_tools.go
@@ -861,8 +861,9 @@ func conversationsReadDef() mcpruntime.ToolDef {
 
 func notificationDismissDef() mcpruntime.ToolDef {
 	return mcpruntime.ToolDef{
-		Name:        "notification_dismiss",
-		Description: "Dismiss a notification or all notifications, marking them as read.",
+		Name:         "notification_dismiss",
+		Description:  "Dismiss a notification or all notifications, marking them as read.",
+		OutputSchema: genericDataObjectOutputSchema(),
 		InputSchema: json.RawMessage(`{
 			"type":"object",
 			"properties":{
@@ -1677,8 +1678,9 @@ func firstString(values []string) string {
 
 func postCreateDef() mcpruntime.ToolDef {
 	return mcpruntime.ToolDef{
-		Name:        "post_create",
-		Description: "Create a new post.",
+		Name:         "post_create",
+		Description:  "Create a new post.",
+		OutputSchema: genericDataObjectOutputSchema(),
 		InputSchema: json.RawMessage(`{
 			"type":"object",
 			"properties":{
@@ -1693,8 +1695,9 @@ func postCreateDef() mcpruntime.ToolDef {
 
 func postBoostDef() mcpruntime.ToolDef {
 	return mcpruntime.ToolDef{
-		Name:        "post_boost",
-		Description: "Boost/reblog a post.",
+		Name:         "post_boost",
+		Description:  "Boost/reblog a post.",
+		OutputSchema: genericDataObjectOutputSchema(),
 		InputSchema: json.RawMessage(`{
 			"type":"object",
 			"properties":{"post_id":{"type":"string"}},
@@ -1705,8 +1708,9 @@ func postBoostDef() mcpruntime.ToolDef {
 
 func postFavoriteDef() mcpruntime.ToolDef {
 	return mcpruntime.ToolDef{
-		Name:        "post_favorite",
-		Description: "Favorite a post.",
+		Name:         "post_favorite",
+		Description:  "Favorite a post.",
+		OutputSchema: genericDataObjectOutputSchema(),
 		InputSchema: json.RawMessage(`{
 			"type":"object",
 			"properties":{"post_id":{"type":"string"}},
@@ -1717,8 +1721,9 @@ func postFavoriteDef() mcpruntime.ToolDef {
 
 func followDef() mcpruntime.ToolDef {
 	return mcpruntime.ToolDef{
-		Name:        "follow",
-		Description: "Follow an account.",
+		Name:         "follow",
+		Description:  "Follow an account.",
+		OutputSchema: genericDataObjectOutputSchema(),
 		InputSchema: json.RawMessage(`{
 			"type":"object",
 			"properties":{"account_id":{"type":"string"}},
@@ -1729,8 +1734,9 @@ func followDef() mcpruntime.ToolDef {
 
 func unfollowDef() mcpruntime.ToolDef {
 	return mcpruntime.ToolDef{
-		Name:        "unfollow",
-		Description: "Unfollow an account.",
+		Name:         "unfollow",
+		Description:  "Unfollow an account.",
+		OutputSchema: genericDataObjectOutputSchema(),
 		InputSchema: json.RawMessage(`{
 			"type":"object",
 			"properties":{"account_id":{"type":"string"}},
@@ -1741,8 +1747,9 @@ func unfollowDef() mcpruntime.ToolDef {
 
 func profileUpdateDef() mcpruntime.ToolDef {
 	return mcpruntime.ToolDef{
-		Name:        "profile_update",
-		Description: "Update display name, bio, and avatar (best-effort).",
+		Name:         "profile_update",
+		Description:  "Update display name, bio, and avatar (best-effort).",
+		OutputSchema: genericDataObjectOutputSchema(),
 		InputSchema: json.RawMessage(`{
 			"type":"object",
 			"properties":{


### PR DESCRIPTION
## Milestone
Phase 3 — Tool metadata schemas for MCP v1.6 adoption.

Closes #207.
Closes #208.

## Classification
tool-surface metadata, MCP-contract additive metadata, host-delegation documentation, docs.

## Surfaces affected
- `internal/mcpserver/*` tool definitions
- `internal/mcpserver/output_schemas.go`
- `internal/mcpapp/well_known.go`
- `internal/mcpapp/tool_output_schema_test.go`
- `docs/mcp.md`

## Specialist walks referenced
- Tool surface: output-schema metadata only; no tool additions/removals, no handler behavior changes, no input schema changes, no scope/profile changes.
- MCP contract: additive metadata. `tools/list` now includes `outputSchema` on selected tools, and `.well-known/mcp.json` includes optional `outputSchema` for tools that define one.
- Lesser integration: none. No lesser REST API shape changes and no direct data-schema changes.
- Host delegation: preserved. Communication schemas document existing host-delegated fields (`messageId`, `status`, `idempotencyKey`) without changing delivery, idempotency, rate limiting, credential handling, or PII logging.
- Framework: idiomatic use of AppTheory `ToolDef.OutputSchema`; no framework patches.

## MCP contract audit

### Surfaces affected
- `.well-known/mcp.json`: additive optional `tools[].outputSchema` for tools that define schemas.
- OAuth protected-resource metadata: unchanged.
- JSON-RPC request/response envelopes: unchanged.
- `tools/list`: additive `outputSchema` fields on selected tool definitions.
- Tool `structuredContent`: unchanged; schemas describe existing success payload shapes.

### Compatibility classification
Additive / backward-compatible metadata. Existing clients that ignore `outputSchema` continue unchanged. Schema-aware clients gain typed hints for existing payloads.

### Client impact
- Claude / Anthropic MCP clients: no required update; may use output schemas when supported.
- Anthropic AgentCore: no required update; additive validation hints only.
- Other MCP clients: no required update; unknown fields should be ignored per normal JSON behavior.

### Versioning / rollout
No protocol-version bump and no versioned endpoint required. Release notes should call out that output schemas are metadata-only and describe `structuredContent` success shapes.

### RFC 9728
No OAuth metadata changes.

## Tool-surface audit

### Tools affected
- Read metadata schemas: `memory_query`, `skills_catalog`, `skill_bundle_get`, `soul_read`, `identity_whoami`, `identity_lookup`, `identity_verify`.
- Communication schemas: `email_send`, `email_read`, `email_get`, `email_get_content`, `email_search`, `email_reply`, `email_delete`, `email_mark_read`, `email_mark_unread`, `sms_send`, `sms_read`, `voicemail_read`.
- Write/mutation schemas: `memory_append`, `notification_dismiss`, `post_create`, `post_boost`, `post_favorite`, `follow`, `unfollow`, `profile_update`.

### Scope/profile impact
None. Existing scope and runtime-profile gates are preserved.

### Communication-tool discipline
- Delegation to lesser-host remains the only delivery path.
- `LESSER_HOST_INSTANCE_KEY` handling is unchanged and never logged.
- Caller-visible idempotency fields are documented in output schemas; idempotency behavior is unchanged.
- No recipient address/phone/body logging changes.

## Tasks
- [x] #207 — Add output schema support for low-risk read tools
- [x] #208 — Add output schema support for communication and write tools

## Validation
- `go test ./internal/mcpapp -run 'Test(ReadToolOutputSchemas|CommunicationAndWriteToolOutputSchemas)' -count=1 -v`
- `go test ./internal/mcpapp -run TestReadToolOutputSchemasAdvertisedInToolsListAndDiscovery -count=1 -v`
- `go test ./internal/mcpapp -run TestCommunicationAndWriteToolOutputSchemasAdvertised -count=1 -v`
- `go test ./internal/mcpapp -run 'Test(LBM0_CommunicationToolSchemasMatchSpec|CommunicationAndWriteToolOutputSchemasAdvertised|MCPToolAnnotations)' -count=1`
- `go test ./internal/mcpapp ./internal/mcpserver`
- `go vet ./internal/mcpapp ./internal/mcpserver`
- `go test ./...`
- `(cd cdk && go test . ./stacks)`
- `go vet ./...`
- `(cd cdk && go vet . ./stacks)`
- `gofmt -l .` (empty)
- `scripts/build.sh`
- `git diff --check`

## Stage rollout plan (handoff to deploy-body)
- [ ] Merged to main
- [ ] Deployed to lab / dev
- [ ] Lab soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
None required for Phase 3. This PR does not change SSM exports, managed-deploy artifacts, lesser REST APIs, lesser-host comm APIs, auth models, or the first-deploy order.

## Advisor-brief authorization
Not applicable; this work was directed by Aron in the active Codex session.
