### PR TITLE
feat(mcp): pilot task-backed read execution

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -73,20 +73,19 @@ Variables:
   - Hard maximum size for one logical MCP stream event before AppTheory fails the event closed. CDK deployments use
     AppTheory's default `10485760`.
 - `MCP_TASK_TABLE` (string, optional)
-  - If set by CDK, names the DynamoDB table prepared for AppTheory's MCP task runtime state. As of the current
-    deployment shape, this is **storage readiness only**: lesser-body does not wire `mcp.WithTaskRuntime(...)`, does not
-    advertise the MCP `tasks` capability, and does not serve `tasks/*` methods.
+  - If set by CDK, names the DynamoDB table used by AppTheory's MCP task runtime. Setting it wires
+    `mcp.WithTaskRuntime(...)`, advertises the MCP `tasks` capability for MCP 2025-11-25 sessions, and enables the
+    read-only `skill_bundle_get` task pilot. Leave it unset to fail closed with no task capability.
 - `MCP_TASK_TTL_MINUTES` (string, optional)
-  - Default MCP task lifetime in minutes for the future task runtime. CDK deployments set `10` so task state remains
-    short-lived and does not outlive the session persistence window.
+  - Default MCP task lifetime in minutes. CDK deployments set `10` so task state remains short-lived and does not
+    outlive the session persistence window; body also caps caller-requested task TTLs at one hour.
 
 `MCP_STREAM_TTL_MINUTES` is the runtime replay window: AppTheory rejects expired stream event records before reading
 inline or S3-spilled payloads. DynamoDB TTL and S3 lifecycle cleanup are best-effort cleanup backstops, not access
 enforcement.
 
-`MCP_TASK_TABLE` follows the same readiness pattern: AppTheory's CDK construct provisions the canonical
-`sessionId`/`taskId`/`expiresAt` table and injects env vars, but MCP task capability advertisement still requires a
-future application-code change that wires an explicit task runtime and marks selected read-only tools as task-capable.
+`MCP_TASK_TABLE` enables AppTheory's task runtime over the canonical `sessionId`/`taskId`/`expiresAt` table. Body uses
+that runtime only for the current read-only `skill_bundle_get` pilot; task state remains transient and session-scoped.
 
 ### Endpoints
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -53,9 +53,9 @@ And it publishes these (consumed by Lesser when `soulEnabled=true`):
 The stream-spill bucket is internal to body's AppTheory-backed MCP transport. It is not an SSM export and does not
 change the public MCP endpoint contract; clients still resume by logical `Last-Event-ID`.
 
-The MCP task table is also internal in the current release shape. It prepares storage for a future task-runtime phase,
-but lesser-body does not advertise `tasks`, does not serve `tasks/*` methods, and does not publish an
-`mcp_task_table_name` SSM export.
+The MCP task table is also internal in the current release shape. When `MCP_TASK_TABLE` is configured, it backs
+AppTheory's task runtime for the read-only `skill_bundle_get` task pilot and the public MCP `tasks` capability for
+2025-11-25 sessions. It still does not publish an `mcp_task_table_name` SSM export.
 
 ## Deploy order (avoid the “missing SSM param” trap)
 
@@ -152,9 +152,9 @@ Notes:
 - The corrected MCP stream-table baseline is a versioned physical table (`...-mcp-streams-v2`) while the exported SSM
   parameter name remains `mcp_stream_table_name`. Existing durable Lesser actor data is preserved; only transient MCP
   session/stream state may reset during the update.
-- The MCP task table baseline is `...-mcp-tasks` with a 10-minute TTL. It is transient readiness state for a later
-  task-runtime rollout and remains outside the managed SSM export contract until there is a concrete lesser/host
-  consumer.
+- The MCP task table baseline is `...-mcp-tasks` with a 10-minute TTL. It is transient state for the read-only
+  `skill_bundle_get` task pilot and remains outside the managed SSM export contract until there is a concrete
+  lesser/host consumer.
 
 See `docs/managed-deploy-contract.md` for the full release contract.
 

--- a/docs/managed-deploy-contract.md
+++ b/docs/managed-deploy-contract.md
@@ -202,11 +202,11 @@ not part of the SSM export contract; managed consumers should treat it as intern
 runtime enforces `MCP_STREAM_TTL_MINUTES` before reading inline or spilled payload data, while DynamoDB TTL and S3
 lifecycle cleanup remain cleanup backstops.
 
-The task table is transient MCP runtime readiness state. Managed templates provision the canonical AppTheory task schema
+The task table is transient MCP task runtime state. Managed templates provision the canonical AppTheory task schema
 (`sessionId` hash key, `taskId` range key, `expiresAt` TTL), grant the MCP Lambda access through the AppTheory construct,
-and inject `MCP_TASK_TABLE` plus `MCP_TASK_TTL_MINUTES=10`. This does **not** enable the public MCP `tasks` capability:
-body does not wire `mcp.WithTaskRuntime(...)` or mark any tool task-capable in this phase. The task table is intentionally
-not exported through SSM until there is a concrete lesser/host managed-deploy consumer for that name.
+and inject `MCP_TASK_TABLE` plus `MCP_TASK_TTL_MINUTES=10`. That environment enables the public MCP `tasks` capability
+for MCP 2025-11-25 sessions and the read-only `skill_bundle_get` task pilot. The task table is intentionally not exported
+through SSM until there is a concrete lesser/host managed-deploy consumer for that name.
 
 ## Published exports
 

--- a/docs/managed-deploy-inventory.md
+++ b/docs/managed-deploy-inventory.md
@@ -77,7 +77,7 @@ These are deterministic artifacts produced once at release time and then consume
 - auxiliary AppTheory/CDK file assets required by release-produced templates
 - stage-specific deploy templates that can provision the stack without a source checkout
 - AppTheory Remote MCP storage assets, including the session table, durable stream table/spill bucket, and the internal
-  task table prepared for a future task runtime
+  task table used by the read-only `skill_bundle_get` task pilot
 - machine-readable metadata describing the deploy asset contract
 - checksums that let consumers verify every published deploy asset automatically
 - documentation describing the managed deploy contract and exported SSM values

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -156,10 +156,16 @@ AppTheory’s MCP server implements:
 - `prompts/list`
 - `prompts/get`
 - `completion/complete`
+- `tasks/list` (when `MCP_TASK_TABLE` enables the task runtime)
+- `tasks/get` (when `MCP_TASK_TABLE` enables the task runtime)
+- `tasks/result` (when `MCP_TASK_TABLE` enables the task runtime)
+- `tasks/cancel` (when `MCP_TASK_TABLE` enables the task runtime)
 
