### PR TITLE
feat(mcp): add prompt and resource completions

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -536,3 +536,19 @@ Prompts are reusable templates returned via MCP (`prompts/list`, `prompts/get`).
 - `compose_email`
 - `handle_inbound`
 - `respect_preferences`
+
+## Completions
+
+lesser-body advertises the MCP `completions` capability after registering AppTheory completion hooks. The
+`completion/complete` method is read-scoped, profile-aware, and intentionally static/bounded for the first release:
+
+- prompt completions suggest non-PII enum-like values such as `summarize_timeline.timeline` (`home`, `local`,
+  `federated`), prompt `tone` values, communication `channel` values, and generic `period` values.
+- resource completions support resource URI-template arguments such as `ref/resource` with
+  `uri="agent://{resource}"` and `argument.name="resource"`, returning only resource paths allowed for the caller's
+  runtime profile. Use `{uri}` / `argument.name="uri"` for full `agent://...` URI suggestions.
+- drone-profile callers do not receive souled-only communication prompt/resource suggestions. Exact souled-only prompt
+  or resource completion refs are rejected by the same runtime-boundary discipline as `prompts/get` and
+  `resources/read`; template completions filter suggestions to the caller's allowed resource set.
+- unsupported prompt/resource refs or arguments return an empty completion set rather than querying Lesser or
+  lesser-host. Completions do not call Lesser APIs and do not inspect mailbox or channel contents.

--- a/internal/mcpapp/audit.go
+++ b/internal/mcpapp/audit.go
@@ -152,6 +152,8 @@ func requiredScopesForMCPRequest(req *mcpruntime.Request) []string {
 			return nil
 		}
 		return []string{"read"}
+	case "completion/complete":
+		return []string{"read"}
 	default:
 		return nil
 	}

