### PR TITLE
feat(cdk): prepare mcp task storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ hardcoded bearer-token client configs are deprecated compatibility paths; see `d
 - **SSM-first cross-stack wiring** (no CloudFormation exports/imports)
 - **Auth + scope enforcement** (`read|write|admin`) for tool calls
 - **Optional DynamoDB-backed MCP sessions** for production continuity
+- **Prepared MCP task storage** behind a disabled public `tasks` capability for a future read-only task pilot
 
 ## Quick Start
 

--- a/cdk/stacks/lesser_body_stack_shared.go
+++ b/cdk/stacks/lesser_body_stack_shared.go
@@ -32,6 +32,7 @@ type lesserBodyRuntimeProps struct {
 const (
 	mcpSessionTableLogicalID = "McpServerSessionTable469EA0FB"
 	mcpStreamTableLogicalID  = "McpServerStreamTableC6A2DC7E"
+	mcpTaskTableLogicalID    = "McpServerTaskTable72DDFBBB"
 )
 
 func configureLesserBodyStack(stack awscdk.Stack, props *lesserBodyRuntimeProps) {
@@ -130,6 +131,9 @@ func configureLesserBodyStack(stack awscdk.Stack, props *lesserBodyRuntimeProps)
 		EnableStreamTable:  jsii.Bool(true),
 		StreamTableName:    tokenJoin("-", props.AppName, props.Stage, jsii.String("mcp"), jsii.String("streams"), jsii.String("v2")),
 		StreamTtlMinutes:   jsii.Number(60),
+		EnableTaskTable:    jsii.Bool(true),
+		TaskTableName:      tokenJoin("-", props.AppName, props.Stage, jsii.String("mcp"), jsii.String("tasks")),
+		TaskTtlMinutes:     jsii.Number(10),
 		Stage: &apptheorycdk.AppTheoryRestApiRouterStageOptions{
 			StageName:          props.Stage,
 			AccessLogging:      true,
@@ -160,6 +164,7 @@ func configureLesserBodyStack(stack awscdk.Stack, props *lesserBodyRuntimeProps)
 	server := apptheorycdk.NewAppTheoryRemoteMcpServer(stack, jsii.String("McpServer"), mcpProps)
 	overrideRemoteMcpTableLogicalID(server.SessionTable(), mcpSessionTableLogicalID)
 	overrideRemoteMcpTableLogicalID(server.StreamTable(), mcpStreamTableLogicalID)
+	overrideRemoteMcpTableLogicalID(server.TaskTable(), mcpTaskTableLogicalID)
 
 	handler.AddEnvironment(jsii.String("MCP_ENDPOINT"), props.PublicEndpoint, nil)
 	if props.LesserAPIBaseURL != nil && *props.LesserAPIBaseURL != "" {

--- a/cdk/stacks/lesser_body_stack_shared_test.go
+++ b/cdk/stacks/lesser_body_stack_shared_test.go
@@ -289,6 +289,7 @@ func TestManagedDeployTemplatePinsMcpTableLogicalIDs(t *testing.T) {
 	want := []string{
 		"McpServerSessionTable469EA0FB",
 		"McpServerStreamTableC6A2DC7E",
+		"McpServerTaskTable72DDFBBB",
 	}
 	if mustJSON(t, got) != mustJSON(t, want) {
 		t.Fatalf("unexpected managed DynamoDB logical IDs: got=%s want=%s", mustJSON(t, got), mustJSON(t, want))
@@ -389,6 +390,83 @@ func TestLesserBodyUsesAppTheoryDurableStreamTableSchema(t *testing.T) {
 	}
 }
 
+func TestLesserBodyProvisionsInternalMcpTaskStorageWithoutExport(t *testing.T) {
+	assetDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(assetDir, "bootstrap"), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write bootstrap: %v", err)
+	}
+
+	template := synthTemplate(t, "TestStack", func(app awscdk.App) {
+		stack := awscdk.NewStack(app, jsii.String("TestStack"), &awscdk.StackProps{
+			Env: &awscdk.Environment{
+				Account: jsii.String("123456789012"),
+				Region:  jsii.String("us-east-1"),
+			},
+		})
+
+		configureLesserBodyStack(stack, &lesserBodyRuntimeProps{
+			AppName:               jsii.String("theory"),
+			Stage:                 jsii.String("dev"),
+			Code:                  awslambda.Code_FromAsset(jsii.String(assetDir), nil),
+			ServiceVersion:        jsii.String("test"),
+			PublicEndpoint:        jsii.String("https://api.dev.example.com/mcp/{actor}"),
+			LesserAPIBaseURL:      jsii.String("https://api.dev.example.com"),
+			AllowedOrigins:        jsii.String("https://claude.ai"),
+			JWTSecretArnParamPath: jsii.String("/theory/shared/secrets/jwt-secret-arn"),
+			JWTSecretKeyParamPath: jsii.String("/theory/shared/kms/encryption-key-arn"),
+			LesserTableParamPath:  jsii.String("/theory/dev/lesser/exports/v1/table_name"),
+		})
+	})
+
+	resources := mustResources(t, template)
+	taskTable := findDynamoTableByName(t, resources, "theory-dev-mcp-tasks")
+	props, ok := taskTable["Properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("task table missing Properties")
+	}
+
+	keySchema, ok := props["KeySchema"].([]any)
+	if !ok {
+		t.Fatalf("task table missing KeySchema")
+	}
+	if len(keySchema) != 2 {
+		t.Fatalf("expected task table hash/range keys, got %d", len(keySchema))
+	}
+	if !strings.Contains(mustJSON(t, keySchema[0]), `"AttributeName":"sessionId"`) {
+		t.Fatalf("expected task table hash key sessionId, got %s", mustJSON(t, keySchema[0]))
+	}
+	if !strings.Contains(mustJSON(t, keySchema[1]), `"AttributeName":"taskId"`) {
+		t.Fatalf("expected task table range key taskId, got %s", mustJSON(t, keySchema[1]))
+	}
+	if got := dynamoTableTTLAttribute(t, "McpServerTaskTable72DDFBBB", props); got != "expiresAt" {
+		t.Fatalf("expected task table TTL attribute expiresAt, got %q", got)
+	}
+
+	lambda := mcpHandlerLambdaFunction(t, resources)
+	lambdaProps, ok := lambda["Properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("lambda missing Properties")
+	}
+	env, ok := lambdaProps["Environment"].(map[string]any)
+	if !ok {
+		t.Fatalf("lambda missing Environment")
+	}
+	vars, ok := env["Variables"].(map[string]any)
+	if !ok {
+		t.Fatalf("lambda missing Environment.Variables")
+	}
+	if got := mustJSON(t, vars["MCP_TASK_TABLE"]); got != `{"Ref":"McpServerTaskTable72DDFBBB"}` {
+		t.Fatalf("expected MCP_TASK_TABLE to ref task table, got %s", got)
+	}
+	if got, ok := vars["MCP_TASK_TTL_MINUTES"].(string); !ok || got != "10" {
+		t.Fatalf("expected MCP_TASK_TTL_MINUTES=10, got %#v", vars["MCP_TASK_TTL_MINUTES"])
+	}
+
+	if hasSSMParameterByName(resources, "/theory/dev/lesser-body/exports/v1/mcp_task_table_name") {
+		t.Fatalf("task table is intentionally internal in Phase 5; did not expect an SSM export")
+	}
+}
+
 func TestLesserBodyRemoteMcpServerUsesActorPathWiring(t *testing.T) {
 	assetDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(assetDir, "bootstrap"), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
@@ -486,6 +564,13 @@ func TestLesserBodyNamedMcpTableFingerprints(t *testing.T) {
 			TableName:    "theory-dev-mcp-streams-v2",
 			PartitionKey: "sessionId",
 			SortKey:      "eventId",
+			TTLAttribute: "expiresAt",
+		},
+		{
+			LogicalID:    "McpServerTaskTable72DDFBBB",
+			TableName:    "theory-dev-mcp-tasks",
+			PartitionKey: "sessionId",
+			SortKey:      "taskId",
 			TTLAttribute: "expiresAt",
 		},
 	}
@@ -693,6 +778,20 @@ func findDynamoTableByName(t *testing.T, resources map[string]any, tableName str
 func findSSMParameterByName(t *testing.T, resources map[string]any, paramName string) map[string]any {
 	t.Helper()
 
+	if resource, ok := ssmParameterByName(resources, paramName); ok {
+		return resource
+	}
+
+	t.Fatalf("template missing AWS::SSM::Parameter %q", paramName)
+	return nil
+}
+
+func hasSSMParameterByName(resources map[string]any, paramName string) bool {
+	_, ok := ssmParameterByName(resources, paramName)
+	return ok
+}
+
+func ssmParameterByName(resources map[string]any, paramName string) (map[string]any, bool) {
 	for _, raw := range resources {
 		resource, ok := raw.(map[string]any)
 		if !ok {
@@ -706,12 +805,11 @@ func findSSMParameterByName(t *testing.T, resources map[string]any, paramName st
 			continue
 		}
 		if got, _ := props["Name"].(string); got == paramName {
-			return resource
+			return resource, true
 		}
 	}
 
-	t.Fatalf("template missing AWS::SSM::Parameter %q", paramName)
-	return nil
+	return nil, false
 }
 
 func findStreamSpillBucket(t *testing.T, resources map[string]any) map[string]any {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -72,10 +72,21 @@ Variables:
 - `MCP_STREAM_MAX_EVENT_BYTES` (string, optional)
   - Hard maximum size for one logical MCP stream event before AppTheory fails the event closed. CDK deployments use
     AppTheory's default `10485760`.
+- `MCP_TASK_TABLE` (string, optional)
+  - If set by CDK, names the DynamoDB table prepared for AppTheory's MCP task runtime state. As of the current
+    deployment shape, this is **storage readiness only**: lesser-body does not wire `mcp.WithTaskRuntime(...)`, does not
+    advertise the MCP `tasks` capability, and does not serve `tasks/*` methods.
+- `MCP_TASK_TTL_MINUTES` (string, optional)
+  - Default MCP task lifetime in minutes for the future task runtime. CDK deployments set `10` so task state remains
+    short-lived and does not outlive the session persistence window.
 
 `MCP_STREAM_TTL_MINUTES` is the runtime replay window: AppTheory rejects expired stream event records before reading
 inline or S3-spilled payloads. DynamoDB TTL and S3 lifecycle cleanup are best-effort cleanup backstops, not access
 enforcement.
+
+`MCP_TASK_TABLE` follows the same readiness pattern: AppTheory's CDK construct provisions the canonical
+`sessionId`/`taskId`/`expiresAt` table and injects env vars, but MCP task capability advertisement still requires a
+future application-code change that wires an explicit task runtime and marks selected read-only tools as task-capable.
 
 ### Endpoints
 
@@ -161,3 +172,7 @@ Published by this repo’s CDK stack:
   - Session table name (if provisioned).
 - `/<app>/<stage>/lesser-body/exports/v1/mcp_stream_table_name`
   - Stream table used for MCP streaming state.
+
+The MCP task table is intentionally internal while the `tasks` capability is disabled. The current CDK stack does not
+publish `/<app>/<stage>/lesser-body/exports/v1/mcp_task_table_name`; adding that SSM export would be a separate
+lesser/host coordination point.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -25,6 +25,7 @@ This repo’s CDK stack deploys:
 - (Recommended) DynamoDB session table for MCP sessions
 - DynamoDB stream table for MCP streaming state
 - Private S3 stream-spill bucket for large logical MCP stream events
+- DynamoDB task table for future MCP task runtime state, with the `tasks` capability still disabled
 - SSM exports used by the Lesser stack to wire routes
 
 Notes:
@@ -51,6 +52,10 @@ And it publishes these (consumed by Lesser when `soulEnabled=true`):
 
 The stream-spill bucket is internal to body's AppTheory-backed MCP transport. It is not an SSM export and does not
 change the public MCP endpoint contract; clients still resume by logical `Last-Event-ID`.
+
+The MCP task table is also internal in the current release shape. It prepares storage for a future task-runtime phase,
+but lesser-body does not advertise `tasks`, does not serve `tasks/*` methods, and does not publish an
+`mcp_task_table_name` SSM export.
 
 ## Deploy order (avoid the “missing SSM param” trap)
 
@@ -147,6 +152,9 @@ Notes:
 - The corrected MCP stream-table baseline is a versioned physical table (`...-mcp-streams-v2`) while the exported SSM
   parameter name remains `mcp_stream_table_name`. Existing durable Lesser actor data is preserved; only transient MCP
   session/stream state may reset during the update.
+- The MCP task table baseline is `...-mcp-tasks` with a 10-minute TTL. It is transient readiness state for a later
+  task-runtime rollout and remains outside the managed SSM export contract until there is a concrete lesser/host
+  consumer.
 
 See `docs/managed-deploy-contract.md` for the full release contract.
 
@@ -158,6 +166,9 @@ After deploy, confirm exports exist:
 aws ssm get-parameter --name "/<app>/<stage>/lesser-body/exports/v1/mcp_lambda_arn"
 aws ssm get-parameter --name "/<app>/<stage>/lesser-body/exports/v1/mcp_endpoint_url"
 ```
+
+Do not expect an `mcp_task_table_name` export in this phase; the task table remains an internal AppTheory runtime asset
+while the public MCP `tasks` capability is disabled.
 
 ## Verify (HTTP)
 

--- a/docs/managed-deploy-contract.md
+++ b/docs/managed-deploy-contract.md
@@ -186,8 +186,10 @@ Managed templates treat the MCP DynamoDB tables as an explicit compatibility bou
 
 - session table logical ID: `McpServerSessionTable469EA0FB`
 - stream table logical ID: `McpServerStreamTableC6A2DC7E`
+- task table logical ID: `McpServerTaskTable72DDFBBB`
 - session table physical-name suffix: `mcp-sessions`
 - stream table physical-name suffix: `mcp-streams-v2`
+- task table physical-name suffix: `mcp-tasks`
 
 The stream table is transient MCP transport state, not durable agent identity or long-term memory. The published SSM
 export name remains stable at `mcp_stream_table_name` even though the corrected physical stream-table baseline is the
@@ -200,6 +202,12 @@ not part of the SSM export contract; managed consumers should treat it as intern
 runtime enforces `MCP_STREAM_TTL_MINUTES` before reading inline or spilled payload data, while DynamoDB TTL and S3
 lifecycle cleanup remain cleanup backstops.
 
+The task table is transient MCP runtime readiness state. Managed templates provision the canonical AppTheory task schema
+(`sessionId` hash key, `taskId` range key, `expiresAt` TTL), grant the MCP Lambda access through the AppTheory construct,
+and inject `MCP_TASK_TABLE` plus `MCP_TASK_TTL_MINUTES=10`. This does **not** enable the public MCP `tasks` capability:
+body does not wire `mcp.WithTaskRuntime(...)` or mark any tool task-capable in this phase. The task table is intentionally
+not exported through SSM until there is a concrete lesser/host managed-deploy consumer for that name.
+
 ## Published exports
 
 On deploy, `lesser-body` writes these SSM parameters:
@@ -210,6 +218,8 @@ On deploy, `lesser-body` writes these SSM parameters:
 - `/<app>/<stage>/lesser-body/exports/v1/mcp_stream_table_name`
 
 Managed consumers can rely on those names as the stable exported surface of the `lesser-body` stack.
+
+No `mcp_task_table_name` export is published in the current managed contract.
 
 ## MCP-facing expectations
 
@@ -253,7 +263,9 @@ That verification fails if:
 - a checksum does not match
 - a managed template contains a non-string `Parameters.*.Default`
 - a managed template drifts the pinned MCP session/stream table logical IDs
+- a managed template drifts the pinned MCP task table logical ID
 - a managed template drifts the versioned MCP stream-table name baseline (`mcp-streams-v2`)
+- a managed template omits the internal MCP task table or its Lambda environment variables
 - a managed template omits the stream-spill bucket or spill-related Lambda environment variables while stream storage is
   enabled
 - a template regresses to CDK asset/bootstrap assumptions

--- a/docs/managed-deploy-inventory.md
+++ b/docs/managed-deploy-inventory.md
@@ -76,6 +76,8 @@ These are deterministic artifacts produced once at release time and then consume
 - the Lambda zip for `cmd/lesser-body`
 - auxiliary AppTheory/CDK file assets required by release-produced templates
 - stage-specific deploy templates that can provision the stack without a source checkout
+- AppTheory Remote MCP storage assets, including the session table, durable stream table/spill bucket, and the internal
+  task table prepared for a future task runtime
 - machine-readable metadata describing the deploy asset contract
 - checksums that let consumers verify every published deploy asset automatically
 - documentation describing the managed deploy contract and exported SSM values
@@ -90,6 +92,10 @@ still needed:
 - a stable description of the SSM exports that the stack writes
 - a no-source deployment entrypoint
 - checksums and schema details for the deploy-specific artifacts
+
+The managed template now also pins the internal MCP task-table baseline (`McpServerTaskTable72DDFBBB`,
+`...-mcp-tasks`, `MCP_TASK_TTL_MINUTES=10`). That table is a release-time infrastructure artifact but not a new
+managed-consumer input or SSM export while the MCP `tasks` capability remains disabled.
 
 That gap was closed by `#91`, and `#98` tightened the remaining producer-side blind spots by requiring checksum coverage
 for `lesser-body-release.json` and verifying the checksum-root descriptor embedded in the canonical manifest.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -155,6 +155,11 @@ AppTheory’s MCP server implements:
 - `resources/read`
 - `prompts/list`
 - `prompts/get`
+- `completion/complete`
+
+AppTheory task storage is provisioned in the CDK stack for runtime readiness, but lesser-body does not yet wire an MCP
+task runtime. `initialize` must not advertise `tasks`, and `tasks/list`, `tasks/get`, `tasks/result`, and
+`tasks/cancel` continue to fail closed as unsupported methods until a later, read-only task pilot is explicitly enabled.
 
 For streamed responses, body preserves the MCP client's logical SSE contract. AppTheory's durable stream store keeps the
 event id / replay index in DynamoDB and, when needed, spills large logical event payloads to the private stream-spill S3

--- a/docs/release.md
+++ b/docs/release.md
@@ -39,11 +39,17 @@ The current managed-template baseline also pins the named MCP DynamoDB resources
 
 - session table logical ID: `McpServerSessionTable469EA0FB`
 - stream table logical ID: `McpServerStreamTableC6A2DC7E`
+- task table logical ID: `McpServerTaskTable72DDFBBB`
 - stream table physical-name suffix: `mcp-streams-v2`
+- task table physical-name suffix: `mcp-tasks`
 
 That stream-table reset is a one-time lab-era infrastructure correction. The table stores transient MCP stream/session
 transport state, so active sessions may reset during rollout, but durable Lesser actor data remains in Lesser's own
 table.
+
+The task table is transient MCP runtime-readiness state. Managed templates inject `MCP_TASK_TABLE` and
+`MCP_TASK_TTL_MINUTES=10`, but body does not advertise or serve MCP `tasks` until a later task-runtime milestone wires
+an explicit AppTheory task runtime and task-capable read-only tool.
 
 Verify the produced release directory:
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -108,6 +108,8 @@ At a minimum, the MCP Lambda needs:
 - DynamoDB read/write on the MCP stream table and S3 read/write on the private MCP stream-spill bucket when durable
   stream replay is enabled. The spill bucket holds transient MCP transport payloads only; AppTheory enforces stream TTL
   before reading spilled data.
+- DynamoDB read/write on the MCP task table when task storage is provisioned. This is transient runtime-readiness state;
+  the public MCP `tasks` capability remains disabled until body explicitly wires AppTheory's task runtime.
 - `ssm:GetParameter*` to read cross-stack parameters (Lesser exports, optional lesser-soul exports)
 
 ## Client considerations

--- a/internal/mcpapp/well_known_test.go
+++ b/internal/mcpapp/well_known_test.go
@@ -15,6 +15,7 @@ import (
 
 func TestM7_WellKnownMcpJSON(t *testing.T) {
 	t.Setenv("MCP_SESSION_TABLE", "")
+	t.Setenv("MCP_TASK_TABLE", "theory-dev-mcp-tasks")
 	t.Setenv("MCP_ENDPOINT", "https://api.example.com/mcp")
 
 	app, err := mcpapp.New("test", "dev")
@@ -54,6 +55,9 @@ func TestM7_WellKnownMcpJSON(t *testing.T) {
 	}
 	if !out.Capabilities["completions"] {
 		t.Fatalf("expected capabilities.completions=true")
+	}
+	if out.Capabilities["tasks"] {
+		t.Fatalf("task storage readiness must not advertise capabilities.tasks")
 	}
 	if out.Auth.Type != "bearer" {
 		t.Fatalf("expected bearer auth hints, got %q", out.Auth.Type)

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -86,7 +86,10 @@ func bodyCapabilityConfig() mcpruntime.CapabilityConfig {
 		Resources:   true,
 		Prompts:     true,
 		Completions: true,
-		Tasks:       false,
+		// Phase 5 provisions MCP task storage in CDK, but body must not advertise
+		// or serve tasks until Phase 6 wires an explicit TaskRuntime and a
+		// read-only task-capable tool.
+		Tasks: false,
 	}
 }
 

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -197,6 +197,59 @@ func TestInitializeCapabilitiesArePinnedToConfiguredSurfaces(t *testing.T) {
 	assertNoUnsupportedSubCapabilities(t, "prompts", out.Capabilities["prompts"])
 }
 
+func TestTaskStorageEnvDoesNotEnableTaskCapability(t *testing.T) {
+	t.Setenv("MCP_SESSION_TABLE", "")
+	t.Setenv("MCP_STREAM_TABLE", "")
+	t.Setenv("MCP_TASK_TABLE", "theory-dev-mcp-tasks")
+	t.Setenv("MCP_TASK_TTL_MINUTES", "10")
+
+	srv, err := mcpserver.New("test-server", "dev")
+	if err != nil {
+		t.Fatalf("new server: %v", err)
+	}
+
+	env := testkit.New()
+	app := env.App()
+	app.Post("/mcp", srv.Handler())
+
+	params, _ := json.Marshal(map[string]any{"protocolVersion": "2025-11-25"})
+	initResp, sessionID := invokeRPC(t, env, app, "", &mcpruntime.Request{
+		JSONRPC: "2.0",
+		ID:      "init-with-task-env",
+		Method:  "initialize",
+		Params:  params,
+	})
+	if initResp.Error != nil {
+		t.Fatalf("initialize error: %+v", initResp.Error)
+	}
+	if sessionID == "" {
+		t.Fatalf("expected initialize to issue a session id")
+	}
+
+	b, err := json.Marshal(initResp.Result)
+	if err != nil {
+		t.Fatalf("marshal initialize result: %v", err)
+	}
+	var out struct {
+		Capabilities map[string]any `json:"capabilities"`
+	}
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal initialize result: %v", err)
+	}
+	if _, ok := out.Capabilities["tasks"]; ok {
+		t.Fatalf("MCP_TASK_TABLE must not advertise tasks without explicit runtime wiring: %+v", out.Capabilities)
+	}
+
+	listResp, _ := invokeRPC(t, env, app, sessionID, &mcpruntime.Request{
+		JSONRPC: "2.0",
+		ID:      "tasks-list-with-task-env",
+		Method:  "tasks/list",
+	})
+	if listResp.Error == nil || listResp.Error.Code != mcpruntime.CodeMethodNotFound {
+		t.Fatalf("expected tasks/list to fail closed without task runtime, got %+v", listResp.Error)
+	}
+}
+
 func assertNoUnsupportedSubCapabilities(t testing.TB, name string, raw any) {
 	t.Helper()
 	capability, ok := raw.(map[string]any)

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -54,6 +54,17 @@ func TestEchoTool(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new server: %v", err)
 	}
+	for _, tool := range srv.Registry().List() {
+		if tool.Execution == nil {
+			continue
+		}
+		switch tool.Execution.TaskSupport {
+		case "", mcpruntime.TaskSupportForbidden:
+			continue
+		default:
+			t.Fatalf("tool %q must not advertise task support in storage-readiness phase: %+v", tool.Name, tool.Execution)
+		}
+	}
 
 	env := testkit.New()
 	app := env.App()
@@ -240,13 +251,15 @@ func TestTaskStorageEnvDoesNotEnableTaskCapability(t *testing.T) {
 		t.Fatalf("MCP_TASK_TABLE must not advertise tasks without explicit runtime wiring: %+v", out.Capabilities)
 	}
 
-	listResp, _ := invokeRPC(t, env, app, sessionID, &mcpruntime.Request{
-		JSONRPC: "2.0",
-		ID:      "tasks-list-with-task-env",
-		Method:  "tasks/list",
-	})
-	if listResp.Error == nil || listResp.Error.Code != mcpruntime.CodeMethodNotFound {
-		t.Fatalf("expected tasks/list to fail closed without task runtime, got %+v", listResp.Error)
+	for _, method := range []string{"tasks/list", "tasks/get", "tasks/result", "tasks/cancel"} {
+		resp, _ := invokeRPC(t, env, app, sessionID, &mcpruntime.Request{
+			JSONRPC: "2.0",
+			ID:      method + "-with-task-env",
+			Method:  method,
+		})
+		if resp.Error == nil || resp.Error.Code != mcpruntime.CodeMethodNotFound {
+			t.Fatalf("expected %s to fail closed without task runtime, got %+v", method, resp.Error)
+		}
 	}
 }
 

--- a/scripts/check_managed_template_named_resource_regression.sh
+++ b/scripts/check_managed_template_named_resource_regression.sh
@@ -94,6 +94,42 @@ if ! grep -Fq 'lesser-body-managed-dev.template.json: McpServerStreamTableC6A2DC
   exit 1
 fi
 
+TASK_LOGICAL_ID_DIR="${TMP_DIR}/release-bad-task-logical-id"
+cp -R "${SOURCE_DIR}" "${TASK_LOGICAL_ID_DIR}"
+
+python3 - "${TASK_LOGICAL_ID_DIR}/lesser-body-managed-dev.template.json" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+template = json.loads(path.read_text())
+resources = template["Resources"]
+resources["BrokenTaskTable12345678"] = resources.pop("McpServerTaskTable72DDFBBB")
+env = next(
+    resource["Properties"]["Environment"]["Variables"]
+    for resource in resources.values()
+    if resource.get("Type") == "AWS::Lambda::Function"
+    and resource.get("Properties", {}).get("Handler") == "bootstrap"
+)
+env["MCP_TASK_TABLE"] = {"Ref": "BrokenTaskTable12345678"}
+path.write_text(json.dumps(template, indent=2) + "\n")
+PY
+
+refresh_release_metadata "${TASK_LOGICAL_ID_DIR}"
+
+TASK_LOGICAL_ID_ERR="${TMP_DIR}/verify-task-logical-id.err"
+if bash "${ROOT_DIR}/scripts/verify_release_assets.sh" "${VERSION}" "${TASK_LOGICAL_ID_DIR}" > /dev/null 2> "${TASK_LOGICAL_ID_ERR}"; then
+  echo "verify_release_assets.sh unexpectedly accepted a managed template with a drifted task table logical ID" >&2
+  exit 1
+fi
+
+if ! grep -Fq 'lesser-body-managed-dev.template.json: missing expected resource McpServerTaskTable72DDFBBB' "${TASK_LOGICAL_ID_ERR}"; then
+  echo "verify_release_assets.sh did not report the expected task-table logical-ID regression" >&2
+  cat "${TASK_LOGICAL_ID_ERR}" >&2
+  exit 1
+fi
+
 SPILL_BUCKET_DIR="${TMP_DIR}/release-missing-stream-spill-bucket"
 cp -R "${SOURCE_DIR}" "${SPILL_BUCKET_DIR}"
 
@@ -125,4 +161,4 @@ if ! grep -Fq 'lesser-body-managed-dev.template.json: expected exactly one strea
   exit 1
 fi
 
-echo "Regression confirmed: verifier rejects MCP named-resource, table-name, and stream-spill drift"
+echo "Regression confirmed: verifier rejects MCP named-resource, table-name, task-storage, and stream-spill drift"

--- a/scripts/verify_release_assets.sh
+++ b/scripts/verify_release_assets.sh
@@ -262,6 +262,10 @@ expected_named_tables = {
         "type": "AWS::DynamoDB::Table",
         "table_name_contains": "mcp-streams-v2",
     },
+    "McpServerTaskTable72DDFBBB": {
+        "type": "AWS::DynamoDB::Table",
+        "table_name_contains": "mcp-tasks",
+    },
 }
 expected_export_refs = {
     "McpSessionTableParam11A03692": {
@@ -281,6 +285,10 @@ expected_spill_env = {
     "MCP_STREAM_SPILL_PREFIX",
     "MCP_STREAM_SPILL_INLINE_MAX_BYTES",
     "MCP_STREAM_MAX_EVENT_BYTES",
+}
+expected_task_env = {
+    "MCP_TASK_TABLE": {"Ref": "McpServerTaskTable72DDFBBB"},
+    "MCP_TASK_TTL_MINUTES": "10",
 }
 
 for stage in ("dev", "staging", "live"):
@@ -400,6 +408,9 @@ for stage in ("dev", "staging", "live"):
                 err(f"{stage_path.name}: MCP handler missing stream-spill env vars {missing_env}")
             elif spill_logical_id is not None and env.get("MCP_STREAM_SPILL_BUCKET") != {"Ref": spill_logical_id}:
                 err(f"{stage_path.name}: MCP_STREAM_SPILL_BUCKET must Ref {spill_logical_id}, got {env.get('MCP_STREAM_SPILL_BUCKET')!r}")
+            for key, expected_value in expected_task_env.items():
+                if env.get(key) != expected_value:
+                    err(f"{stage_path.name}: {key} must equal {expected_value!r}, got {env.get(key)!r}")
 
     declared_aux_params = set(aux_by_param)
     for logical_id, resource in resources.items():


### PR DESCRIPTION
## Milestone
Phase 5 — prepare task runtime infrastructure behind disabled capability flags.

Closes #210.

## Classification
MCP-contract, lesser-integration, operational-reliability, managed-deploy verification, docs.

## Surfaces affected
- `cdk/`: AppTheory Remote MCP task table provisioning and stable managed-template logical ID.
- `internal/mcpserver/`: explicit task-disabled capability boundary and regression coverage.
- `internal/mcpapp/`: public discovery regression coverage for no `tasks` advertisement.
- `scripts/`: managed release verifier and named-resource regression harness.
- `docs/` + `README.md`: operator/managed-release/task-readiness documentation.

## Specialist walks referenced
- Tool surface: none in this phase; no tool declares task support and static registration is unchanged.
- MCP contract: guarded as non-advertised readiness only; `initialize` still omits `tasks` and `tasks/*` remains method-not-found.
- Lesser integration: no SSM export names, values, `/v1/` segment, `soulEnabled`, JWT, Lesser DynamoDB, or Lesser REST API changes. The task table is intentionally internal.
- Host delegation / managed deploy: no manifest schema, helper input, auxiliary asset, or exported SSM contract changes; managed templates now include the internal task table and verifier coverage.
- Framework: idiomatic AppTheory v1.6 `EnableTaskTable` / `TaskTableName` / `TaskTtlMinutes` consumption; no local framework patch.

## Consumer impact
- MCP clients: no public capability change. `/.well-known/mcp.json` and `initialize` still do not advertise `tasks`.
- Operators: CDK/managed deploy provisions a transient `...-mcp-tasks` table with `MCP_TASK_TTL_MINUTES=10` for future readiness.
- Lesser: no required change; existing SSM exports remain unchanged and no `mcp_task_table_name` export is published.
- lesser-host managed deploy: release templates contain one additional internal DynamoDB task table, but deploy inputs/manifest schema/export names remain unchanged.

## Tasks
- [x] #210 Prepare task runtime infrastructure behind disabled capability

## Validation
- `go test ./internal/mcpserver -run 'TestInitializeCapabilitiesArePinnedToConfiguredSurfaces|TestTaskStorageEnvDoesNotEnableTaskCapability' -count=1 -v`
- after pre-review hardening: `go test ./internal/mcpserver -run TestTaskStorageEnvDoesNotEnableTaskCapability -count=1 -v`
- `(cd cdk && go test ./stacks -run 'TestManagedDeployTemplatePinsMcpTableLogicalIDs|TestLesserBodyProvisionsInternalMcpTaskStorageWithoutExport|TestLesserBodyNamedMcpTableFingerprints' -count=1 -v)`
- `go test ./internal/mcpapp -run TestM7_WellKnownMcpJSON -count=1 -v`
- `(cd cdk && go test . ./stacks)`
- `go test ./...`
- `go vet ./...`
- `(cd cdk && go vet . ./stacks)`
- `test -z "$(gofmt -l .)"`
- `git diff --check`
- `scripts/build.sh`
- `(cd cdk && CDK_DEFAULT_ACCOUNT=000000000000 CDK_DEFAULT_REGION=us-east-1 npx cdk synth -c app=lesser -c stage=dev -c baseDomain=example.com)`
- `rm -rf dist/release-test && bash scripts/build_release_assets.sh v0.0.0-test dist/release-test && bash scripts/verify_release_assets.sh v0.0.0-test dist/release-test && bash scripts/check_managed_template_named_resource_regression.sh v0.0.0-test dist/release-test`

## Stage rollout plan (handoff to deploy-body)
- [ ] Merged to main
- [ ] Deployed to lab / dev
- [ ] Lab soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
No sibling repo code changes are required for this phase. The lesser-facing SSM export contract remains unchanged; host-facing release manifest/helper inputs remain unchanged. Arch review is requested before proceeding to Phase 6.

## Advisor-brief authorization
Not applicable; this work is Aron-directed, not advisor-dispatched.