-AppTheory task storage is provisioned in the CDK stack for runtime readiness, but lesser-body does not yet wire an MCP
-task runtime. `initialize` must not advertise `tasks`, and `tasks/list`, `tasks/get`, `tasks/result`, and
-`tasks/cancel` continue to fail closed as unsupported methods until a later, read-only task pilot is explicitly enabled.
+Task support is an additive MCP 2025-11-25 pilot. When `MCP_TASK_TABLE` is configured, body wires AppTheory’s
+`TaskRuntime`, `initialize` advertises the `tasks` capability for 2025-11-25 sessions, and `skill_bundle_get` declares
+optional task execution. Existing synchronous `tools/call` behavior remains supported. Deployments without
+`MCP_TASK_TABLE` omit the `tasks` capability, do not mark `skill_bundle_get` task-capable, and `tasks/*` methods fail
+closed as unsupported.
 
 For streamed responses, body preserves the MCP client's logical SSE contract. AppTheory's durable stream store keeps the
 event id / replay index in DynamoDB and, when needed, spills large logical event payloads to the private stream-spill S3
@@ -310,7 +316,7 @@ Scope key:
 | `memory_append` | Write | Append a memory event to the authenticated agent's memory timeline. |
 | `memory_query` | Read | Query memory events for the authenticated agent. |
 | `skills_catalog` | Read | List approved skill bundles from Lesser's authoritative skills catalog, preserving bundle digests, provenance, install hints, and exposure metadata. |
-| `skill_bundle_get` | Read | Fetch a selected approved Lesser skill bundle and optionally report local install-state verification from caller-supplied local file bytes. |
+| `skill_bundle_get` | Read | Fetch a selected approved Lesser skill bundle and optionally report local install-state verification from caller-supplied local file bytes. When `MCP_TASK_TABLE` is configured, this read-only tool also supports optional task-backed execution. |
 | `email_send` | Write | Send a new email through lesser-host on behalf of the authenticated soul agent; use `email_reply` for mailbox replies. |
 | `email_read` | Read | List email metadata/previews from lesser-host's canonical Soul Comm Mailbox. |
 | `email_get` | Read | Get email metadata/state by opaque host `messageId`/`messageRef`. |
@@ -541,6 +547,46 @@ Prompts are reusable templates returned via MCP (`prompts/list`, `prompts/get`).
 - `compose_email`
 - `handle_inbound`
 - `respect_preferences`