--- a/internal/mcpapp/completions_test.go
+++ b/internal/mcpapp/completions_test.go
@@ -1,0 +1,229 @@
+package mcpapp_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+	mcpruntime "github.com/theory-cloud/apptheory/runtime/mcp"
+	"github.com/theory-cloud/apptheory/testkit"
+
+	"github.com/equaltoai/lesser-body/internal/auth"
+	"github.com/equaltoai/lesser-body/internal/mcpapp"
+)
+
+func TestMCPCompletions_SouledPromptAndResourceSuggestions(t *testing.T) {
+	t.Setenv("MCP_SESSION_TABLE", "")
+	t.Setenv("MCP_ENDPOINT", "https://api.example.com/mcp/{actor}")
+	t.Setenv("JWT_SECRET", "test")
+	installSoulBindingLookup(t, "agent1", "0x1111111111111111111111111111111111111111111111111111111111111111")
+	auth.ResetForTests()
+
+	app, err := mcpapp.New("test", "dev")
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+	env := testkit.New()
+	authHeader := "Bearer " + newTestTokenWithAudience(t, "test", "agent1", []string{"read"}, []string{"https://api.example.com/mcp/agent1"})
+	sessionID := initializeCompletionSession(t, env, app, "/mcp/agent1", authHeader, true)
+
+	timelineValues := completionValuesFor(t, env, app, "/mcp/agent1", authHeader, sessionID, 2, map[string]any{
+		"ref":      map[string]any{"type": "ref/prompt", "name": "summarize_timeline"},
+		"argument": map[string]any{"name": "timeline", "value": "l"},
+	})
+	if !equalStrings(timelineValues, []string{"local"}) {
+		t.Fatalf("expected local timeline completion, got %#v", timelineValues)
+	}
+
+	resourceValues := completionValuesFor(t, env, app, "/mcp/agent1", authHeader, sessionID, 3, map[string]any{
+		"ref":      map[string]any{"type": "ref/resource", "uri": "agent://{resource}"},
+		"argument": map[string]any{"name": "resource", "value": "channels"},
+	})
+	if !containsString(resourceValues, "channels") || !containsString(resourceValues, "channels/preferences") {
+		t.Fatalf("expected souled channel resource completions, got %#v", resourceValues)
+	}
+}
+
+func TestMCPCompletions_DroneProfileFiltersSensitiveSuggestions(t *testing.T) {
+	t.Setenv("MCP_SESSION_TABLE", "")
+	t.Setenv("MCP_ENDPOINT", "https://api.example.com/mcp/{actor}")
+	t.Setenv("JWT_SECRET", "test")
+	installMissingSoulBindingLookup(t)
+	auth.ResetForTests()
+
+	app, err := mcpapp.New("test", "dev")
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+	env := testkit.New()
+	authHeader := "Bearer " + newTestTokenWithAudience(t, "test", "agent1", []string{"read"}, []string{"https://api.example.com/mcp/agent1"})
+	sessionID := initializeCompletionSession(t, env, app, "/mcp/agent1", authHeader, true)
+
+	promptParams, _ := json.Marshal(map[string]any{
+		"ref":      map[string]any{"type": "ref/prompt", "name": "compose_email"},
+		"argument": map[string]any{"name": "tone", "value": "f"},
+	})
+	promptResp := invokeJSONAtPath(t, env, app, "/mcp/agent1", map[string][]string{
+		"authorization":  {authHeader},
+		"mcp-session-id": {sessionID},
+	}, &mcpruntime.Request{JSONRPC: "2.0", ID: 2, Method: "completion/complete", Params: promptParams})
+	if promptResp.Status != 403 {
+		t.Fatalf("expected drone runtime boundary for compose_email completion, got status=%d body=%s", promptResp.Status, string(promptResp.Body))
+	}
+	if !strings.Contains(string(promptResp.Body), "runtime_boundary") {
+		t.Fatalf("expected runtime_boundary response, got %s", string(promptResp.Body))
+	}
+
+	resourceValues := completionValuesFor(t, env, app, "/mcp/agent1", authHeader, sessionID, 3, map[string]any{
+		"ref":      map[string]any{"type": "ref/resource", "uri": "agent://{resource}"},
+		"argument": map[string]any{"name": "resource", "value": "channels"},
+	})
+	if len(resourceValues) != 0 {
+		t.Fatalf("did not expect drone channel resource completions, got %#v", resourceValues)
+	}
+
+	timelineValues := completionValuesFor(t, env, app, "/mcp/agent1", authHeader, sessionID, 4, map[string]any{
+		"ref":      map[string]any{"type": "ref/prompt", "name": "summarize_timeline"},
+		"argument": map[string]any{"name": "timeline", "value": "h"},
+	})
+	if !equalStrings(timelineValues, []string{"home"}) {
+		t.Fatalf("expected drone-safe timeline completion, got %#v", timelineValues)
+	}
+}
+
+func TestMCPCompletions_RequireReadScope(t *testing.T) {
+	t.Setenv("MCP_SESSION_TABLE", "")
+	t.Setenv("MCP_ENDPOINT", "https://api.example.com/mcp/{actor}")
+	t.Setenv("JWT_SECRET", "test")
+	installSoulBindingLookup(t, "agent1", "0x1111111111111111111111111111111111111111111111111111111111111111")
+	auth.ResetForTests()
+
+	app, err := mcpapp.New("test", "dev")
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+	env := testkit.New()
+	authHeader := "Bearer " + newTestTokenWithAudience(t, "test", "agent1", nil, []string{"https://api.example.com/mcp/agent1"})
+	sessionID := initializeCompletionSession(t, env, app, "/mcp/agent1", authHeader, true)
+
+	params, _ := json.Marshal(map[string]any{
+		"ref":      map[string]any{"type": "ref/prompt", "name": "summarize_timeline"},
+		"argument": map[string]any{"name": "timeline", "value": "h"},
+	})
+	resp := invokeJSONAtPath(t, env, app, "/mcp/agent1", map[string][]string{
+		"authorization":  {authHeader},
+		"mcp-session-id": {sessionID},
+	}, &mcpruntime.Request{JSONRPC: "2.0", ID: 2, Method: "completion/complete", Params: params})
+	if resp.Status != 403 {
+		t.Fatalf("completion/complete: expected 403, got %d (%s)", resp.Status, string(resp.Body))
+	}
+	if got := firstHeader(resp.Headers, "www-authenticate"); !strings.Contains(got, "insufficient_scope") || !strings.Contains(got, `scope="read"`) {
+		t.Fatalf("expected insufficient_scope read challenge, got %q", got)
+	}
+}
+
+func TestMCPCompletions_UnsupportedRefsReturnNoSuggestions(t *testing.T) {
+	t.Setenv("MCP_SESSION_TABLE", "")
+	t.Setenv("MCP_ENDPOINT", "https://api.example.com/mcp/{actor}")
+	t.Setenv("JWT_SECRET", "test")
+	installSoulBindingLookup(t, "agent1", "0x1111111111111111111111111111111111111111111111111111111111111111")
+	auth.ResetForTests()
+
+	app, err := mcpapp.New("test", "dev")
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+	env := testkit.New()
+	authHeader := "Bearer " + newTestTokenWithAudience(t, "test", "agent1", []string{"read"}, []string{"https://api.example.com/mcp/agent1"})
+	sessionID := initializeCompletionSession(t, env, app, "/mcp/agent1", authHeader, true)
+
+	values := completionValuesFor(t, env, app, "/mcp/agent1", authHeader, sessionID, 2, map[string]any{
+		"ref":      map[string]any{"type": "ref/prompt", "name": "unknown_prompt"},
+		"argument": map[string]any{"name": "tone", "value": "f"},
+	})
+	if len(values) != 0 {
+		t.Fatalf("expected unsupported prompt to return no suggestions, got %#v", values)
+	}
+}
+
+func initializeCompletionSession(t testing.TB, env *testkit.Env, app *apptheory.App, path string, authHeader string, wantCompletions bool) string {
+	t.Helper()
+	params, _ := json.Marshal(map[string]any{"protocolVersion": "2025-11-25"})
+	initResp := invokeJSONAtPath(t, env, app, path, map[string][]string{
+		"authorization": {authHeader},
+	}, &mcpruntime.Request{JSONRPC: "2.0", ID: 1, Method: "initialize", Params: params})
+	if initResp.Status != 200 {
+		t.Fatalf("initialize: status=%d body=%s", initResp.Status, string(initResp.Body))
+	}
+	sessionID := initResp.Headers["mcp-session-id"][0]
+
+	var rpc mcpruntime.Response
+	if err := json.Unmarshal(initResp.Body, &rpc); err != nil {
+		t.Fatalf("unmarshal initialize: %v", err)
+	}
+	if rpc.Error != nil {
+		t.Fatalf("initialize error: %+v", rpc.Error)
+	}
+	var out struct {
+		Capabilities map[string]any `json:"capabilities"`
+	}
+	b, _ := json.Marshal(rpc.Result)
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal initialize result: %v", err)
+	}
+	_, hasCompletions := out.Capabilities["completions"]
+	if hasCompletions != wantCompletions {
+		t.Fatalf("initialize completions capability: got %v want %v in %+v", hasCompletions, wantCompletions, out.Capabilities)
+	}
+	return sessionID
+}
+
+func completionValuesFor(t testing.TB, env *testkit.Env, app *apptheory.App, path string, authHeader string, sessionID string, id int, params map[string]any) []string {
+	t.Helper()
+	rawParams, _ := json.Marshal(params)
+	resp := invokeJSONAtPath(t, env, app, path, map[string][]string{
+		"authorization":  {authHeader},
+		"mcp-session-id": {sessionID},
+	}, &mcpruntime.Request{JSONRPC: "2.0", ID: id, Method: "completion/complete", Params: rawParams})
+	if resp.Status != 200 {
+		t.Fatalf("completion/complete: status=%d body=%s", resp.Status, string(resp.Body))
+	}
+	var rpc mcpruntime.Response
+	if err := json.Unmarshal(resp.Body, &rpc); err != nil {
+		t.Fatalf("unmarshal completion/complete: %v", err)
+	}
+	if rpc.Error != nil {
+		t.Fatalf("completion/complete error: %+v", rpc.Error)
+	}
+	var out struct {
+		Completion struct {
+			Values  []string `json:"values"`
+			Total   *int     `json:"total,omitempty"`
+			HasMore *bool    `json:"hasMore,omitempty"`
+		} `json:"completion"`
+	}
+	b, _ := json.Marshal(rpc.Result)
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal completion result: %v", err)
+	}
+	if out.Completion.Total == nil || *out.Completion.Total < len(out.Completion.Values) {
+		t.Fatalf("unexpected completion total metadata: %+v", out.Completion)
+	}
+	if out.Completion.HasMore == nil {
+		t.Fatalf("expected hasMore metadata in completion result: %+v", out.Completion)
+	}
+	return out.Completion.Values
+}
+
+func equalStrings(a []string, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/mcpapp/runtime_policy.go
+++ b/internal/mcpapp/runtime_policy.go
@@ -95,6 +95,19 @@ func enforceRuntimePolicy(reqs []*mcpruntime.Request, resolved runtimepolicy.Res
 			if name != "" && !runtimepolicy.PromptAllowed(resolved.Profile, name) {
 				return runtimeBoundaryViolationResponse("prompt", name, resolved)
 			}
+		case "completion/complete":
+			if surface, name := requestedCompletionRef(req); name != "" {
+				switch surface {
+				case "prompt":
+					if !runtimepolicy.PromptAllowed(resolved.Profile, name) {
+						return runtimeBoundaryViolationResponse(surface, name, resolved)
+					}
+				case "resource":
+					if !isResourceTemplateRef(name) && !runtimepolicy.ResourceAllowed(resolved.Profile, name) {
+						return runtimeBoundaryViolationResponse(surface, name, resolved)
+					}
+				}
+			}
 		}
 	}
 