+
+
+## Tasks
+
+lesser-body uses AppTheory’s MCP task runtime for a narrow read-only pilot when task storage is configured:
+
+- Runtime gate: `MCP_TASK_TABLE` must be set. The CDK stack provisions the short-lived DynamoDB task table and injects
+  `MCP_TASK_TTL_MINUTES=10`.
+- Protocol gate: AppTheory advertises tasks only for negotiated MCP protocol `2025-11-25`; older sessions keep the
+  existing method set.
+- Tool gate: only `skill_bundle_get` is task-capable in the pilot, and its support is `optional`, so synchronous
+  `tools/call` remains valid.
+- Scope gate: `tasks/list`, `tasks/get`, `tasks/result`, and `tasks/cancel` require `read` scope. `tasks/cancel` is
+  read-scoped because it only cancels session-scoped work created for the read-only pilot tool.
+- Session gate: task state is keyed by MCP session id. A task created in one `mcp-session-id` cannot be read, listed,
+  result-fetched, or canceled from another session.
+- TTL bounds: the deployment default is 10 minutes (`MCP_TASK_TTL_MINUTES=10`) and body caps requested task TTLs at one
+  hour. DynamoDB TTL is cleanup; AppTheory enforces task lookup/session scoping before returning state.
+
+Example task-backed `skill_bundle_get` request:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "bundle-task-1",
+  "method": "tools/call",
+  "params": {
+    "name": "skill_bundle_get",
+    "arguments": {
+      "skill_id": "skill-a",
+      "revision_number": 1
+    },
+    "task": { "ttl": 30000 }
+  }
+}
+```
+
+The immediate response contains a task id. Poll `tasks/get` for status, call `tasks/result` for the final tool result,
+or call `tasks/cancel` to cancel in-flight work. Task audit logs include method, task id, identity, and request id only;
+body does not log tool arguments or task results.
 
 ## Completions
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -47,9 +47,9 @@ That stream-table reset is a one-time lab-era infrastructure correction. The tab
 transport state, so active sessions may reset during rollout, but durable Lesser actor data remains in Lesser's own
 table.
 
-The task table is transient MCP runtime-readiness state. Managed templates inject `MCP_TASK_TABLE` and
-`MCP_TASK_TTL_MINUTES=10`, but body does not advertise or serve MCP `tasks` until a later task-runtime milestone wires
-an explicit AppTheory task runtime and task-capable read-only tool.
+The task table is transient MCP task runtime state. Managed templates inject `MCP_TASK_TABLE` and
+`MCP_TASK_TTL_MINUTES=10`; body advertises MCP `tasks` for MCP 2025-11-25 sessions and enables optional task-backed
+execution only for the read-only `skill_bundle_get` pilot.
 
 Verify the produced release directory:
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -30,14 +30,16 @@ This doc describes the implemented security posture of `lesser-body`.
 
 ### Scope enforcement (MCP calls)
 
-JWT callers are authorized by scope on `tools/call`, `resources/read`, and `prompts/get`:
+JWT callers are authorized by scope on `tools/call`, `resources/read`, `prompts/get`, `completion/complete`, and
+MCP task methods:
 
-- `admin`: all tools
-- `write`: write tools + read tools
-- `read`: read tools only
+- `admin`: all tools and task methods
+- `write`: write tools + read tools + task methods
+- `read`: read tools and task methods only
 
-Data-bearing resources and prompts require at least `read` scope. Tool-specific write operations require `write`
-scope (or `admin`).
+Data-bearing resources, prompts, completions, and task methods require at least `read` scope. Tool-specific write
+operations require `write` scope (or `admin`). `tasks/cancel` remains read-scoped because the Phase 6 task pilot only
+cancels session-scoped execution of the read-only `skill_bundle_get` tool.
 
 Write tools include:
 
@@ -60,8 +62,11 @@ remain the long-term inbound client auth model.
 - request id
 - authenticated identity (agent username or `instance`)
 - tool name
+- whether task-backed execution was requested
 
-It does not log bearer tokens or tool arguments by default.
+It also logs MCP task method invocations (`tasks/list`, `tasks/get`, `tasks/result`, `tasks/cancel`) with request id,
+identity, method, and task id when present. It does not log bearer tokens, tool arguments, task request bodies, task
+results, or communication payloads by default.
 
 ## Private soul self-scope reads
 
@@ -108,8 +113,9 @@ At a minimum, the MCP Lambda needs:
 - DynamoDB read/write on the MCP stream table and S3 read/write on the private MCP stream-spill bucket when durable
   stream replay is enabled. The spill bucket holds transient MCP transport payloads only; AppTheory enforces stream TTL
   before reading spilled data.
-- DynamoDB read/write on the MCP task table when task storage is provisioned. This is transient runtime-readiness state;
-  the public MCP `tasks` capability remains disabled until body explicitly wires AppTheory's task runtime.
+- DynamoDB read/write on the MCP task table when task storage is provisioned. This is transient task runtime state used
+  for session-scoped MCP task records; body advertises the MCP `tasks` capability only when `MCP_TASK_TABLE` is set and
+  the read-only `skill_bundle_get` task pilot is registered.
 - `ssm:GetParameter*` to read cross-stack parameters (Lesser exports, optional lesser-soul exports)
 
 ## Client considerations

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -225,6 +225,35 @@ Fix:
 - Always call `initialize` first and store the returned `mcp-session-id`.
 - Enable session table in infra (recommended for production).
 
+## MCP tasks are missing, inaccessible, or stuck
+
+Symptoms:
+
+- `initialize` does not include a `tasks` capability.
+- `tasks/list`, `tasks/get`, `tasks/result`, or `tasks/cancel` returns method-not-found.
+- `tools/call` with a `task` object returns an invalid params error.
+- A task created from `skill_bundle_get` cannot be read from a later request.
+
+Common causes:
+
+- `MCP_TASK_TABLE` is unset, so body intentionally omits the task runtime and task-capable tool metadata.
+- The client negotiated an MCP protocol version older than `2025-11-25`; AppTheory gates task methods to that protocol.
+- The caller token lacks `read` scope. Task methods are read-scoped and return an OAuth insufficient-scope challenge when
+  the token has only unrelated scopes such as `follow`.
+- The client is using a different `mcp-session-id` than the one that created the task. Task state is session-scoped.
+- The requested task TTL is outside body's bounds. CDK sets a 10-minute default (`MCP_TASK_TTL_MINUTES=10`), and body
+  caps requested task TTLs at one hour.
+
+Fix:
+
+- Confirm the Lambda environment includes `MCP_TASK_TABLE` and `MCP_TASK_TTL_MINUTES=10`.
+- Negotiate MCP protocol `2025-11-25`, then call `initialize` and inspect `capabilities.tasks`.
+- Preserve the returned `mcp-session-id` and send it on every `tools/call` / `tasks/*` request.
+- Request a token with `read` (or `write` / `admin`) scope.
+- Use task-backed execution only for `skill_bundle_get` during the pilot; other tools continue to reject task metadata.
+- If `tasks/result` waits longer than expected, check whether the Lesser skills-bundle endpoint is slow or unavailable and
+  use `tasks/cancel` to cancel the in-flight read.
+
 ## CDK deploy fails: missing SSM parameters
 
 Symptoms:

--- a/internal/mcpapp/audit.go
+++ b/internal/mcpapp/audit.go
@@ -154,6 +154,8 @@ func requiredScopesForMCPRequest(req *mcpruntime.Request) []string {
 		return []string{"read"}
 	case "completion/complete":
 		return []string{"read"}
+	case "tasks/list", "tasks/get", "tasks/result", "tasks/cancel":
+		return []string{"read"}
 	default:
 		return nil
 	}
@@ -217,18 +219,41 @@ func auditMcpRequest(logger *slog.Logger, requestID string, identity string, req
 		return
 	}
 
-	if req.Method != "tools/call" {
-		return
-	}
+	switch req.Method {
+	case "tools/call":
+		var params struct {
+			Name string           `json:"name"`
+			Task *json.RawMessage `json:"task,omitempty"`
+		}
+		_ = json.Unmarshal(req.Params, &params)
 
+		logger.Info("mcp tool call",
+			"request_id", requestID,
+			"identity", identity,
+			"tool", strings.TrimSpace(params.Name),
+			"task_requested", taskMetadataPresent(params.Task),
+		)
+	case "tasks/list", "tasks/get", "tasks/result", "tasks/cancel":
+		logger.Info("mcp task method",
+			"request_id", requestID,
+			"identity", identity,
+			"method", req.Method,
+			"task_id", taskIDFromParams(req.Params),
+		)
+	}
+}
+
+func taskMetadataPresent(raw *json.RawMessage) bool {
+	if raw == nil {
+		return false
+	}
+	return strings.TrimSpace(string(*raw)) != "" && strings.TrimSpace(string(*raw)) != "null"
+}
+
+func taskIDFromParams(raw json.RawMessage) string {
 	var params struct {
-		Name string `json:"name"`
+		TaskID string `json:"taskId"`
 	}
-	_ = json.Unmarshal(req.Params, &params)
-
-	logger.Info("mcp tool call",
-		"request_id", requestID,
-		"identity", identity,
-		"tool", strings.TrimSpace(params.Name),
-	)
+	_ = json.Unmarshal(raw, &params)
+	return strings.TrimSpace(params.TaskID)
 }

--- a/internal/mcpapp/audit_task_test.go
+++ b/internal/mcpapp/audit_task_test.go
@@ -1,0 +1,74 @@
+package mcpapp
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+
+	mcpruntime "github.com/theory-cloud/apptheory/runtime/mcp"
+)
+
+func TestTaskMethodsRequireReadScope(t *testing.T) {
+	for _, method := range []string{"tasks/list", "tasks/get", "tasks/result", "tasks/cancel"} {
+		t.Run(method, func(t *testing.T) {
+			req := &mcpruntime.Request{JSONRPC: "2.0", ID: method, Method: method}
+			if method != "tasks/list" {
+				req.Params = mustRawForAuditTest(t, map[string]any{"taskId": "task-1"})
+			}
+			got := requiredScopesForMCPRequest(req)
+			if len(got) != 1 || got[0] != "read" {
+				t.Fatalf("expected read scope for %s, got %#v", method, got)
+			}
+		})
+	}
+}
+
+func TestAuditMcpRequestLogsTaskMetadataWithoutArguments(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+
+	auditMcpRequest(logger, "req-1", "agent1", &mcpruntime.Request{
+		JSONRPC: "2.0",
+		ID:      "tool-task",
+		Method:  "tools/call",
+		Params: mustRawForAuditTest(t, map[string]any{
+			"name":      "skill_bundle_get",
+			"arguments": map[string]any{"skill_id": "secret-skill"},
+			"task":      map[string]any{"ttl": 30_000},
+		}),
+	})
+	logged := buf.String()
+	for _, want := range []string{`"msg":"mcp tool call"`, `"tool":"skill_bundle_get"`, `"task_requested":true`} {
+		if !strings.Contains(logged, want) {
+			t.Fatalf("expected audit log to contain %s, got %s", want, logged)
+		}
+	}
+	if strings.Contains(logged, "secret-skill") || strings.Contains(logged, "30000") {
+		t.Fatalf("audit log must not include tool arguments or task metadata body, got %s", logged)
+	}
+
+	buf.Reset()
+	auditMcpRequest(logger, "req-2", "agent1", &mcpruntime.Request{
+		JSONRPC: "2.0",
+		ID:      "task-get",
+		Method:  "tasks/get",
+		Params:  mustRawForAuditTest(t, map[string]any{"taskId": "task-1"}),
+	})
+	logged = buf.String()
+	for _, want := range []string{`"msg":"mcp task method"`, `"method":"tasks/get"`, `"task_id":"task-1"`} {
+		if !strings.Contains(logged, want) {
+			t.Fatalf("expected task audit log to contain %s, got %s", want, logged)
+		}
+	}
+}
+
+func mustRawForAuditTest(t testing.TB, v any) json.RawMessage {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return b
+}

--- a/internal/mcpapp/tasks_auth_test.go
+++ b/internal/mcpapp/tasks_auth_test.go
@@ -1,0 +1,81 @@
+package mcpapp_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	mcpruntime "github.com/theory-cloud/apptheory/runtime/mcp"
+	"github.com/theory-cloud/apptheory/testkit"
+
+	"github.com/equaltoai/lesser-body/internal/auth"
+	"github.com/equaltoai/lesser-body/internal/mcpapp"
+)
+
+func TestMcpAuth_TaskMethodsRequireReadScope(t *testing.T) {
+	t.Setenv("MCP_SESSION_TABLE", "")
+	t.Setenv("MCP_STREAM_TABLE", "")
+	t.Setenv("MCP_TASK_TABLE", "")
+	t.Setenv("MCP_ENDPOINT", "https://api.example.com/mcp/{actor}")
+	t.Setenv("JWT_SECRET", "test")
+	auth.ResetForTests()
+
+	token := newTestTokenWithAudience(t, "test", "agent1", []string{"follow"}, []string{"https://api.example.com/mcp/agent1"})
+	app, err := mcpapp.New("test", "dev")
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+	env := testkit.New()
+	authHeaders := map[string][]string{"authorization": {"Bearer " + token}}
+
+	initResp := invokeJSON(t, env, app, authHeaders, &mcpruntime.Request{JSONRPC: "2.0", ID: "init", Method: "initialize"})
+	if initResp.Status != 200 {
+		t.Fatalf("initialize: status=%d body=%s", initResp.Status, string(initResp.Body))
+	}
+	sessionID := firstHeader(initResp.Headers, "mcp-session-id")
+	if sessionID == "" {
+		t.Fatal("expected mcp-session-id")
+	}
+
+	for _, method := range []string{"tasks/list", "tasks/get", "tasks/result", "tasks/cancel"} {
+		t.Run(method, func(t *testing.T) {
+			req := &mcpruntime.Request{JSONRPC: "2.0", ID: method, Method: method}
+			if method != "tasks/list" {
+				req.Params = mustRawTaskAuthTest(t, map[string]any{"taskId": "task-1"})
+			}
+			resp := invokeJSON(t, env, app, map[string][]string{
+				"authorization":  {"Bearer " + token},
+				"mcp-session-id": {sessionID},
+			}, req)
+			if resp.Status != 403 {
+				t.Fatalf("expected 403 for %s, got %d (%s)", method, resp.Status, string(resp.Body))
+			}
+			if got := firstHeader(resp.Headers, "www-authenticate"); got != `Bearer error="insufficient_scope", resource_metadata="https://api.example.com/.well-known/oauth-protected-resource/mcp/agent1", scope="follow read", error_description="Additional read permission required"` {
+				t.Fatalf("unexpected WWW-Authenticate header: %q", got)
+			}
+			var out struct {
+				Error struct {
+					Code    string `json:"code"`
+					Details struct {
+						Reason         string   `json:"reason"`
+						RequiredScopes []string `json:"requiredScopes"`
+					} `json:"details"`
+				} `json:"error"`
+			}
+			if err := json.Unmarshal(resp.Body, &out); err != nil {
+				t.Fatalf("unmarshal %s error body: %v", method, err)
+			}
+			if out.Error.Code != "app.forbidden" || out.Error.Details.Reason != "insufficient_scope" || len(out.Error.Details.RequiredScopes) != 1 || out.Error.Details.RequiredScopes[0] != "read" {
+				t.Fatalf("unexpected insufficient-scope body for %s: %+v", method, out)
+			}
+		})
+	}
+}
+
+func mustRawTaskAuthTest(t testing.TB, v any) json.RawMessage {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return b
+}

--- a/internal/mcpapp/well_known.go
+++ b/internal/mcpapp/well_known.go
@@ -63,6 +63,9 @@ func WellKnownMcpHandler(srv *mcpserver.Server, name string, version string) app
 			},
 			RuntimeProfiles: runtimepolicy.Contracts(),
 		}
+		if mcpserver.TasksPublicDiscoveryEnabled(srv) {
+			doc.Capabilities["tasks"] = true
+		}
 
 		if srv != nil && srv.Registry() != nil {
 			for _, tool := range srv.Registry().List() {

--- a/internal/mcpapp/well_known_test.go
+++ b/internal/mcpapp/well_known_test.go
@@ -15,7 +15,9 @@ import (
 
 func TestM7_WellKnownMcpJSON(t *testing.T) {
 	t.Setenv("MCP_SESSION_TABLE", "")
+	t.Setenv("MCP_STREAM_TABLE", "")
 	t.Setenv("MCP_TASK_TABLE", "theory-dev-mcp-tasks")
+	t.Setenv("AWS_REGION", "us-east-1")
 	t.Setenv("MCP_ENDPOINT", "https://api.example.com/mcp")
 
 	app, err := mcpapp.New("test", "dev")
@@ -56,8 +58,8 @@ func TestM7_WellKnownMcpJSON(t *testing.T) {
 	if !out.Capabilities["completions"] {
 		t.Fatalf("expected capabilities.completions=true")
 	}
-	if out.Capabilities["tasks"] {
-		t.Fatalf("task storage readiness must not advertise capabilities.tasks")
+	if !out.Capabilities["tasks"] {
+		t.Fatalf("expected task pilot runtime to advertise capabilities.tasks")
 	}
 	if out.Auth.Type != "bearer" {
 		t.Fatalf("expected bearer auth hints, got %q", out.Auth.Type)

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -18,15 +18,21 @@ const (
 	envMcpAllowedOrigins = "MCP_ALLOWED_ORIGINS"
 	envMcpSessionTable   = "MCP_SESSION_TABLE"
 	envMcpStreamTable    = "MCP_STREAM_TABLE"
+	envMcpTaskTable      = "MCP_TASK_TABLE"
 
 	initialSessionListenerSafetyBuffer = 5 * time.Second
 	initialSessionListenerMaxDuration  = 25 * time.Second
+	taskRuntimeMaxTTL                  = time.Hour
 )
 
 var newMCPDB = func() (tablecore.DB, error) {
 	return tabletheory.NewBasic(session.Config{
 		Region: os.Getenv("AWS_REGION"),
 	})
+}
+
+var newMCPTaskStore = func(db tablecore.DB) mcpruntime.TaskStore {
+	return mcpruntime.NewDynamoTaskStore(db)
 }
 
 func New(name, version string) (*Server, error) {
@@ -63,7 +69,7 @@ func buildServerOptionsFromEnv() ([]ServerOption, error) {
 		opts = append(opts, mcpruntime.WithOriginValidator(validator))
 	}
 
-	if os.Getenv(envMcpSessionTable) != "" || os.Getenv(envMcpStreamTable) != "" {
+	if os.Getenv(envMcpSessionTable) != "" || os.Getenv(envMcpStreamTable) != "" || TaskRuntimeConfiguredFromEnv() {
 		db, err := newMCPDB()
 		if err != nil {
 			return nil, fmt.Errorf("create tabletheory client: %w", err)
@@ -74,6 +80,12 @@ func buildServerOptionsFromEnv() ([]ServerOption, error) {
 		}
 		if os.Getenv(envMcpStreamTable) != "" {
 			opts = append(opts, mcpruntime.WithStreamStore(mcpruntime.NewDynamoStreamStore(db)))
+		}
+		if TaskRuntimeConfiguredFromEnv() {
+			opts = append(opts, mcpruntime.WithTaskRuntime(mcpruntime.TaskRuntimeOptions{
+				Store:  newMCPTaskStore(db),
+				MaxTTL: taskRuntimeMaxTTL,
+			}))
 		}
 	}
 
@@ -86,11 +98,32 @@ func bodyCapabilityConfig() mcpruntime.CapabilityConfig {
 		Resources:   true,
 		Prompts:     true,
 		Completions: true,
-		// Phase 5 provisions MCP task storage in CDK, but body must not advertise
-		// or serve tasks until Phase 6 wires an explicit TaskRuntime and a
-		// read-only task-capable tool.
-		Tasks: false,
+		// AppTheory still requires an explicit TaskRuntime and at least one
+		// task-capable tool before initialize advertises tasks. Enabling the
+		// surface here lets deployments with MCP_TASK_TABLE opt into the Phase 6
+		// read-only task pilot while deployments without task storage fail closed.
+		Tasks: true,
 	}
+}
+
+func TaskRuntimeConfiguredFromEnv() bool {
+	return strings.TrimSpace(os.Getenv(envMcpTaskTable)) != ""
+}
+
+func TasksPublicDiscoveryEnabled(srv *Server) bool {
+	if !TaskRuntimeConfiguredFromEnv() || srv == nil || srv.Registry() == nil {
+		return false
+	}
+	for _, tool := range srv.Registry().List() {
+		if tool.Execution == nil {
+			continue
+		}
+		switch tool.Execution.TaskSupport {
+		case mcpruntime.TaskSupportOptional, mcpruntime.TaskSupportRequired:
+			return true
+		}
+	}
+	return false
 }
 
 func originValidatorFromEnv() mcpruntime.OriginValidator {

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -62,7 +62,7 @@ func TestEchoTool(t *testing.T) {
 		case "", mcpruntime.TaskSupportForbidden:
 			continue
 		default:
-			t.Fatalf("tool %q must not advertise task support in storage-readiness phase: %+v", tool.Name, tool.Execution)
+			t.Fatalf("tool %q must not advertise task support without MCP_TASK_TABLE: %+v", tool.Name, tool.Execution)
 		}
 	}
 
@@ -206,61 +206,6 @@ func TestInitializeCapabilitiesArePinnedToConfiguredSurfaces(t *testing.T) {
 	assertNoUnsupportedSubCapabilities(t, "tools", out.Capabilities["tools"])
 	assertNoUnsupportedSubCapabilities(t, "resources", out.Capabilities["resources"])
 	assertNoUnsupportedSubCapabilities(t, "prompts", out.Capabilities["prompts"])
-}
-
-func TestTaskStorageEnvDoesNotEnableTaskCapability(t *testing.T) {
-	t.Setenv("MCP_SESSION_TABLE", "")
-	t.Setenv("MCP_STREAM_TABLE", "")
-	t.Setenv("MCP_TASK_TABLE", "theory-dev-mcp-tasks")
-	t.Setenv("MCP_TASK_TTL_MINUTES", "10")
-
-	srv, err := mcpserver.New("test-server", "dev")
-	if err != nil {
-		t.Fatalf("new server: %v", err)
-	}
-
-	env := testkit.New()
-	app := env.App()
-	app.Post("/mcp", srv.Handler())
-
-	params, _ := json.Marshal(map[string]any{"protocolVersion": "2025-11-25"})
-	initResp, sessionID := invokeRPC(t, env, app, "", &mcpruntime.Request{
-		JSONRPC: "2.0",
-		ID:      "init-with-task-env",
-		Method:  "initialize",
-		Params:  params,
-	})
-	if initResp.Error != nil {
-		t.Fatalf("initialize error: %+v", initResp.Error)
-	}
-	if sessionID == "" {
-		t.Fatalf("expected initialize to issue a session id")
-	}
-
-	b, err := json.Marshal(initResp.Result)
-	if err != nil {
-		t.Fatalf("marshal initialize result: %v", err)
-	}
-	var out struct {
-		Capabilities map[string]any `json:"capabilities"`
-	}
-	if err := json.Unmarshal(b, &out); err != nil {
-		t.Fatalf("unmarshal initialize result: %v", err)
-	}
-	if _, ok := out.Capabilities["tasks"]; ok {
-		t.Fatalf("MCP_TASK_TABLE must not advertise tasks without explicit runtime wiring: %+v", out.Capabilities)
-	}
-
-	for _, method := range []string{"tasks/list", "tasks/get", "tasks/result", "tasks/cancel"} {
-		resp, _ := invokeRPC(t, env, app, sessionID, &mcpruntime.Request{
-			JSONRPC: "2.0",
-			ID:      method + "-with-task-env",
-			Method:  method,
-		})
-		if resp.Error == nil || resp.Error.Code != mcpruntime.CodeMethodNotFound {
-			t.Fatalf("expected %s to fail closed without task runtime, got %+v", method, resp.Error)
-		}
-	}
 }
 
 func assertNoUnsupportedSubCapabilities(t testing.TB, name string, raw any) {

--- a/internal/mcpserver/skills_tools.go
+++ b/internal/mcpserver/skills_tools.go
@@ -116,7 +116,7 @@ func skillsCatalogDef() mcpruntime.ToolDef {
 }
 
 func skillBundleGetDef() mcpruntime.ToolDef {
-	return mcpruntime.ToolDef{
+	def := mcpruntime.ToolDef{
 		Name:         "skill_bundle_get",
 		Description:  "Fetch a selected approved Lesser skill bundle and optionally compare caller-supplied local file bytes to the published digests.",
 		Annotations:  readOnlyToolAnnotations(),
@@ -144,6 +144,10 @@ func skillBundleGetDef() mcpruntime.ToolDef {
 			}
 		}`),
 	}
+	if TaskRuntimeConfiguredFromEnv() {
+		def.Execution = &mcpruntime.ToolExecution{TaskSupport: mcpruntime.TaskSupportOptional}
+	}
+	return def
 }
 
 func handleSkillsCatalog(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {

--- a/internal/mcpserver/task_runtime_test.go
+++ b/internal/mcpserver/task_runtime_test.go
@@ -1,0 +1,407 @@
+package mcpserver
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/equaltoai/lesser-body/internal/auth"
+	"github.com/equaltoai/lesser-body/internal/lesserapi"
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+	mcpruntime "github.com/theory-cloud/apptheory/runtime/mcp"
+	"github.com/theory-cloud/apptheory/testkit"
+	tablecore "github.com/theory-cloud/tabletheory/pkg/core"
+)
+
+func TestTaskRuntimeEnvEnablesSkillBundleGetTaskExecution(t *testing.T) {
+	store := installMemoryTaskRuntimeForTest(t)
+	t.Setenv(envMcpSessionTable, "")
+	t.Setenv(envMcpStreamTable, "")
+	t.Setenv(envMcpTaskTable, "theory-dev-mcp-tasks")
+	t.Setenv("MCP_TASK_TTL_MINUTES", "10")
+
+	authSeen := make(chan string, 1)
+	lesser := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case authSeen <- r.Header.Get("Authorization"):
+		default:
+		}
+		if r.Method != http.MethodGet || r.URL.Path != "/api/v1/skills/skill-a/revisions/1/bundle" {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":"not found"}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"bundle":{"schema_version":"lesser.skill.bundle.v1","bundle_id":"skill:skill-a:revision:00000001","digests":{"bundle_digest":"sha256:bundle","publication_digest":"sha256:publication"},"files":[{"path":"SKILL.md","digest":"sha256:file","content_included":false}]}}`))
+	}))
+	defer lesser.Close()
+	t.Setenv("LESSER_API_BASE_URL", lesser.URL)
+	lesserapi.ResetForTests()
+
+	srv, err := New("test-server", "dev")
+	if err != nil {
+		t.Fatalf("new server: %v", err)
+	}
+	if !TasksPublicDiscoveryEnabled(srv) {
+		t.Fatalf("expected task public discovery to be enabled when task runtime and task-capable tool are configured")
+	}
+
+	env := testkit.New()
+	app := env.App()
+	app.Post("/mcp", srv.Handler())
+	ctx := taskToolContext()
+
+	initResp, sessionID := invokeTaskRPC(t, ctx, env, app, "", &mcpruntime.Request{
+		JSONRPC: "2.0",
+		ID:      "init-task-runtime",
+		Method:  "initialize",
+		Params:  mustJSONRaw(t, map[string]any{"protocolVersion": "2025-11-25"}),
+	})
+	if initResp.Error != nil {
+		t.Fatalf("initialize error: %+v", initResp.Error)
+	}
+	if sessionID == "" {
+		t.Fatalf("expected initialize to issue a session id")
+	}
+	assertInitializeAdvertisesTasks(t, initResp)
+
+	toolsResp, _ := invokeTaskRPC(t, ctx, env, app, sessionID, &mcpruntime.Request{JSONRPC: "2.0", ID: "tools-list", Method: "tools/list"})
+	if toolsResp.Error != nil {
+		t.Fatalf("tools/list error: %+v", toolsResp.Error)
+	}
+	assertSkillBundleGetTaskSupport(t, toolsResp)
+
+	createParams := mustJSONRaw(t, map[string]any{
+		"name": "skill_bundle_get",
+		"arguments": map[string]any{
+			"skill_id":        "skill-a",
+			"revision_number": 1,
+			"include_content": false,
+			"local_files":     []any{},
+		},
+		"task": map[string]any{"ttl": int64(30_000)},
+	})
+	createResp, _ := invokeTaskRPC(t, ctx, env, app, sessionID, &mcpruntime.Request{JSONRPC: "2.0", ID: "create-task", Method: "tools/call", Params: createParams})
+	if createResp.Error != nil {
+		t.Fatalf("tools/call task create error: %+v", createResp.Error)
+	}
+	created := decodeCreateTaskResult(t, createResp.Result)
+	if created.Task.TaskID == "" || created.Task.Status != mcpruntime.TaskStatusWorking {
+		t.Fatalf("unexpected created task: %+v", created.Task)
+	}
+	record := waitForTaskStatus(t, store, sessionID, created.Task.TaskID, mcpruntime.TaskStatusCompleted)
+	if record.ToolName != "skill_bundle_get" || record.Method != "tools/call" || len(record.Result) == 0 {
+		t.Fatalf("unexpected stored task record: %+v", record)
+	}
+	select {
+	case gotAuth := <-authSeen:
+		if gotAuth != "Bearer task-test-token" {
+			t.Fatalf("task-backed skill_bundle_get should preserve caller bearer, got %q", gotAuth)
+		}
+	default:
+		t.Fatalf("task-backed skill_bundle_get did not call Lesser")
+	}
+
+	getResp, _ := invokeTaskRPC(t, ctx, env, app, sessionID, taskRequest("get-task", "tasks/get", created.Task.TaskID))
+	if getResp.Error != nil {
+		t.Fatalf("tasks/get error: %+v", getResp.Error)
+	}
+	gotTask := decodeTask(t, getResp.Result)
+	if gotTask.TaskID != created.Task.TaskID || gotTask.Status != mcpruntime.TaskStatusCompleted {
+		t.Fatalf("unexpected tasks/get result: %+v", gotTask)
+	}
+
+	resultResp, _ := invokeTaskRPC(t, ctx, env, app, sessionID, taskRequest("result-task", "tasks/result", created.Task.TaskID))
+	if resultResp.Error != nil {
+		t.Fatalf("tasks/result error: %+v", resultResp.Error)
+	}
+	resultBytes, _ := json.Marshal(resultResp.Result)
+	if !json.Valid(resultBytes) || !containsJSON(resultBytes, "skill:skill-a:revision:00000001") || !containsJSON(resultBytes, "io.modelcontextprotocol/related-task") {
+		t.Fatalf("expected skill bundle task result with related-task metadata, got %s", string(resultBytes))
+	}
+
+	listResp, _ := invokeTaskRPC(t, ctx, env, app, sessionID, &mcpruntime.Request{JSONRPC: "2.0", ID: "list-tasks", Method: "tasks/list"})
+	if listResp.Error != nil {
+		t.Fatalf("tasks/list error: %+v", listResp.Error)
+	}
+	list := decodeTaskList(t, listResp.Result)
+	if len(list.Tasks) != 1 || list.Tasks[0].TaskID != created.Task.TaskID {
+		t.Fatalf("unexpected task list: %+v", list)
+	}
+
+	_, otherSessionID := invokeTaskRPC(t, ctx, env, app, "", &mcpruntime.Request{
+		JSONRPC: "2.0",
+		ID:      "init-other-session",
+		Method:  "initialize",
+		Params:  mustJSONRaw(t, map[string]any{"protocolVersion": "2025-11-25"}),
+	})
+	otherGet, _ := invokeTaskRPC(t, ctx, env, app, otherSessionID, taskRequest("get-other-session", "tasks/get", created.Task.TaskID))
+	if otherGet.Error == nil || otherGet.Error.Code != mcpruntime.CodeInvalidParams {
+		t.Fatalf("expected task lookup from another session to fail closed, got %+v", otherGet.Error)
+	}
+
+	twoHours := int64((2 * time.Hour) / time.Millisecond)
+	excessiveTTLParams := mustJSONRaw(t, map[string]any{
+		"name":      "skill_bundle_get",
+		"arguments": map[string]any{"skill_id": "skill-a", "revision_number": 1},
+		"task":      map[string]any{"ttl": twoHours},
+	})
+	excessiveTTLResp, _ := invokeTaskRPC(t, ctx, env, app, sessionID, &mcpruntime.Request{JSONRPC: "2.0", ID: "excessive-ttl", Method: "tools/call", Params: excessiveTTLParams})
+	if excessiveTTLResp.Error == nil || excessiveTTLResp.Error.Code != mcpruntime.CodeInvalidParams {
+		t.Fatalf("expected excessive task ttl to fail closed, got %+v", excessiveTTLResp.Error)
+	}
+}
+
+func TestTaskRuntimeCancelsInFlightSkillBundleGet(t *testing.T) {
+	store := installMemoryTaskRuntimeForTest(t)
+	t.Setenv(envMcpSessionTable, "")
+	t.Setenv(envMcpStreamTable, "")
+	t.Setenv(envMcpTaskTable, "theory-dev-mcp-tasks")
+	t.Setenv("MCP_TASK_TTL_MINUTES", "10")
+
+	started := make(chan struct{})
+	canceled := make(chan struct{})
+	lesser := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(started)
+		<-r.Context().Done()
+		close(canceled)
+	}))
+	defer lesser.Close()
+	t.Setenv("LESSER_API_BASE_URL", lesser.URL)
+	lesserapi.ResetForTests()
+
+	srv, err := New("test-server", "dev")
+	if err != nil {
+		t.Fatalf("new server: %v", err)
+	}
+	env := testkit.New()
+	app := env.App()
+	app.Post("/mcp", srv.Handler())
+	ctx := taskToolContext()
+
+	_, sessionID := invokeTaskRPC(t, ctx, env, app, "", &mcpruntime.Request{
+		JSONRPC: "2.0",
+		ID:      "init-cancel",
+		Method:  "initialize",
+		Params:  mustJSONRaw(t, map[string]any{"protocolVersion": "2025-11-25"}),
+	})
+	createResp, _ := invokeTaskRPC(t, ctx, env, app, sessionID, &mcpruntime.Request{
+		JSONRPC: "2.0",
+		ID:      "create-cancel-task",
+		Method:  "tools/call",
+		Params: mustJSONRaw(t, map[string]any{
+			"name":      "skill_bundle_get",
+			"arguments": map[string]any{"skill_id": "slow", "revision_number": 1},
+			"task":      map[string]any{},
+		}),
+	})
+	if createResp.Error != nil {
+		t.Fatalf("tools/call task create error: %+v", createResp.Error)
+	}
+	created := decodeCreateTaskResult(t, createResp.Result)
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("skill_bundle_get task did not start Lesser request")
+	}
+
+	cancelResp, _ := invokeTaskRPC(t, ctx, env, app, sessionID, taskRequest("cancel-task", "tasks/cancel", created.Task.TaskID))
+	if cancelResp.Error != nil {
+		t.Fatalf("tasks/cancel error: %+v", cancelResp.Error)
+	}
+	canceledTask := decodeTask(t, cancelResp.Result)
+	if canceledTask.Status != mcpruntime.TaskStatusCanceled {
+		t.Fatalf("expected canceled task status, got %+v", canceledTask)
+	}
+
+	select {
+	case <-canceled:
+	case <-time.After(time.Second):
+		t.Fatal("skill_bundle_get request context was not canceled")
+	}
+	stored := waitForTaskStatus(t, store, sessionID, created.Task.TaskID, mcpruntime.TaskStatusCanceled)
+	if stored.Task.Status != mcpruntime.TaskStatusCanceled {
+		t.Fatalf("expected stored task to remain canceled, got %+v", stored.Task)
+	}
+}
+
+func installMemoryTaskRuntimeForTest(t testing.TB) mcpruntime.TaskStore {
+	t.Helper()
+	store := mcpruntime.NewMemoryTaskStore()
+	oldDB := newMCPDB
+	oldTaskStore := newMCPTaskStore
+	newMCPDB = func() (tablecore.DB, error) { return nil, nil }
+	newMCPTaskStore = func(tablecore.DB) mcpruntime.TaskStore { return store }
+	t.Cleanup(func() {
+		newMCPDB = oldDB
+		newMCPTaskStore = oldTaskStore
+	})
+	return store
+}
+
+func taskToolContext() context.Context {
+	principal := &auth.Principal{
+		Type:     auth.PrincipalTypeOAuthToken,
+		Identity: "agent1",
+		Claims:   &auth.Claims{Username: "agent1", Scopes: []string{"read"}},
+	}
+	return auth.InjectToolContext(context.Background(), principal, "task-test-token")
+}
+
+func invokeTaskRPC(t testing.TB, ctx context.Context, env *testkit.Env, app *apptheory.App, sessionID string, req *mcpruntime.Request) (*mcpruntime.Response, string) {
+	t.Helper()
+	body, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	headers := map[string][]string{
+		"content-type": {"application/json"},
+		"accept":       {"application/json, text/event-stream"},
+	}
+	if sessionID != "" {
+		headers["mcp-session-id"] = []string{sessionID}
+	}
+	resp := env.Invoke(ctx, app, apptheory.Request{Method: "POST", Path: "/mcp", Headers: headers, Body: body})
+	nextSessionID := sessionID
+	if ids := resp.Headers["mcp-session-id"]; len(ids) > 0 && ids[0] != "" {
+		nextSessionID = ids[0]
+	}
+	var rpc mcpruntime.Response
+	if err := json.Unmarshal(resp.Body, &rpc); err != nil {
+		t.Fatalf("unmarshal rpc response: %v (status=%d body=%s)", err, resp.Status, string(resp.Body))
+	}
+	return &rpc, nextSessionID
+}
+
+func mustJSONRaw(t testing.TB, value any) json.RawMessage {
+	t.Helper()
+	b, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("marshal json: %v", err)
+	}
+	return b
+}
+
+func taskRequest(id string, method string, taskID string) *mcpruntime.Request {
+	return &mcpruntime.Request{
+		JSONRPC: "2.0",
+		ID:      id,
+		Method:  method,
+		Params:  mustJSONRawNoTest(map[string]any{"taskId": taskID}),
+	}
+}
+
+func mustJSONRawNoTest(value any) json.RawMessage {
+	b, err := json.Marshal(value)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
+func assertInitializeAdvertisesTasks(t testing.TB, resp *mcpruntime.Response) {
+	t.Helper()
+	b, _ := json.Marshal(resp.Result)
+	var out struct {
+		Capabilities map[string]any `json:"capabilities"`
+	}
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal initialize result: %v", err)
+	}
+	tasks, ok := out.Capabilities["tasks"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected initialize capabilities.tasks object, got %+v", out.Capabilities)
+	}
+	if _, ok := tasks["list"].(map[string]any); !ok {
+		t.Fatalf("expected tasks.list capability, got %+v", tasks)
+	}
+	if _, ok := tasks["cancel"].(map[string]any); !ok {
+		t.Fatalf("expected tasks.cancel capability, got %+v", tasks)
+	}
+	requests, _ := tasks["requests"].(map[string]any)
+	tools, _ := requests["tools"].(map[string]any)
+	if _, ok := tools["call"].(map[string]any); !ok {
+		t.Fatalf("expected tasks.requests.tools.call capability, got %+v", tasks)
+	}
+}
+
+func assertSkillBundleGetTaskSupport(t testing.TB, resp *mcpruntime.Response) {
+	t.Helper()
+	b, _ := json.Marshal(resp.Result)
+	var out struct {
+		Tools []mcpruntime.ToolDef `json:"tools"`
+	}
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal tools/list: %v", err)
+	}
+	for _, tool := range out.Tools {
+		if tool.Name != "skill_bundle_get" {
+			continue
+		}
+		if tool.Execution == nil || tool.Execution.TaskSupport != mcpruntime.TaskSupportOptional {
+			t.Fatalf("skill_bundle_get should declare optional task support, got %+v", tool.Execution)
+		}
+		return
+	}
+	t.Fatalf("skill_bundle_get missing from tools/list")
+}
+
+func decodeCreateTaskResult(t testing.TB, raw any) mcpruntime.CreateTaskResult {
+	t.Helper()
+	b, _ := json.Marshal(raw)
+	var out mcpruntime.CreateTaskResult
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal create task result: %v (%s)", err, string(b))
+	}
+	return out
+}
+
+func decodeTask(t testing.TB, raw any) mcpruntime.Task {
+	t.Helper()
+	b, _ := json.Marshal(raw)
+	var out mcpruntime.Task
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal task: %v (%s)", err, string(b))
+	}
+	return out
+}
+
+func decodeTaskList(t testing.TB, raw any) mcpruntime.TaskListResult {
+	t.Helper()
+	b, _ := json.Marshal(raw)
+	var out mcpruntime.TaskListResult
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal task list: %v (%s)", err, string(b))
+	}
+	return out
+}
+
+func waitForTaskStatus(t testing.TB, store mcpruntime.TaskStore, sessionID string, taskID string, status mcpruntime.TaskStatus) *mcpruntime.TaskRecord {
+	t.Helper()
+	deadline := time.After(time.Second)
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		record, err := store.Get(context.Background(), mcpruntime.TaskLookup{SessionID: sessionID, TaskID: taskID})
+		if err == nil && record.Task.Status == status {
+			return record
+		}
+		select {
+		case <-deadline:
+			if err != nil {
+				t.Fatalf("task %s did not reach %s: %v", taskID, status, err)
+			}
+			t.Fatalf("task %s did not reach %s; latest status=%s", taskID, status, record.Task.Status)
+		case <-ticker.C:
+		}
+	}
+}
+
+func containsJSON(b []byte, needle string) bool {
+	return json.Valid(b) && len(needle) > 0 && strings.Contains(string(b), needle)
+}


### PR DESCRIPTION
## Milestone
MCP v1.6 Phase 6 / #211 — pilot task-backed execution for one read-only long-running tool.

Closes #211.

## Classification
MCP-contract, tool-surface, operational-reliability, security/scope-profile, test-coverage, docs.

## Surfaces affected
- `internal/mcpserver/`
- `internal/mcpapp/`
- `docs/mcp.md`
- `docs/security.md`
- `docs/troubleshooting.md`
- related operator/managed-deploy docs that previously described task storage as future-only readiness state

## Specialist walks referenced
- Tool surface: selected `skill_bundle_get` because it is read-only, Lesser-authoritative, and has no workspace mutation or host communication side effects. Scope remains `read`; profile semantics remain unchanged; synchronous `tools/call` remains supported.
- MCP contract: additive task capability for MCP `2025-11-25` sessions only. No endpoint/path changes and OAuth protected-resource metadata is unchanged. Deployments without `MCP_TASK_TABLE` continue to omit `tasks` and task-capable tool metadata.
- Lesser integration: preserves existing Lesser REST API usage and forwards the caller bearer to Lesser from task-backed `skill_bundle_get`; no new DynamoDB reads of Lesser data and no SSM export change.
- Host delegation: not touched; the pilot tool is not a communication tool.
- Framework: uses AppTheory `WithTaskRuntime`, `NewDynamoTaskStore`, `ToolExecution{TaskSupport: optional}`, and AppTheory task method semantics without local framework patches.

## Consumer impact
- MCP clients negotiating `2025-11-25` can create/read/list/result/cancel tasks for `skill_bundle_get` when `MCP_TASK_TABLE` is configured.
- Existing synchronous calls still work.
- Older protocol sessions and deployments without `MCP_TASK_TABLE` fail closed without advertising `tasks`.
- `tasks/*` methods require `read` scope; `tasks/cancel` is read-scoped because it only cancels session-scoped read-only pilot work.

## Tasks
- [x] Wire AppTheory task runtime when `MCP_TASK_TABLE` is configured.
- [x] Mark `skill_bundle_get` as the only optional task-capable pilot tool under the same runtime gate.
- [x] Advertise `.well-known/mcp.json` `capabilities.tasks` only when the runtime gate and task-capable tool are present.
- [x] Add read-scope enforcement and sanitized audit events for `tasks/list`, `tasks/get`, `tasks/result`, and `tasks/cancel`.
- [x] Cover task create/get/list/result/cancel, TTL bounds, cancellation, session scoping, and insufficient-scope access in tests.
- [x] Update MCP/security/troubleshooting and related operator docs.

## Validation
- `go test ./...`
- `go test -count=1 ./internal/mcpapp ./internal/mcpserver`
- `go vet ./...`
- `gofmt -l .` (empty)
- `scripts/build.sh`
- `(cd cdk && go test . ./stacks && go vet . ./stacks)`
- CDK synth not run: this PR does not change CDK/template code; Phase 5 already provisioned and validated the task table env.

## Stage rollout plan (handoff to deploy-body)
- [ ] Merged to main
- [ ] Deployed to lab / dev
- [ ] Lab soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
None required for code changes in this PR. Release notes/operator docs call out the additive MCP task capability and existing managed-deploy task table behavior.

## Advisor-brief authorization
Not advisor-dispatched.