@@ -144,6 +157,29 @@ func requestedPromptName(req *mcpruntime.Request) string {
 	}
 	_ = json.Unmarshal(req.Params, &params)
 	return strings.TrimSpace(params.Name)
+}
+
+func requestedCompletionRef(req *mcpruntime.Request) (string, string) {
+	var params struct {
+		Ref struct {
+			Type string `json:"type"`
+			Name string `json:"name,omitempty"`
+			URI  string `json:"uri,omitempty"`
+		} `json:"ref"`
+	}
+	_ = json.Unmarshal(req.Params, &params)
+	switch strings.TrimSpace(params.Ref.Type) {
+	case "ref/prompt":
+		return "prompt", strings.TrimSpace(params.Ref.Name)
+	case "ref/resource":
+		return "resource", strings.TrimSpace(params.Ref.URI)
+	default:
+		return "", ""
+	}
+}
+
+func isResourceTemplateRef(uri string) bool {
+	return strings.Contains(strings.TrimSpace(uri), "{")
 }
 
 func filterRuntimeCapabilityLists(reqs []*mcpruntime.Request, batch bool, resp *apptheory.Response, profile runtimepolicy.Profile) {

--- a/internal/mcpapp/well_known.go
+++ b/internal/mcpapp/well_known.go
@@ -51,9 +51,10 @@ func WellKnownMcpHandler(srv *mcpserver.Server, name string, version string) app
 			Version:  strings.TrimSpace(version),
 			Endpoint: endpoint,
 			Capabilities: map[string]bool{
-				"tools":     true,
-				"resources": srv != nil && srv.Resources() != nil && srv.Resources().Len() > 0,
-				"prompts":   srv != nil && srv.Prompts() != nil && srv.Prompts().Len() > 0,
+				"tools":       true,
+				"resources":   srv != nil && srv.Resources() != nil && srv.Resources().Len() > 0,
+				"prompts":     srv != nil && srv.Prompts() != nil && srv.Prompts().Len() > 0,
+				"completions": true,
 			},
 			Auth: map[string]any{
 				"type":   "bearer",

--- a/internal/mcpapp/well_known_test.go
+++ b/internal/mcpapp/well_known_test.go
@@ -52,6 +52,9 @@ func TestM7_WellKnownMcpJSON(t *testing.T) {
 	if !out.Capabilities["tools"] {
 		t.Fatalf("expected capabilities.tools=true")
 	}
+	if !out.Capabilities["completions"] {
+		t.Fatalf("expected capabilities.completions=true")
+	}
 	if out.Auth.Type != "bearer" {
 		t.Fatalf("expected bearer auth hints, got %q", out.Auth.Type)
 	}

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -56,6 +56,7 @@ func buildServerOptionsFromEnv() ([]ServerOption, error) {
 			SafetyBuffer: initialSessionListenerSafetyBuffer,
 			MaxDuration:  initialSessionListenerMaxDuration,
 		}),
+		mcpruntime.WithCompletionHooks(promptCompletion, resourceCompletion),
 	}
 
 	if validator := originValidatorFromEnv(); validator != nil {
@@ -84,7 +85,7 @@ func bodyCapabilityConfig() mcpruntime.CapabilityConfig {
 		Tools:       true,
 		Resources:   true,
 		Prompts:     true,
-		Completions: false,
+		Completions: true,
 		Tasks:       false,
 	}
 }

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -148,7 +148,7 @@ func TestEchoTool(t *testing.T) {
 	}
 }
 
-func TestInitializeCapabilitiesArePinnedFailClosed(t *testing.T) {
+func TestInitializeCapabilitiesArePinnedToConfiguredSurfaces(t *testing.T) {
 	t.Setenv("MCP_SESSION_TABLE", "")
 
 	srv, err := mcpserver.New("test-server", "dev")
@@ -182,12 +182,12 @@ func TestInitializeCapabilitiesArePinnedFailClosed(t *testing.T) {
 		t.Fatalf("unmarshal initialize result: %v", err)
 	}
 
-	for _, name := range []string{"tools", "resources", "prompts"} {
+	for _, name := range []string{"tools", "resources", "prompts", "completions"} {
 		if _, ok := out.Capabilities[name]; !ok {
 			t.Fatalf("expected %q capability to remain advertised: %+v", name, out.Capabilities)
 		}
 	}
-	for _, name := range []string{"completions", "tasks", "logging"} {
+	for _, name := range []string{"tasks", "logging"} {
 		if _, ok := out.Capabilities[name]; ok {
 			t.Fatalf("did not expect fail-closed %q capability to be advertised: %+v", name, out.Capabilities)
 		}

--- a/internal/mcpserver/resources_prompts.go
+++ b/internal/mcpserver/resources_prompts.go
@@ -384,6 +384,163 @@ func resourceConfig(_ context.Context) ([]mcpruntime.ResourceContent, error) {
 	})
 }
 
+const maxCompletionValues = 20
+
+var (
+	toneCompletionValues = []string{
+		"neutral",
+		"friendly",
+		"formal",
+		"concise",
+		"playful",
+		"careful",
+	}
+	periodCompletionValues = []string{
+		"last hour",
+		"today",
+		"last day",
+		"this week",
+		"last week",
+	}
+)
+
+func promptCompletion(ctx context.Context, req mcpruntime.CompletionRequest) (*mcpruntime.CompletionResult, error) {
+	profile := completionProfile(ctx)
+	promptName := strings.TrimSpace(req.Ref.Name)
+	argumentName := strings.TrimSpace(req.Argument.Name)
+	if promptName == "" || argumentName == "" || !runtimepolicy.PromptAllowed(profile, promptName) {
+		return completionValues(nil), nil
+	}
+
+	var values []string
+	switch promptName {
+	case "compose_post":
+		switch argumentName {
+		case "tone":
+			values = toneCompletionValues
+		case "max_length":
+			values = []string{"280", "500", "1000"}
+		}
+	case "summarize_timeline":
+		switch argumentName {
+		case "timeline":
+			values = []string{"home", "local", "federated"}
+		case "period":
+			values = periodCompletionValues
+		}
+	case "draft_reply":
+		if argumentName == "tone" {
+			values = toneCompletionValues
+		}
+	case "memory_reflect":
+		if argumentName == "period" {
+			values = periodCompletionValues
+		}
+	case "compose_email":
+		if argumentName == "tone" {
+			values = toneCompletionValues
+		}
+	case "handle_inbound":
+		switch argumentName {
+		case "channel":
+			values = []string{"email", "sms", "voice"}
+		case "intent":
+			values = []string{"summarize", "reply if appropriate", "archive if no action is needed"}
+		}
+	}
+
+	return completionValues(filterCompletionValues(values, req.Argument.Value)), nil
+}
+
+func resourceCompletion(ctx context.Context, req mcpruntime.CompletionRequest) (*mcpruntime.CompletionResult, error) {
+	profile := completionProfile(ctx)
+	argumentName := strings.TrimSpace(req.Argument.Name)
+	if !supportsResourceCompletionRef(req.Ref.URI, argumentName) {
+		return completionValues(nil), nil
+	}
+
+	resources := runtimepolicy.ResourcesForProfile(profile)
+	values := make([]string, 0, len(resources))
+	for _, resource := range resources {
+		resource = strings.TrimSpace(resource)
+		if resource == "" {
+			continue
+		}
+		switch argumentName {
+		case "resource", "path":
+			values = append(values, strings.TrimPrefix(resource, "agent://"))
+		default:
+			values = append(values, resource)
+		}
+	}
+
+	return completionValues(filterCompletionValues(values, req.Argument.Value)), nil
+}
+
+func completionProfile(ctx context.Context) runtimepolicy.Profile {
+	if resolved, ok := runtimepolicy.FromContext(ctx); ok && strings.TrimSpace(string(resolved.Profile)) != "" {
+		return resolved.Profile
+	}
+	return runtimepolicy.ProfileSouled
+}
+
+func supportsResourceCompletionRef(uri string, argumentName string) bool {
+	uri = strings.TrimSpace(uri)
+	switch strings.TrimSpace(argumentName) {
+	case "uri":
+		return uri == "{uri}" || strings.Contains(uri, "{uri}")
+	case "resource":
+		return strings.Contains(uri, "{resource}")
+	case "path":
+		return strings.Contains(uri, "{path}")
+	default:
+		return false
+	}
+}
+
+func filterCompletionValues(values []string, rawPrefix string) []string {
+	prefix := strings.ToLower(strings.TrimSpace(rawPrefix))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if prefix != "" && !strings.HasPrefix(strings.ToLower(value), prefix) {
+			continue
+		}
+		out = append(out, value)
+	}
+	return out
+}
+
+func completionValues(values []string) *mcpruntime.CompletionResult {
+	if values == nil {
+		values = []string{}
+	}
+	total := len(values)
+	hasMore := false
+	if total > maxCompletionValues {
+		hasMore = true
+		values = copyCompletionValues(values[:maxCompletionValues])
+	} else {
+		values = copyCompletionValues(values)
+	}
+	return &mcpruntime.CompletionResult{
+		Completion: mcpruntime.Completion{
+			Values:  values,
+			Total:   &total,
+			HasMore: &hasMore,
+		},
+	}
+}
+
+func copyCompletionValues(values []string) []string {
+	out := make([]string, len(values))
+	copy(out, values)
+	return out
+}
+
 func promptComposePost(_ context.Context, args json.RawMessage) (*mcpruntime.PromptResult, error) {
 	var in struct {
 		Topic     string `json:"topic,omitempty"`


### PR DESCRIPTION
## Milestone
Phase 4 — Prompt and resource completions for MCP v1.6 adoption

## Classification
MCP-contract, operational-reliability, docs

## Surfaces affected
- `initialize` capability advertisement now includes `completions` once AppTheory hooks are configured.
- `completion/complete` now returns static, bounded prompt/resource suggestions.
- Scope/profile enforcement covers `completion/complete` as a read-scoped, profile-aware MCP method.
- `.well-known/mcp.json` public discovery advertises `capabilities.completions=true`.
- `docs/mcp.md` documents supported completion refs and fail-closed behavior.

## Specialist walks referenced
- Tool surface: not applicable; no tools added/removed and no tool behavior/schema/scope/profile changed.
- MCP contract: additive `completions` capability and additive `completion/complete` method behavior; no OAuth metadata change; no existing JSON-RPC envelope change; no protocol bump.
- Lesser integration: none; completion sources are static and do not call Lesser APIs.
- Host delegation: preserved; completions do not inspect mailbox/channel contents and do not call lesser-host.
- Framework: idiomatic AppTheory `mcp.WithCompletionHooks(...)`; no framework patch.

## Consumer impact
MCP clients that use completions can receive bounded suggestions for known prompt/resource-template arguments. Existing clients that ignore `completions` continue unchanged. Drone callers do not receive souled-only prompt/resource suggestions.

## Tasks
- [x] Closes #209

## Validation
- [x] `go test ./internal/mcpapp -run 'TestMCPCompletions|TestM7_WellKnownMcpJSON' -count=1 -v`
- [x] `go test ./internal/mcpserver -run 'TestInitializeCapabilities|TestEchoTool' -count=1 -v`
- [x] `go test ./internal/mcpapp ./internal/mcpserver`
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `(cd cdk && go test . ./stacks && go vet . ./stacks)`
- [x] `scripts/build.sh`
- [x] `gofmt -l .` (empty)
- [x] `git diff --check`

## Stage rollout plan (handoff to deploy-body)
- [ ] Merged to main
- [ ] Deployed to lab / dev
- [ ] Lab soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
None for this milestone. This is an additive body MCP behavior using AppTheory v1.6 hooks with static completion data.

## Advisor-brief authorization
Not applicable; this is Aron-directed roadmap execution.
