### PR TITLE
fix(auth): enforce bound-body operation policy

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -61,6 +61,9 @@ Notes:
 - `internal/soulapi/`
   - `LESSER_SOUL_API_BASE_URL` / managed `TRUST_CONFIG.baseURL` points at lesser-host
   - uses `LESSER_HOST_INSTANCE_KEY` / `LESSER_HOST_INSTANCE_KEY_ARN` as the server-to-server credential
+  - verifies bound-body capability plus caller access/payment policy from the Host effective policy contract before
+    invoking private communication operations, loading the policy from Soul Comm contactability when it is not embedded
+    in the registration payload
   - reads mailbox metadata/content/state through `/api/v1/soul/comm/mailbox/*`
   - sends and replies through lesser-host so body never becomes mailbox authority or delivery provider
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -181,7 +181,8 @@ client-visible S3 links.
   - Social, memory, and public soul-read MCP surfaces remain available.
   - Communication surfaces and wallet-backed product semantics stay disabled.
 - `souled`
-  - Full lesser-body MCP surface, including communication tooling and soul-linked runtime behavior.
+  - Soul-linked MCP runtime. Communication tooling is visible to souled callers, but invoking private communication
+    operations additionally requires explicit bound-body operation policy from Host's effective policy contract.
 
 The profile contract is exposed in two places:
 
@@ -201,6 +202,28 @@ When the active profile is `drone`, lesser-body filters `tools/list`, `resources
 direct calls to communication-only surfaces such as `sms_send`, `agent://channels`, and `compose_email`.
 The drone boundary also applies inside mixed read tools: `notifications_read` rejects explicit
 `communication:inbound` filters for drone actors and filters communication-shaped rows from untyped notification reads.
+
+### Bound-body operation policy
+
+Soul binding proves that an MCP actor is associated with a Host/Soul agent; it does **not** grant the full private
+communication surface by itself. Before private communication or self-channel operations run, lesser-body now checks:
+
+1. the authenticated OAuth caller is still authorized for the bound soul via Lesser's `/api/v1/souls/bound/me`;
+2. Host's effective policy exposes explicit capability policy for the requested operation; and
+3. the caller class is allowed by caller access/payment policy.
+
+The v1 Host contract is `hosted-bound-soul/v1`, surfaced through Soul Comm contactability when it is not already
+embedded in the registration payload. Body treats channel presence or channel `capabilities` alone as insufficient:
+effective policy must also be present.
+
+The modeled caller classes are `principal_operator`, `bound_body`, `instance_key`, `allowlisted_peer`, and
+`public_paid`. In M1, `public_paid` is recognized but always denied; public x402 invocation waits for the later scoped
+grant milestone. SMS and voice/voicemail operations require an affirmative paid/provisioned entitlement in policy before
+body calls lesser-host.
+
+Denied policy checks return a sanitized `operation_not_allowed` tool/resource error with `source`,
+`reason`, `operation`, `callerClass`, and optional `policyVersion`. Denials intentionally omit private reachability,
+provider, payment evidence, tenant, wallet, and message-body details.
 
 ## Examples (curl)
 
@@ -386,12 +409,13 @@ Notes:
 - Communication and identity tools also require an **OAuth JWT** bearer token for agent-context reads such as `identity_whoami`
   and inbox-backed verification. For self-identity checks, lesser-body passes that bearer to Lesser's
   `GET /api/v1/souls/bound/me` endpoint and fails closed if Lesser does not confirm an active bound soul for the
-  authenticated local username.
+  authenticated local username. Soul binding alone is not enough to use private communication/channel operations; Host
+  must also expose explicit bound-body capability and caller access/payment policy for the operation.
 - Host-backed communication tools (`email_send`, `email_read`, `email_get`, `email_get_content`, `email_search`,
   `email_reply`, `email_delete`, `email_mark_read`, `email_mark_unread`, `sms_send`, `sms_read`, `voicemail_read`)
   additionally require the managed
   `LESSER_HOST_INSTANCE_KEY` (or `LESSER_HOST_INSTANCE_KEY_ARN`) so lesser-body can authenticate to lesser-host's
-  `/api/v1/soul/comm/*` endpoints.
+  `/api/v1/soul/comm/*` endpoints. Policy denials fail before any lesser-host communication endpoint is called.
 - Mailbox list/get/search results return redacted previews in `body`/`preview`; use `email_get_content` for full
   content when `content.available=true`. The `messageId` field in mailbox outputs is the opaque host `messageRef`
   accepted by get/content/state/reply calls; legacy host `messageId` appears as `hostMessageId` when present.

--- a/docs/security.md
+++ b/docs/security.md
@@ -46,6 +46,20 @@ Write tools include:
 - `post_create`, `post_boost`, `post_favorite`, `follow`, `unfollow`, `profile_update`, `memory_append`
 - `email_send`, `email_reply`, `email_delete`, `email_mark_read`, `email_mark_unread`, `sms_send`
 
+## Bound-body operation authorization
+
+For private communication and self-channel operations, the souled runtime profile is necessary but not sufficient.
+`lesser-body` checks the actor's binding through Lesser, then requires Host's effective `hosted-bound-soul/v1` policy
+or an equivalent explicit operation policy for the operation and caller class before calling lesser-host. Channel
+presence or channel `capabilities` alone do not grant private operation authority. The modeled caller classes are
+`principal_operator`, `bound_body`, `instance_key`, `allowlisted_peer`, and `public_paid`; `public_paid` remains denied
+in M1, and no public x402 invocation path exists in body yet.
+
+Denied operation-policy checks fail closed with a sanitized `operation_not_allowed` result. The details include only
+policy-safe fields such as `reason`, `operation`, `callerClass`, and optional `policyVersion`; they must not include
+private reachability, provider details, payment evidence, tenant data, wallet material, message bodies, or unresolved
+security details. Policy denial happens before lesser-host communication endpoints are invoked.
+
 The managed instance key compatibility path bypasses scope checks (treat as `admin`), which is why it should not
 remain the long-term inbound client auth model.
 

--- a/internal/mcpapp/app_test.go
+++ b/internal/mcpapp/app_test.go
@@ -41,6 +41,32 @@ func newTestTokenWithAudience(t testing.TB, secret string, username string, scop
 	return newTestTokenWithTimesAndAudience(t, secret, username, scopes, now, now.Add(time.Hour), audience)
 }
 
+func newTestTokenWithClientClass(t testing.TB, secret string, username string, scopes []string, clientClass string) string {
+	t.Helper()
+
+	now := time.Now().UTC()
+	claims := &auth.Claims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Subject:   username,
+			IssuedAt:  jwt.NewNumericDate(now),
+			NotBefore: jwt.NewNumericDate(now),
+			ExpiresAt: jwt.NewNumericDate(now.Add(time.Hour)),
+			ID:        "jti_test",
+		},
+		Username:    username,
+		Scopes:      scopes,
+		ClientID:    "test-client",
+		ClientClass: clientClass,
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	signed, err := token.SignedString([]byte(secret))
+	if err != nil {
+		t.Fatalf("sign token: %v", err)
+	}
+	return signed
+}
+
 func newTestTokenWithTimesAndAudience(t testing.TB, secret string, username string, scopes []string, issuedAt, expiresAt time.Time, audience []string) string {
 	t.Helper()
 

--- a/internal/mcpapp/cancellation_test.go
+++ b/internal/mcpapp/cancellation_test.go
@@ -130,7 +130,7 @@ func TestCancellationNotificationCancelsStreamingSmsSend(t *testing.T) {
 		case "/api/v1/soul/agents/" + agentID:
 			_, _ = w.Write([]byte(`{"version":"1","agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-eve","status":"active"}}`))
 		case "/api/v1/soul/agents/" + agentID + "/registration":
-			_, _ = w.Write([]byte(`{"version":"3","channels":{"phone":{"number":"+15550142","capabilities":["sms-send"],"verified":true}},"contactPreferences":{}}`))
+			_, _ = w.Write([]byte(`{"version":"3","channels":{"phone":{"number":"+15550142","capabilities":["sms-send"],"verified":true,"entitlement":{"state":"provisioned"}}},"contactPreferences":{},` + boundBodyPolicyJSON("communication.sms.send") + `}`))
 		case "/api/v1/soul/comm/send":
 			_, _ = io.ReadAll(r.Body)
 			closeStarted.Do(func() { close(started) })

--- a/internal/mcpapp/email_tools_test.go
+++ b/internal/mcpapp/email_tools_test.go
@@ -49,7 +49,9 @@ func TestLBM2_EmailSendAndReply_TalkToCommAPI(t *testing.T) {
 		case r.URL.Path == "/api/v1/soul/agents/"+agentID:
 			_, _ = w.Write([]byte(`{"version":"1","agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-bob","status":"active"}}`))
 		case r.URL.Path == "/api/v1/soul/agents/"+agentID+"/registration":
-			_, _ = w.Write([]byte(`{"version":"3","channels":{},"contactPreferences":{},"boundaries":[{"id":"b1","category":"communication_policy","channel":"email","statement":"no unsolicited"}]}`))
+			_, _ = w.Write([]byte(`{"version":"3","channels":{"email":{"capabilities":["email-send","email-read","email-manage"]}},"contactPreferences":{},"boundaries":[{"id":"b1","category":"communication_policy","channel":"email","statement":"no unsolicited"}]}`))
+		case r.URL.Path == "/api/v1/soul/comm/contactability/"+agentID:
+			_, _ = w.Write([]byte(`{` + hostedBoundSoulPolicyJSON("not_entitled", false, false) + `,"channels":[{"channelType":"email","sendAllowed":true,"receiveAllowed":true}]}`))
 		case r.URL.Path == "/api/v1/soul/comm/send" && r.Method == http.MethodPost:
 			gotAuth = r.Header.Get("Authorization")
 			body, _ := io.ReadAll(r.Body)
@@ -301,5 +303,134 @@ func TestLBM2_EmailSendAndReply_TalkToCommAPI(t *testing.T) {
 		if !strings.Contains(strings.ToLower(errPayload["message"].(string)), "blocked") {
 			t.Fatalf("expected error message to mention blocked, got %+v", errPayload)
 		}
+	}
+}
+
+func TestBoundBodyOperationPolicyDeniesImplicitAndPublicPaidEmail(t *testing.T) {
+	scenarios := []struct {
+		name          string
+		registration  string
+		token         func(testing.TB) string
+		wantReason    string
+		wantPolicyVer string
+	}{
+		{
+			name:         "bound soul without explicit policy cannot send email",
+			registration: `{"version":"3","channels":{"email":{"address":"agent@example.com"}},"contactPreferences":{}}`,
+			token: func(tb testing.TB) string {
+				return newTestToken(tb, "test", "agent1", []string{"write"})
+			},
+			wantReason: "capability_policy_denied",
+		},
+		{
+			name:         "public paid caller remains modeled but denied in M1",
+			registration: `{"version":"3","channels":{"email":{"capabilities":["email-send"]}},"contactPreferences":{},` + boundBodyPolicyJSON("communication.email.send") + `}`,
+			token: func(tb testing.TB) string {
+				return newTestTokenWithClientClass(tb, "test", "agent1", []string{"write"}, "public_paid")
+			},
+			wantReason:    "public_paid_callers_denied_in_m1",
+			wantPolicyVer: "2026-05-16",
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			t.Setenv("MCP_SESSION_TABLE", "")
+			t.Setenv("JWT_SECRET", "test")
+			t.Setenv("LESSER_HOST_INSTANCE_KEY", "instance-key-123")
+			installSoulBindingLookup(t, "agent1", "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+			auth.ResetForTests()
+			lesserapi.ResetForTests()
+			soulapi.ResetForTests()
+			restoreTrustConfig := mcpapp.SetLoadEffectiveTrustConfigForTests(func(context.Context) (*trustconfig.Effective, error) {
+				return &trustconfig.Effective{}, nil
+			})
+			t.Cleanup(restoreTrustConfig)
+
+			const agentID = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+			var commSendCalled bool
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch r.URL.Path {
+				case "/api/v1/souls/bound/me":
+					_, _ = w.Write([]byte(boundSelfResponse(agentID, "agent1", "test.example.com", "agent-bob")))
+				case "/api/v1/soul/agents/" + agentID:
+					_, _ = w.Write([]byte(`{"version":"1","agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-bob","status":"active"}}`))
+				case "/api/v1/soul/agents/" + agentID + "/registration":
+					_, _ = w.Write([]byte(scenario.registration))
+				case "/api/v1/soul/comm/send":
+					commSendCalled = true
+					_, _ = w.Write([]byte(`{"messageId":"comm-msg-001","status":"sent"}`))
+				default:
+					w.WriteHeader(http.StatusNotFound)
+					_, _ = w.Write([]byte(`{"error":{"message":"not found"}}`))
+				}
+			}))
+			defer server.Close()
+
+			t.Setenv("LESSER_API_BASE_URL", server.URL)
+			t.Setenv("LESSER_SOUL_API_BASE_URL", server.URL)
+			lesserapi.ResetForTests()
+			soulapi.ResetForTests()
+
+			app, err := mcpapp.New("test", "dev")
+			if err != nil {
+				t.Fatalf("new app: %v", err)
+			}
+			env := testkit.New()
+			authHeader := "Bearer " + scenario.token(t)
+			initResp := invokeJSON(t, env, app, map[string][]string{
+				"authorization": {authHeader},
+			}, &mcpruntime.Request{JSONRPC: "2.0", ID: 1, Method: "initialize"})
+			if initResp.Status != 200 {
+				t.Fatalf("initialize: status=%d body=%s", initResp.Status, string(initResp.Body))
+			}
+			sessionID := initResp.Headers["mcp-session-id"][0]
+
+			callParams, _ := json.Marshal(map[string]any{
+				"name": "email_send",
+				"arguments": map[string]any{
+					"to":      "alice@example.com",
+					"subject": "Hello",
+					"body":    "Hi",
+				},
+			})
+			resp := invokeJSON(t, env, app, map[string][]string{
+				"authorization":  {authHeader},
+				"mcp-session-id": {sessionID},
+			}, &mcpruntime.Request{JSONRPC: "2.0", ID: 2, Method: "tools/call", Params: callParams})
+			if resp.Status != 200 {
+				t.Fatalf("email_send: status=%d body=%s", resp.Status, string(resp.Body))
+			}
+			if commSendCalled {
+				t.Fatalf("denied operation must fail before lesser-host comm/send")
+			}
+
+			var rpc mcpruntime.Response
+			_ = json.Unmarshal(resp.Body, &rpc)
+			if rpc.Error != nil {
+				t.Fatalf("email_send rpc error: %+v", rpc.Error)
+			}
+			var out mcpruntime.ToolResult
+			b, _ := json.Marshal(rpc.Result)
+			_ = json.Unmarshal(b, &out)
+			if !out.IsError {
+				t.Fatalf("expected operation_not_allowed tool error, got %+v", out)
+			}
+			errPayload, _ := out.StructuredContent["error"].(map[string]any)
+			if errPayload["code"] != "operation_not_allowed" {
+				t.Fatalf("expected operation_not_allowed, got %+v", errPayload)
+			}
+			details, _ := errPayload["details"].(map[string]any)
+			if details["reason"] != scenario.wantReason || details["operation"] != "communication.email.send" {
+				t.Fatalf("unexpected sanitized denial details: %+v", details)
+			}
+			if details["provider"] != nil || details["paymentEvidence"] != nil || details["tenant"] != nil || details["wallet"] != nil {
+				t.Fatalf("denial details must not expose provider/payment/tenant/wallet data: %+v", details)
+			}
+			if scenario.wantPolicyVer != "" && details["policyVersion"] != scenario.wantPolicyVer {
+				t.Fatalf("expected policyVersion=%q, got %+v", scenario.wantPolicyVer, details)
+			}
+		})
 	}
 }

--- a/internal/mcpapp/email_tools_test.go
+++ b/internal/mcpapp/email_tools_test.go
@@ -38,6 +38,7 @@ func TestLBM2_EmailSendAndReply_TalkToCommAPI(t *testing.T) {
 	const tokenUser = "agent1"
 
 	var gotAuth string
+	var gotContactabilityAuth string
 	var gotBody map[string]any
 	var statusCode int
 
@@ -51,6 +52,7 @@ func TestLBM2_EmailSendAndReply_TalkToCommAPI(t *testing.T) {
 		case r.URL.Path == "/api/v1/soul/agents/"+agentID+"/registration":
 			_, _ = w.Write([]byte(`{"version":"3","channels":{"email":{"capabilities":["email-send","email-read","email-manage"]}},"contactPreferences":{},"boundaries":[{"id":"b1","category":"communication_policy","channel":"email","statement":"no unsolicited"}]}`))
 		case r.URL.Path == "/api/v1/soul/comm/contactability/"+agentID:
+			gotContactabilityAuth = r.Header.Get("Authorization")
 			_, _ = w.Write([]byte(`{` + hostedBoundSoulPolicyJSON("not_entitled", false, false) + `,"channels":[{"channelType":"email","sendAllowed":true,"receiveAllowed":true}]}`))
 		case r.URL.Path == "/api/v1/soul/comm/send" && r.Method == http.MethodPost:
 			gotAuth = r.Header.Get("Authorization")
@@ -125,6 +127,9 @@ func TestLBM2_EmailSendAndReply_TalkToCommAPI(t *testing.T) {
 		}
 		if gotAuth != "Bearer instance-key-123" {
 			t.Fatalf("expected comm api Authorization=%q, got %q", "Bearer instance-key-123", gotAuth)
+		}
+		if gotContactabilityAuth != "Bearer instance-key-123" {
+			t.Fatalf("expected contactability Authorization=%q, got %q", "Bearer instance-key-123", gotContactabilityAuth)
 		}
 		if gotBody["channel"] != "email" || gotBody["agentId"] != agentID {
 			t.Fatalf("unexpected comm api body: %+v", gotBody)

--- a/internal/mcpapp/identity_surfaces_test.go
+++ b/internal/mcpapp/identity_surfaces_test.go
@@ -89,7 +89,8 @@ func TestLBM1_IdentityToolsAndChannelResources(t *testing.T) {
 					"availability":{"schedule":"always"},
 					"responseExpectation":{"target":"1h","guarantee":"best-effort"},
 					"languages":["en"]
-				}
+				},
+				` + boundBodyPolicyJSON("identity.self.read", "communication.channels.read", "communication.email.read") + `
 			}`))
 		case r.URL.Path == "/api/v1/soul/agents/"+agentID+"/channels":
 			channelResolveQueries = append(channelResolveQueries, agentID)

--- a/internal/mcpapp/identity_surfaces_test.go
+++ b/internal/mcpapp/identity_surfaces_test.go
@@ -90,7 +90,7 @@ func TestLBM1_IdentityToolsAndChannelResources(t *testing.T) {
 					"responseExpectation":{"target":"1h","guarantee":"best-effort"},
 					"languages":["en"]
 				},
-				` + boundBodyPolicyJSON("identity.self.read", "communication.channels.read", "communication.email.read") + `
+				` + boundBodyPolicyJSON("identity.self.read", "communication.channels.read", "communication.email.read", "communication.sms.read") + `
 			}`))
 		case r.URL.Path == "/api/v1/soul/agents/"+agentID+"/channels":
 			channelResolveQueries = append(channelResolveQueries, agentID)
@@ -833,6 +833,99 @@ func TestLBM1_IdentityToolsAndChannelResources(t *testing.T) {
 		if len(channelResolveQueries) != 0 {
 			t.Fatalf("identity_verify ENS should not fetch private /channels, got %+v", channelResolveQueries)
 		}
+	}
+}
+
+func TestIdentityVerifyHostMessageRequiresMailboxReadPolicy(t *testing.T) {
+	t.Setenv("MCP_SESSION_TABLE", "")
+	t.Setenv("JWT_SECRET", "test")
+	t.Setenv("LESSER_HOST_INSTANCE_KEY", "instance-key-123")
+	installSoulBindingLookup(t, "agent1", "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	auth.ResetForTests()
+	lesserapi.ResetForTests()
+	soulapi.ResetForTests()
+	restoreTrustConfig := mcpapp.SetLoadEffectiveTrustConfigForTests(func(context.Context) (*trustconfig.Effective, error) {
+		return &trustconfig.Effective{}, nil
+	})
+	t.Cleanup(restoreTrustConfig)
+
+	const agentID = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	var hostMailboxCalled bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/api/v1/souls/bound/me":
+			_, _ = w.Write([]byte(boundSelfResponse(agentID, "agent1", "test.example.com", "agent-alice")))
+		case r.URL.Path == "/api/v1/soul/agents/"+agentID:
+			_, _ = w.Write([]byte(`{"version":"1","agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-alice","status":"active"}}`))
+		case r.URL.Path == "/api/v1/soul/agents/"+agentID+"/registration":
+			_, _ = w.Write([]byte(`{"version":"3","channels":{"email":{"address":"agent-alice@lessersoul.ai"}},"contactPreferences":{},` + boundBodyPolicyJSON("identity.self.read", "communication.channels.read") + `}`))
+		case r.URL.Path == "/api/v1/soul/comm/mailbox/"+agentID+"/messages/comm-delivery-email":
+			hostMailboxCalled = true
+			_, _ = w.Write([]byte(`{"message":{"messageRef":"comm-delivery-email","channelType":"email"}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":{"message":"not found"}}`))
+		}
+	}))
+	defer server.Close()
+
+	t.Setenv("LESSER_API_BASE_URL", server.URL)
+	t.Setenv("LESSER_SOUL_API_BASE_URL", server.URL)
+	lesserapi.ResetForTests()
+	soulapi.ResetForTests()
+
+	app, err := mcpapp.New("test", "dev")
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+	env := testkit.New()
+	authHeader := "Bearer " + newTestToken(t, "test", "agent1", []string{"read"})
+	initResp := invokeJSON(t, env, app, map[string][]string{
+		"authorization": {authHeader},
+	}, &mcpruntime.Request{JSONRPC: "2.0", ID: 1, Method: "initialize"})
+	if initResp.Status != 200 {
+		t.Fatalf("initialize: status=%d body=%s", initResp.Status, string(initResp.Body))
+	}
+	sessionID := initResp.Headers["mcp-session-id"][0]
+
+	callParams, _ := json.Marshal(map[string]any{
+		"name": "identity_verify",
+		"arguments": map[string]any{
+			"channel":    "email",
+			"identifier": "agent-alice@lessersoul.ai",
+			"messageId":  "comm-delivery-email",
+		},
+	})
+	resp := invokeJSON(t, env, app, map[string][]string{
+		"authorization":  {authHeader},
+		"mcp-session-id": {sessionID},
+	}, &mcpruntime.Request{JSONRPC: "2.0", ID: 2, Method: "tools/call", Params: callParams})
+	if resp.Status != 200 {
+		t.Fatalf("identity_verify: status=%d body=%s", resp.Status, string(resp.Body))
+	}
+	if hostMailboxCalled {
+		t.Fatalf("identity_verify must not call Host mailbox when only channels.read policy is allowed")
+	}
+
+	var rpc mcpruntime.Response
+	_ = json.Unmarshal(resp.Body, &rpc)
+	if rpc.Error != nil {
+		t.Fatalf("identity_verify rpc error: %+v", rpc.Error)
+	}
+	var out mcpruntime.ToolResult
+	b, _ := json.Marshal(rpc.Result)
+	_ = json.Unmarshal(b, &out)
+	if !out.IsError {
+		t.Fatalf("expected operation_not_allowed tool error, got %+v", out)
+	}
+	errPayload, _ := out.StructuredContent["error"].(map[string]any)
+	if errPayload["code"] != "operation_not_allowed" {
+		t.Fatalf("expected operation_not_allowed, got %+v", errPayload)
+	}
+	details, _ := errPayload["details"].(map[string]any)
+	if details["operation"] != "communication.email.read" {
+		t.Fatalf("expected mailbox read operation denial, got %+v", details)
 	}
 }
 

--- a/internal/mcpapp/identity_surfaces_test.go
+++ b/internal/mcpapp/identity_surfaces_test.go
@@ -929,6 +929,115 @@ func TestIdentityVerifyHostMessageRequiresMailboxReadPolicy(t *testing.T) {
 	}
 }
 
+func TestIdentityVerifyHostMessageRejectsCrossChannelSummary(t *testing.T) {
+	t.Setenv("MCP_SESSION_TABLE", "")
+	t.Setenv("JWT_SECRET", "test")
+	t.Setenv("LESSER_HOST_INSTANCE_KEY", "instance-key-123")
+	installSoulBindingLookup(t, "agent1", "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	auth.ResetForTests()
+	lesserapi.ResetForTests()
+	soulapi.ResetForTests()
+	restoreTrustConfig := mcpapp.SetLoadEffectiveTrustConfigForTests(func(context.Context) (*trustconfig.Effective, error) {
+		return &trustconfig.Effective{}, nil
+	})
+	t.Cleanup(restoreTrustConfig)
+
+	const agentID = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	var hostMailboxCalled bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/api/v1/souls/bound/me":
+			_, _ = w.Write([]byte(boundSelfResponse(agentID, "agent1", "test.example.com", "agent-alice")))
+		case r.URL.Path == "/api/v1/soul/agents/"+agentID:
+			_, _ = w.Write([]byte(`{"version":"1","agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-alice","status":"active"}}`))
+		case r.URL.Path == "/api/v1/soul/agents/"+agentID+"/registration":
+			_, _ = w.Write([]byte(`{"version":"3","channels":{"email":{"address":"agent-alice@lessersoul.ai"},"phone":{"number":"+15550142"}},"contactPreferences":{},` + boundBodyPolicyJSON("communication.email.read") + `}`))
+		case r.URL.Path == "/api/v1/soul/comm/mailbox/"+agentID+"/messages/comm-delivery-sms":
+			hostMailboxCalled = true
+			if got := r.Header.Get("Authorization"); got != "Bearer instance-key-123" {
+				t.Fatalf("expected host instance bearer for mailbox lookup, got %q", got)
+			}
+			_, _ = w.Write([]byte(`{
+				"message":{
+					"messageRef":"comm-delivery-sms",
+					"channelType":"sms",
+					"direction":"inbound",
+					"from":{"number":"+15550142","soulAgentId":"` + agentID + `"},
+					"to":{"number":"+15550199"},
+					"preview":"private sms preview",
+					"createdAt":"2026-05-10T12:01:00Z"
+				}
+			}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":{"message":"not found"}}`))
+		}
+	}))
+	defer server.Close()
+
+	t.Setenv("LESSER_API_BASE_URL", server.URL)
+	t.Setenv("LESSER_SOUL_API_BASE_URL", server.URL)
+	lesserapi.ResetForTests()
+	soulapi.ResetForTests()
+
+	app, err := mcpapp.New("test", "dev")
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+	env := testkit.New()
+	authHeader := "Bearer " + newTestToken(t, "test", "agent1", []string{"read"})
+	initResp := invokeJSON(t, env, app, map[string][]string{
+		"authorization": {authHeader},
+	}, &mcpruntime.Request{JSONRPC: "2.0", ID: 1, Method: "initialize"})
+	if initResp.Status != 200 {
+		t.Fatalf("initialize: status=%d body=%s", initResp.Status, string(initResp.Body))
+	}
+	sessionID := initResp.Headers["mcp-session-id"][0]
+
+	callParams, _ := json.Marshal(map[string]any{
+		"name": "identity_verify",
+		"arguments": map[string]any{
+			"channel":    "email",
+			"identifier": "agent-alice@lessersoul.ai",
+			"messageId":  "comm-delivery-sms",
+		},
+	})
+	resp := invokeJSON(t, env, app, map[string][]string{
+		"authorization":  {authHeader},
+		"mcp-session-id": {sessionID},
+	}, &mcpruntime.Request{JSONRPC: "2.0", ID: 2, Method: "tools/call", Params: callParams})
+	if resp.Status != 200 {
+		t.Fatalf("identity_verify: status=%d body=%s", resp.Status, string(resp.Body))
+	}
+	if !hostMailboxCalled {
+		t.Fatalf("expected initial email-read policy to allow Host fetch before actual channel re-check")
+	}
+
+	var rpc mcpruntime.Response
+	_ = json.Unmarshal(resp.Body, &rpc)
+	if rpc.Error != nil {
+		t.Fatalf("identity_verify rpc error: %+v", rpc.Error)
+	}
+	var out mcpruntime.ToolResult
+	b, _ := json.Marshal(rpc.Result)
+	_ = json.Unmarshal(b, &out)
+	if !out.IsError {
+		t.Fatalf("expected cross-channel operation_not_allowed tool error, got %+v", out)
+	}
+	if _, ok := out.StructuredContent["data"]; ok {
+		t.Fatalf("cross-channel denial must not return message-bearing data: %+v", out.StructuredContent)
+	}
+	errPayload, _ := out.StructuredContent["error"].(map[string]any)
+	if errPayload["code"] != "operation_not_allowed" {
+		t.Fatalf("expected operation_not_allowed, got %+v", errPayload)
+	}
+	details, _ := errPayload["details"].(map[string]any)
+	if details["operation"] != "communication.sms.read" {
+		t.Fatalf("expected actual sms mailbox read denial, got %+v", details)
+	}
+}
+
 func TestLBM1_IdentityLookupBareLocalFailsWithoutTrustworthyCurrentInstanceDomain(t *testing.T) {
 	t.Setenv("MCP_SESSION_TABLE", "")
 	t.Setenv("JWT_SECRET", "test")

--- a/internal/mcpapp/inbox_tools_test.go
+++ b/internal/mcpapp/inbox_tools_test.go
@@ -38,7 +38,7 @@ func TestLBM3_InboxToolsUseHostMailbox(t *testing.T) {
 		case r.URL.Path == "/api/v1/soul/agents/"+agentID:
 			_, _ = w.Write([]byte(`{"version":"1","agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-alice","status":"active"}}`))
 		case r.URL.Path == "/api/v1/soul/agents/"+agentID+"/registration":
-			_, _ = w.Write([]byte(`{"version":"3","channels":{},"contactPreferences":{},"boundaries":[]}`))
+			_, _ = w.Write([]byte(`{"version":"3","channels":{"email":{"capabilities":["email-read","email-manage"]},"phone":{"capabilities":["sms-read","voice-receive"],"entitlement":{"state":"provisioned"}}},"contactPreferences":{},"boundaries":[],` + boundBodyPolicyJSON("communication.email.read", "communication.email.manage", "communication.sms.read", "communication.voice.read") + `}`))
 		case r.URL.Path == "/api/v1/soul/comm/mailbox/"+agentID+"/messages" && r.Method == http.MethodGet:
 			gotAuth = append(gotAuth, r.Header.Get("Authorization"))
 			listQueries = append(listQueries, r.URL.RawQuery)

--- a/internal/mcpapp/outbound_comm_streaming_test.go
+++ b/internal/mcpapp/outbound_comm_streaming_test.go
@@ -41,7 +41,7 @@ func TestSmsSendStreamingEmitsProgressAndFinalResult(t *testing.T) {
 		case "/api/v1/soul/agents/" + agentID:
 			_, _ = w.Write([]byte(`{"version":"1","agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-dana","status":"active"}}`))
 		case "/api/v1/soul/agents/" + agentID + "/registration":
-			_, _ = w.Write([]byte(`{"version":"3","channels":{"phone":{"number":"+15550142","capabilities":["sms-send"],"verified":true}},"contactPreferences":{}}`))
+			_, _ = w.Write([]byte(`{"version":"3","channels":{"phone":{"number":"+15550142","capabilities":["sms-send"],"verified":true,"entitlement":{"state":"provisioned"}}},"contactPreferences":{},` + boundBodyPolicyJSON("communication.sms.send") + `}`))
 		case "/api/v1/soul/comm/send":
 			time.Sleep(10 * time.Millisecond)
 			_, _ = w.Write([]byte(`{"messageId":"comm-msg-sms-002","status":"queued"}`))

--- a/internal/mcpapp/outbound_comm_tools_test.go
+++ b/internal/mcpapp/outbound_comm_tools_test.go
@@ -51,10 +51,11 @@ func TestLBM6_SMSAndVoiceOutboundTools(t *testing.T) {
 			_, _ = w.Write([]byte(`{
 				"version":"3",
 				"channels":{
-					"phone":{"number":"+15550142","capabilities":["sms-send","voice-receive"],"verified":true}
+					"phone":{"number":"+15550142","capabilities":["sms-send","voice-receive"],"verified":true,"entitlement":{"state":"provisioned"}}
 				},
 				"contactPreferences":{},
-				"boundaries":[{"id":"b1","category":"communication_policy","channel":"sms","statement":"reply in thread"}]
+				"boundaries":[{"id":"b1","category":"communication_policy","channel":"sms","statement":"reply in thread"}],
+				` + boundBodyPolicyJSON("communication.sms.send", "communication.voice.read") + `
 			}`))
 		case "/api/v1/soul/comm/send":
 			gotAuth = r.Header.Get("Authorization")

--- a/internal/mcpapp/tabletheory_fake_test.go
+++ b/internal/mcpapp/tabletheory_fake_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -144,6 +145,29 @@ func installSoulBindingLookup(t testing.TB, username string, agentID string) {
 
 func boundSelfResponse(agentID string, username string, domain string, localID string) string {
 	return fmt.Sprintf(`{"agent":{"agent_id":%q,"domain":%q,"local_id":%q,"status":"active","lifecycle_status":"active"},"binding_state":"bound","binding":{"agent_username":%q}}`, agentID, domain, localID, username)
+}
+
+func boundBodyPolicyJSON(operations ...string) string {
+	entries := make([]string, 0, len(operations))
+	for _, operation := range operations {
+		operation = strings.TrimSpace(operation)
+		if operation == "" {
+			continue
+		}
+		entitlement := ""
+		if strings.Contains(operation, ".sms.") || strings.Contains(operation, ".voice.") {
+			entitlement = `,"entitlement":{"state":"provisioned"}`
+		}
+		entries = append(entries, fmt.Sprintf(`%q:{"enabled":true,"callerClasses":["bound_body"]%s}`, operation, entitlement))
+	}
+	return `"capabilityPolicy":{"version":"2026-05-16","operations":{` + strings.Join(entries, ",") + `}},"callerAccessPolicy":{"classes":{"bound_body":{"enabled":true}}}`
+}
+
+func hostedBoundSoulPolicyJSON(phoneEntitlement string, smsAllowed bool, voiceAllowed bool) string {
+	if phoneEntitlement == "" {
+		phoneEntitlement = "not_entitled"
+	}
+	return fmt.Sprintf(`"policy":{"version":"hosted-bound-soul/v1","anchorState":"hosted_offchain","operationalBinding":"hosted_bound_soul","capabilityPolicyVersion":"capability-policy/v1","callerAccessPaymentPolicyVersion":"caller-access-payment/v1","capabilities":{"email":{"defaultAllowed":true},"phone":{"entitlementStatus":%q,"smsAllowed":%t,"voiceAllowed":%t}},"callerAccessPayment":{"publicPaidCaller":{"access":"denied"}},"migration":{"state":"implicit_default_v1"}}`, phoneEntitlement, smsAllowed, voiceAllowed)
 }
 
 func installMissingSoulBindingLookup(t testing.TB) {

--- a/internal/mcpserver/bound_operation_policy.go
+++ b/internal/mcpserver/bound_operation_policy.go
@@ -1,0 +1,788 @@
+package mcpserver
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/equaltoai/lesser-body/internal/auth"
+	"github.com/equaltoai/lesser-body/internal/soulapi"
+)
+
+type boundOperation string
+
+const (
+	boundOperationEmailSend        boundOperation = "communication.email.send"
+	boundOperationEmailRead        boundOperation = "communication.email.read"
+	boundOperationEmailManage      boundOperation = "communication.email.manage"
+	boundOperationSMSSend          boundOperation = "communication.sms.send"
+	boundOperationSMSRead          boundOperation = "communication.sms.read"
+	boundOperationVoiceRead        boundOperation = "communication.voice.read"
+	boundOperationChannelsRead     boundOperation = "communication.channels.read"
+	boundOperationIdentitySelfRead boundOperation = "identity.self.read"
+)
+
+type boundCallerClass string
+
+const (
+	boundCallerClassPrincipalOperator boundCallerClass = "principal_operator"
+	boundCallerClassBoundBody         boundCallerClass = "bound_body"
+	boundCallerClassInstanceKey       boundCallerClass = "instance_key"
+	boundCallerClassAllowlistedPeer   boundCallerClass = "allowlisted_peer"
+	boundCallerClassPublicPaid        boundCallerClass = "public_paid"
+	boundCallerClassUnknown           boundCallerClass = "unknown"
+)
+
+type boundPolicyDecision struct {
+	Operation     boundOperation
+	CallerClass   boundCallerClass
+	Allowed       bool
+	Reason        string
+	PolicyVersion string
+}
+
+func authorizedAgentChannelsPayload(ctx context.Context, operation boundOperation) (map[string]any, error) {
+	client, err := soulapi.Default()
+	if err != nil {
+		return nil, &toolUserError{Code: "not_configured", Message: err.Error(), Status: 500}
+	}
+
+	agentID, err := authenticatedAgentID(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if agentID == "" {
+		return nil, &toolUserError{Code: "not_found", Message: "no bound soul found for this agent", Status: 404}
+	}
+
+	payload, registration, err := agentChannelsPayloadWithRegistration(ctx, client, agentID)
+	if err != nil {
+		return nil, err
+	}
+	registration = withAgentContactabilityPolicy(ctx, client, agentID, registration)
+	if decision := decideBoundOperation(ctx, registration, operation); !decision.Allowed {
+		return nil, boundOperationDeniedError(decision)
+	}
+	return payload, nil
+}
+
+func withAgentContactabilityPolicy(ctx context.Context, client *soulapi.Client, agentID string, registration map[string]any) map[string]any {
+	registration = mapFromAny(registration)
+	if client == nil || normalizeSoulAgentID(agentID) == "" || len(hostedBoundSoulPolicy(registration)) > 0 {
+		return registration
+	}
+	contactabilityAny, err := client.DoJSON(ctx, "GET", "/api/v1/soul/comm/contactability/"+url.PathEscape(normalizeSoulAgentID(agentID)), nil, "", nil)
+	if err != nil {
+		return registration
+	}
+	contactability := mapFromAny(contactabilityAny)
+	if len(contactability) == 0 {
+		return registration
+	}
+	if policy := firstPolicyMap(contactability, "policy", "effectivePolicy", "effective_policy"); len(policy) > 0 {
+		registration["policy"] = policy
+	}
+	if channels := firstArrayFromAny(contactability, "channels"); len(channels) > 0 {
+		registration["contactabilityChannels"] = channels
+	}
+	return registration
+}
+
+func decideBoundOperation(ctx context.Context, registration map[string]any, operation boundOperation) boundPolicyDecision {
+	operation = normalizeBoundOperation(operation)
+	callerClass := classifyBoundOperationCaller(ctx)
+	decision := boundPolicyDecision{
+		Operation:     operation,
+		CallerClass:   callerClass,
+		Allowed:       false,
+		Reason:        "bound_body_policy_denied",
+		PolicyVersion: boundPolicyVersion(registration),
+	}
+
+	if operation == "" {
+		decision.Reason = "operation_unset"
+		return decision
+	}
+	if callerClass == boundCallerClassUnknown {
+		decision.Reason = "caller_class_unknown"
+		return decision
+	}
+	if callerClass == boundCallerClassPublicPaid {
+		decision.Reason = "public_paid_callers_denied_in_m1"
+		return decision
+	}
+
+	capabilityAllowed := boundCapabilityPolicyAllows(registration, operation)
+	callerAllowed := boundCallerAccessPolicyAllows(registration, operation, callerClass)
+	if !capabilityAllowed {
+		decision.Reason = "capability_policy_denied"
+		return decision
+	}
+	if !callerAllowed {
+		decision.Reason = "caller_access_policy_denied"
+		return decision
+	}
+	if boundOperationRequiresEntitlement(operation) && !boundPaymentPolicyAllows(registration, operation) {
+		decision.Reason = "paid_or_provisioned_entitlement_required"
+		return decision
+	}
+
+	decision.Allowed = true
+	decision.Reason = "allowed"
+	return decision
+}
+
+func classifyBoundOperationCaller(ctx context.Context) boundCallerClass {
+	principal := auth.PrincipalFromToolContext(ctx)
+	if principal == nil {
+		return boundCallerClassUnknown
+	}
+	if principal.Type == auth.PrincipalTypeInstanceKey {
+		return boundCallerClassInstanceKey
+	}
+	if principal.Type != auth.PrincipalTypeOAuthToken {
+		return boundCallerClassUnknown
+	}
+
+	claims := principal.Claims
+	if claims == nil {
+		return boundCallerClassUnknown
+	}
+
+	switch normalizeCallerClass(claims.ClientClass) {
+	case boundCallerClassPublicPaid:
+		return boundCallerClassPublicPaid
+	case boundCallerClassAllowlistedPeer:
+		return boundCallerClassAllowlistedPeer
+	case boundCallerClassPrincipalOperator:
+		return boundCallerClassPrincipalOperator
+	case boundCallerClassBoundBody:
+		return boundCallerClassBoundBody
+	}
+
+	if strings.TrimSpace(claims.DelegatedBy) != "" {
+		return boundCallerClassPrincipalOperator
+	}
+	switch strings.ToLower(strings.TrimSpace(claims.AgentType)) {
+	case "operator", "principal", "principal_operator":
+		return boundCallerClassPrincipalOperator
+	}
+	return boundCallerClassBoundBody
+}
+
+func normalizeCallerClass(value string) boundCallerClass {
+	value = strings.ToLower(strings.TrimSpace(value))
+	value = strings.NewReplacer("-", "_", " ", "_", ".", "_", ":", "_").Replace(value)
+	switch value {
+	case "principal_operator", "principal", "operator", "owner", "account_operator":
+		return boundCallerClassPrincipalOperator
+	case "bound_body", "body", "agent", "self", "actor":
+		return boundCallerClassBoundBody
+	case "instance_key", "managed_instance_key", "host_instance_key":
+		return boundCallerClassInstanceKey
+	case "allowlisted_peer", "allowlisted", "trusted_peer", "peer":
+		return boundCallerClassAllowlistedPeer
+	case "public_paid", "paid_public", "x402", "x402_public", "public_x402":
+		return boundCallerClassPublicPaid
+	default:
+		return ""
+	}
+}
+
+func boundOperationDeniedError(decision boundPolicyDecision) *toolUserError {
+	reason := strings.TrimSpace(decision.Reason)
+	if reason == "" {
+		reason = "bound_body_policy_denied"
+	}
+	details := map[string]any{
+		"source":      "bound_body_operation_policy",
+		"reason":      reason,
+		"operation":   string(decision.Operation),
+		"callerClass": string(decision.CallerClass),
+	}
+	if decision.PolicyVersion != "" {
+		details["policyVersion"] = decision.PolicyVersion
+	}
+	return &toolUserError{
+		Code:    "operation_not_allowed",
+		Message: "operation is not allowed by current bound-body policy",
+		Status:  403,
+		Details: details,
+	}
+}
+
+func boundCapabilityPolicyAllows(registration map[string]any, operation boundOperation) bool {
+	if registration == nil {
+		return false
+	}
+	for _, entry := range boundOperationPolicyEntries(registration, operation) {
+		if boundPolicyEntryEnabled(entry) {
+			return true
+		}
+	}
+	return false
+}
+
+func boundCallerAccessPolicyAllows(registration map[string]any, operation boundOperation, callerClass boundCallerClass) bool {
+	if registration == nil || callerClass == "" {
+		return false
+	}
+	for _, entry := range boundOperationPolicyEntries(registration, operation) {
+		if !boundPolicyEntryEnabled(entry) {
+			continue
+		}
+		if boundPolicyEntryAllowsCaller(entry, callerClass) {
+			return true
+		}
+	}
+	for _, root := range boundPolicyRoots(registration, "callerAccessPolicy", "caller_access_policy", "accessPolicy", "access_policy", "callerPolicy", "caller_policy") {
+		if boundPolicyEntryAllowsCaller(root, callerClass) {
+			return true
+		}
+		if classes := firstPolicyMap(root, "classes", "callerClasses", "caller_classes", "callers"); len(classes) > 0 {
+			for key, value := range classes {
+				if normalizeCallerClass(key) != callerClass {
+					continue
+				}
+				if boundPolicyValueEnabled(value) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func boundPaymentPolicyAllows(registration map[string]any, operation boundOperation) bool {
+	if registration == nil {
+		return false
+	}
+	for _, entry := range boundOperationPolicyEntries(registration, operation) {
+		if !boundPolicyEntryEnabled(entry) {
+			continue
+		}
+		if boundEntitlementPresent(entry) {
+			return true
+		}
+	}
+	for _, root := range boundPolicyRoots(registration, "paymentPolicy", "payment_policy", "entitlementPolicy", "entitlement_policy", "callerAccessPolicy", "caller_access_policy") {
+		if boundEntitlementPresent(root) {
+			return true
+		}
+	}
+	channel := boundOperationChannel(operation)
+	if channel != "" {
+		channels := firstPolicyMap(registration, "channels")
+		if channelMap := firstPolicyMap(channels, channel); boundEntitlementPresent(channelMap) {
+			return true
+		}
+		if channel == "sms" || channel == "voice" {
+			if phoneMap := firstPolicyMap(channels, "phone"); boundEntitlementPresent(phoneMap) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func boundOperationPolicyEntries(registration map[string]any, operation boundOperation) []map[string]any {
+	operation = normalizeBoundOperation(operation)
+	if registration == nil || operation == "" {
+		return nil
+	}
+	aliases := boundOperationAliases(operation)
+	entries := []map[string]any{}
+	if entry := hostedBoundSoulPolicyEntry(registration, operation); len(entry) > 0 {
+		entries = append(entries, entry)
+	}
+	for _, root := range boundPolicyRoots(registration, "capabilityPolicy", "capability_policy", "operationPolicy", "operation_policy", "boundBodyPolicy", "bound_body_policy", "bodyPolicy", "body_policy", "policy") {
+		entries = append(entries, boundEntriesFromOperationsMap(root, aliases)...)
+		for _, key := range []string{"capabilities", "operations", "policies", "rules"} {
+			for _, item := range firstArrayFromAny(root, key) {
+				entry := mapFromAny(item)
+				if len(entry) == 0 || !boundEntryMatchesOperation(entry, aliases) {
+					continue
+				}
+				entries = append(entries, entry)
+			}
+		}
+	}
+	return entries
+}
+
+func hostedBoundSoulPolicyEntry(registration map[string]any, operation boundOperation) map[string]any {
+	policy := hostedBoundSoulPolicy(registration)
+	if len(policy) == 0 {
+		return nil
+	}
+	entry := map[string]any{
+		"operation":     string(operation),
+		"enabled":       false,
+		"source":        "hosted-bound-soul/v1",
+		"callerClasses": hostedBoundSoulAllowedCallerClasses(policy),
+	}
+	if version := hostedBoundSoulPolicyVersion(policy); version != "" {
+		entry["policyVersion"] = version
+	}
+	if !hostedBoundSoulOperationalBindingAllowed(policy) {
+		return entry
+	}
+
+	capabilities := firstPolicyMap(policy, "capabilities")
+	phone := firstPolicyMap(capabilities, "phone")
+	switch operation {
+	case boundOperationEmailSend, boundOperationEmailRead, boundOperationEmailManage:
+		email := firstPolicyMap(capabilities, "email")
+		entry["enabled"] = boundPolicyValueEnabled(valueForPolicyKey(email, "defaultAllowed", "default_allowed"))
+	case boundOperationSMSSend, boundOperationSMSRead:
+		entry["enabled"] = boundPolicyValueEnabled(valueForPolicyKey(phone, "smsAllowed", "sms_allowed"))
+		if state := firstNonEmptyStringMap(phone, "entitlementStatus", "entitlement_status", "status", "state"); state != "" {
+			entry["entitlementState"] = state
+		}
+	case boundOperationVoiceRead:
+		entry["enabled"] = boundPolicyValueEnabled(valueForPolicyKey(phone, "voiceAllowed", "voice_allowed"))
+		if state := firstNonEmptyStringMap(phone, "entitlementStatus", "entitlement_status", "status", "state"); state != "" {
+			entry["entitlementState"] = state
+		}
+	case boundOperationChannelsRead, boundOperationIdentitySelfRead:
+		entry["enabled"] = true
+	default:
+		return nil
+	}
+	return entry
+}
+
+func hostedBoundSoulPolicy(registration map[string]any) map[string]any {
+	for _, key := range []string{"policy", "effectivePolicy", "effective_policy"} {
+		policy := firstPolicyMap(registration, key)
+		if hostedBoundSoulPolicyLooksExplicit(policy) {
+			return policy
+		}
+	}
+	for _, key := range []string{"contactability", "commContactability", "comm_contactability"} {
+		contactability := firstPolicyMap(registration, key)
+		if policy := firstPolicyMap(contactability, "policy", "effectivePolicy", "effective_policy"); hostedBoundSoulPolicyLooksExplicit(policy) {
+			return policy
+		}
+	}
+	return nil
+}
+
+func hostedBoundSoulPolicyLooksExplicit(policy map[string]any) bool {
+	if len(policy) == 0 {
+		return false
+	}
+	if hostedBoundSoulPolicyVersion(policy) == "hosted-bound-soul/v1" {
+		return true
+	}
+	return len(firstPolicyMap(policy, "capabilities")) > 0 &&
+		len(firstPolicyMap(policy, "callerAccessPayment", "caller_access_payment")) > 0
+}
+
+func hostedBoundSoulPolicyVersion(policy map[string]any) string {
+	return strings.ToLower(strings.TrimSpace(firstNonEmptyStringMap(policy, "version", "policyVersion", "policy_version")))
+}
+
+func hostedBoundSoulOperationalBindingAllowed(policy map[string]any) bool {
+	return normalizePolicyToken(firstNonEmptyStringMap(policy, "operationalBinding", "operational_binding")) == "hosted_bound_soul"
+}
+
+func hostedBoundSoulAllowedCallerClasses(policy map[string]any) []any {
+	if !hostedBoundSoulCallerPolicyPresent(policy) {
+		return nil
+	}
+	classes := []any{
+		string(boundCallerClassPrincipalOperator),
+		string(boundCallerClassBoundBody),
+		string(boundCallerClassInstanceKey),
+	}
+	callerAccessPayment := firstPolicyMap(policy, "callerAccessPayment", "caller_access_payment")
+	if hostedBoundSoulCallerAccessAllows(callerAccessPayment, "allowlistedPeer", "allowlisted_peer") {
+		classes = append(classes, string(boundCallerClassAllowlistedPeer))
+	}
+	return classes
+}
+
+func hostedBoundSoulCallerPolicyPresent(policy map[string]any) bool {
+	if normalizePolicyToken(firstNonEmptyStringMap(policy, "callerAccessPaymentPolicyVersion", "caller_access_payment_policy_version")) == "caller_access_payment/v1" {
+		return true
+	}
+	return len(firstPolicyMap(policy, "callerAccessPayment", "caller_access_payment")) > 0
+}
+
+func hostedBoundSoulCallerAccessAllows(root map[string]any, keys ...string) bool {
+	for _, key := range keys {
+		entry := firstPolicyMap(root, key)
+		if len(entry) == 0 {
+			continue
+		}
+		switch strings.ToLower(strings.TrimSpace(firstNonEmptyStringMap(entry, "access", "state", "status"))) {
+		case "allowed", "allow", "enabled", "active", "provisioned", "paid":
+			return true
+		}
+	}
+	return false
+}
+
+func valueForPolicyKey(m map[string]any, keys ...string) any {
+	for _, key := range keys {
+		if value, ok := lookupPolicyKey(m, key); ok {
+			return value
+		}
+	}
+	return nil
+}
+
+func boundEntriesFromOperationsMap(root map[string]any, aliases []string) []map[string]any {
+	if root == nil {
+		return nil
+	}
+	out := []map[string]any{}
+	for _, key := range []string{"operations", "operation", "capabilities", "capability"} {
+		ops := firstPolicyMap(root, key)
+		if len(ops) == 0 {
+			continue
+		}
+		for _, alias := range aliases {
+			raw, ok := lookupPolicyKey(ops, alias)
+			if !ok {
+				continue
+			}
+			entry := mapFromAny(raw)
+			if len(entry) == 0 {
+				entry = map[string]any{"operation": alias, "enabled": raw}
+			} else if _, ok := entry["operation"]; !ok {
+				entry["operation"] = alias
+			}
+			out = append(out, entry)
+		}
+	}
+	return out
+}
+
+func boundPolicyRoots(registration map[string]any, keys ...string) []map[string]any {
+	out := []map[string]any{registration}
+	for _, key := range keys {
+		if m := firstPolicyMap(registration, key); len(m) > 0 {
+			out = append(out, m)
+			for _, nestedKey := range keys {
+				if nested := firstPolicyMap(m, nestedKey); len(nested) > 0 {
+					out = append(out, nested)
+				}
+			}
+		}
+	}
+	return out
+}
+
+func firstPolicyMap(raw map[string]any, keys ...string) map[string]any {
+	if raw == nil {
+		return nil
+	}
+	for _, key := range keys {
+		if value, ok := lookupPolicyKey(raw, key); ok {
+			m := mapFromAny(value)
+			if len(m) > 0 {
+				return m
+			}
+		}
+	}
+	return nil
+}
+
+func lookupPolicyKey(m map[string]any, key string) (any, bool) {
+	if m == nil {
+		return nil, false
+	}
+	if value, ok := m[key]; ok {
+		return value, true
+	}
+	normalized := normalizePolicyToken(key)
+	for k, value := range m {
+		if normalizePolicyToken(k) == normalized {
+			return value, true
+		}
+	}
+	return nil, false
+}
+
+func boundEntryMatchesOperation(entry map[string]any, aliases []string) bool {
+	for _, key := range []string{"operation", "capability", "name", "tool", "id"} {
+		value := strings.TrimSpace(fmt.Sprint(entry[key]))
+		if value != "" && stringListContainsNormalized(aliases, value) {
+			return true
+		}
+	}
+	for _, key := range []string{"operations", "capabilities", "tools"} {
+		values := boundStringListFromAny(entry[key])
+		for _, value := range values {
+			if stringListContainsNormalized(aliases, value) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func boundPolicyEntryEnabled(entry map[string]any) bool {
+	if entry == nil {
+		return false
+	}
+	if effect := strings.ToLower(strings.TrimSpace(fmt.Sprint(entry["effect"]))); effect == "deny" || effect == "disabled" {
+		return false
+	}
+	for _, key := range []string{"enabled", "allowed", "allow", "active"} {
+		if raw, ok := lookupPolicyKey(entry, key); ok {
+			return boundPolicyValueEnabled(raw)
+		}
+	}
+	if status := strings.ToLower(strings.TrimSpace(fmt.Sprint(entry["status"]))); status != "" {
+		switch status {
+		case "enabled", "active", "allowed", "provisioned", "paid":
+			return true
+		case "disabled", "denied", "blocked", "inactive":
+			return false
+		}
+	}
+	return true
+}
+
+func boundPolicyEntryAllowsCaller(entry map[string]any, callerClass boundCallerClass) bool {
+	if entry == nil || callerClass == "" {
+		return false
+	}
+	for _, key := range []string{"callerClasses", "caller_classes", "callers", "allowedCallers", "allowed_callers", "allowedCallerClasses", "allowed_caller_classes"} {
+		values := boundStringListFromAny(entry[key])
+		for _, value := range values {
+			if normalizeCallerClass(value) == callerClass {
+				return true
+			}
+		}
+	}
+	if classes := firstPolicyMap(entry, "classes", "callerClasses", "caller_classes", "callers"); len(classes) > 0 {
+		for key, value := range classes {
+			if normalizeCallerClass(key) != callerClass {
+				continue
+			}
+			if boundPolicyValueEnabled(value) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func boundPolicyValueEnabled(raw any) bool {
+	switch typed := raw.(type) {
+	case bool:
+		return typed
+	case string:
+		switch strings.ToLower(strings.TrimSpace(typed)) {
+		case "true", "1", "yes", "on", "enabled", "active", "allowed", "allow", "provisioned", "paid":
+			return true
+		default:
+			return false
+		}
+	case map[string]any:
+		return boundPolicyEntryEnabled(typed)
+	default:
+		return false
+	}
+}
+
+func boundEntitlementPresent(entry map[string]any) bool {
+	if entry == nil {
+		return false
+	}
+	for _, key := range []string{"entitlement", "entitlements", "paymentPolicy", "payment_policy", "accessPaymentPolicy", "access_payment_policy"} {
+		if m := firstPolicyMap(entry, key); len(m) > 0 && boundEntitlementMapAllows(m) {
+			return true
+		}
+	}
+	for _, key := range []string{"entitlementState", "entitlement_state", "entitlementStatus", "entitlement_status", "paymentState", "payment_state", "paymentStatus", "payment_status"} {
+		if raw, ok := lookupPolicyKey(entry, key); ok {
+			if boundEntitlementStateAllows(fmt.Sprint(raw)) {
+				return true
+			}
+		}
+	}
+	for _, key := range []string{"paid", "provisioned", "entitled", "satisfied"} {
+		if raw, ok := lookupPolicyKey(entry, key); ok && boundPolicyValueEnabled(raw) {
+			return true
+		}
+	}
+	return false
+}
+
+func boundEntitlementMapAllows(m map[string]any) bool {
+	if m == nil {
+		return false
+	}
+	for _, key := range []string{"status", "state", "entitlementStatus", "entitlement_state", "paymentStatus", "payment_state"} {
+		if raw, ok := lookupPolicyKey(m, key); ok && boundEntitlementStateAllows(fmt.Sprint(raw)) {
+			return true
+		}
+	}
+	for _, key := range []string{"paid", "provisioned", "entitled", "satisfied", "active", "enabled", "allowed"} {
+		if raw, ok := lookupPolicyKey(m, key); ok && boundPolicyValueEnabled(raw) {
+			return true
+		}
+	}
+	return false
+}
+
+func boundEntitlementStateAllows(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "paid", "provisioned", "active", "enabled", "allowed", "satisfied":
+		return true
+	default:
+		return false
+	}
+}
+
+func boundPolicyVersion(registration map[string]any) string {
+	if policy := hostedBoundSoulPolicy(registration); len(policy) > 0 {
+		if version := hostedBoundSoulPolicyVersion(policy); version != "" {
+			return version
+		}
+	}
+	for _, key := range []string{"capabilityPolicy", "capability_policy", "callerAccessPolicy", "caller_access_policy", "boundBodyPolicy", "bound_body_policy", "policy"} {
+		root := firstPolicyMap(registration, key)
+		if len(root) == 0 {
+			continue
+		}
+		if version := firstNonEmptyStringMap(root, "policyVersion", "policy_version", "version"); version != "" {
+			return version
+		}
+	}
+	if version := firstNonEmptyStringMap(registration, "policyVersion", "policy_version"); version != "" {
+		return version
+	}
+	return ""
+}
+
+func normalizeBoundOperation(operation boundOperation) boundOperation {
+	value := strings.TrimSpace(string(operation))
+	switch value {
+	case string(boundOperationEmailSend):
+		return boundOperationEmailSend
+	case string(boundOperationEmailRead):
+		return boundOperationEmailRead
+	case string(boundOperationEmailManage):
+		return boundOperationEmailManage
+	case string(boundOperationSMSSend):
+		return boundOperationSMSSend
+	case string(boundOperationSMSRead):
+		return boundOperationSMSRead
+	case string(boundOperationVoiceRead):
+		return boundOperationVoiceRead
+	case string(boundOperationChannelsRead):
+		return boundOperationChannelsRead
+	case string(boundOperationIdentitySelfRead):
+		return boundOperationIdentitySelfRead
+	default:
+		return boundOperation(value)
+	}
+}
+
+func boundOperationRequiresEntitlement(operation boundOperation) bool {
+	switch operation {
+	case boundOperationSMSSend, boundOperationSMSRead, boundOperationVoiceRead:
+		return true
+	default:
+		return false
+	}
+}
+
+func boundOperationChannel(operation boundOperation) string {
+	switch operation {
+	case boundOperationEmailSend, boundOperationEmailRead, boundOperationEmailManage:
+		return "email"
+	case boundOperationSMSSend, boundOperationSMSRead:
+		return "sms"
+	case boundOperationVoiceRead:
+		return "voice"
+	default:
+		return ""
+	}
+}
+
+func boundOperationAliases(operation boundOperation) []string {
+	switch operation {
+	case boundOperationEmailSend:
+		return []string{"communication.email.send", "email.send", "email_send", "email-send", "email:send"}
+	case boundOperationEmailRead:
+		return []string{"communication.email.read", "email.read", "email_read", "email-read", "email:read"}
+	case boundOperationEmailManage:
+		return []string{"communication.email.manage", "email.manage", "email_manage", "email-manage", "email:manage"}
+	case boundOperationSMSSend:
+		return []string{"communication.sms.send", "sms.send", "sms_send", "sms-send", "sms:send"}
+	case boundOperationSMSRead:
+		return []string{"communication.sms.read", "sms.read", "sms_read", "sms-read", "sms:read"}
+	case boundOperationVoiceRead:
+		return []string{"communication.voice.read", "voice.read", "voice_read", "voicemail_read", "voicemail.read", "voice-receive"}
+	case boundOperationChannelsRead:
+		return []string{"communication.channels.read", "channels.read", "channels_read", "channels-read"}
+	case boundOperationIdentitySelfRead:
+		return []string{"identity.self.read", "identity_whoami", "identity.whoami", "identity-self-read"}
+	default:
+		if operation == "" {
+			return nil
+		}
+		return []string{string(operation)}
+	}
+}
+
+func boundStringListFromAny(raw any) []string {
+	switch typed := raw.(type) {
+	case []string:
+		return append([]string(nil), typed...)
+	case []any:
+		out := make([]string, 0, len(typed))
+		for _, item := range typed {
+			if s := strings.TrimSpace(fmt.Sprint(item)); s != "" {
+				out = append(out, s)
+			}
+		}
+		return out
+	case string:
+		if strings.TrimSpace(typed) == "" {
+			return nil
+		}
+		parts := strings.FieldsFunc(typed, func(r rune) bool {
+			return r == ',' || r == ' ' || r == '\n' || r == '\t'
+		})
+		out := make([]string, 0, len(parts))
+		for _, part := range parts {
+			if part = strings.TrimSpace(part); part != "" {
+				out = append(out, part)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func stringListContainsNormalized(values []string, want string) bool {
+	want = normalizePolicyToken(want)
+	if want == "" {
+		return false
+	}
+	for _, value := range values {
+		if normalizePolicyToken(value) == want {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizePolicyToken(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	value = strings.NewReplacer("-", "_", ".", "_", ":", "_", " ", "_").Replace(value)
+	for strings.Contains(value, "__") {
+		value = strings.ReplaceAll(value, "__", "_")
+	}
+	return strings.Trim(value, "_")
+}

--- a/internal/mcpserver/bound_operation_policy.go
+++ b/internal/mcpserver/bound_operation_policy.go
@@ -72,7 +72,11 @@ func withAgentContactabilityPolicy(ctx context.Context, client *soulapi.Client, 
 	if client == nil || normalizeSoulAgentID(agentID) == "" || len(hostedBoundSoulPolicy(registration)) > 0 {
 		return registration
 	}
-	contactabilityAny, err := client.DoJSON(ctx, "GET", "/api/v1/soul/comm/contactability/"+url.PathEscape(normalizeSoulAgentID(agentID)), nil, "", nil)
+	commBearer, err := requireCommAPIBearer(ctx)
+	if err != nil {
+		return registration
+	}
+	contactabilityAny, err := client.DoJSON(ctx, "GET", "/api/v1/soul/comm/contactability/"+url.PathEscape(normalizeSoulAgentID(agentID)), nil, commBearer, nil)
 	if err != nil {
 		return registration
 	}

--- a/internal/mcpserver/bound_operation_policy_helpers_test.go
+++ b/internal/mcpserver/bound_operation_policy_helpers_test.go
@@ -1,0 +1,22 @@
+package mcpserver
+
+import (
+	"fmt"
+	"strings"
+)
+
+func boundBodyPolicyJSONForTest(operations ...string) string {
+	entries := make([]string, 0, len(operations))
+	for _, operation := range operations {
+		operation = strings.TrimSpace(operation)
+		if operation == "" {
+			continue
+		}
+		entitlement := ""
+		if strings.Contains(operation, ".sms.") || strings.Contains(operation, ".voice.") {
+			entitlement = `,"entitlement":{"state":"provisioned"}`
+		}
+		entries = append(entries, fmt.Sprintf(`%q:{"enabled":true,"callerClasses":["bound_body"]%s}`, operation, entitlement))
+	}
+	return `"capabilityPolicy":{"version":"2026-05-16","operations":{` + strings.Join(entries, ",") + `}},"callerAccessPolicy":{"classes":{"bound_body":{"enabled":true}}}`
+}

--- a/internal/mcpserver/bound_operation_policy_test.go
+++ b/internal/mcpserver/bound_operation_policy_test.go
@@ -1,0 +1,197 @@
+package mcpserver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/equaltoai/lesser-body/internal/auth"
+)
+
+func TestBoundOperationPolicyDeniesBindingWithoutExplicitCapabilityPolicy(t *testing.T) {
+	ctx := auth.InjectToolContext(context.Background(), &auth.Principal{
+		Type:     auth.PrincipalTypeOAuthToken,
+		Identity: "agent1",
+		Claims:   &auth.Claims{Username: "agent1", Scopes: []string{"write"}},
+	}, "token")
+
+	registration := map[string]any{
+		"version":            "3",
+		"channels":           map[string]any{"email": map[string]any{"address": "agent@example.com", "capabilities": []any{"email-send"}}},
+		"contactPreferences": map[string]any{},
+	}
+
+	decision := decideBoundOperation(ctx, registration, boundOperationEmailSend)
+	if decision.Allowed {
+		t.Fatalf("expected binding-only registration to deny email_send")
+	}
+	if decision.Reason != "capability_policy_denied" {
+		t.Fatalf("expected capability_policy_denied, got %+v", decision)
+	}
+}
+
+func TestBoundOperationPolicyAllowsHostEffectivePolicy(t *testing.T) {
+	ctx := auth.InjectToolContext(context.Background(), &auth.Principal{
+		Type:     auth.PrincipalTypeOAuthToken,
+		Identity: "agent1",
+		Claims:   &auth.Claims{Username: "agent1", Scopes: []string{"write"}},
+	}, "token")
+
+	registration := map[string]any{
+		"version": "3",
+		"policy": map[string]any{
+			"version":                          "hosted-bound-soul/v1",
+			"operationalBinding":               "hosted_bound_soul",
+			"capabilityPolicyVersion":          "capability-policy/v1",
+			"callerAccessPaymentPolicyVersion": "caller-access-payment/v1",
+			"capabilities": map[string]any{
+				"email": map[string]any{"defaultAllowed": true},
+				"phone": map[string]any{
+					"entitlementStatus": "not_entitled",
+					"smsAllowed":        false,
+					"voiceAllowed":      false,
+				},
+			},
+			"callerAccessPayment": map[string]any{
+				"publicPaidCaller": map[string]any{"access": "denied"},
+			},
+		},
+	}
+
+	if decision := decideBoundOperation(ctx, registration, boundOperationEmailSend); !decision.Allowed {
+		t.Fatalf("expected hosted-bound-soul/v1 email policy to allow email_send, got %+v", decision)
+	}
+	operatorCtx := auth.InjectToolContext(context.Background(), &auth.Principal{
+		Type:     auth.PrincipalTypeOAuthToken,
+		Identity: "agent1",
+		Claims:   &auth.Claims{Username: "agent1", DelegatedBy: "operator"},
+	}, "token")
+	if decision := decideBoundOperation(operatorCtx, registration, boundOperationEmailSend); !decision.Allowed {
+		t.Fatalf("expected principal operator caller to allow email_send under hosted policy, got %+v", decision)
+	}
+	peerCtx := auth.InjectToolContext(context.Background(), &auth.Principal{
+		Type:     auth.PrincipalTypeOAuthToken,
+		Identity: "agent1",
+		Claims:   &auth.Claims{Username: "agent1", ClientClass: "allowlisted_peer"},
+	}, "token")
+	if decision := decideBoundOperation(peerCtx, registration, boundOperationEmailSend); decision.Allowed || decision.Reason != "caller_access_policy_denied" {
+		t.Fatalf("expected allowlisted peer to require explicit caller access policy, got %+v", decision)
+	}
+	if decision := decideBoundOperation(ctx, registration, boundOperationSMSSend); decision.Allowed || decision.Reason != "capability_policy_denied" {
+		t.Fatalf("expected hosted-bound-soul/v1 phone policy to deny unentitled sms_send, got %+v", decision)
+	}
+	registration["policy"].(map[string]any)["capabilities"].(map[string]any)["phone"].(map[string]any)["entitlementStatus"] = "provisioned"
+	registration["policy"].(map[string]any)["capabilities"].(map[string]any)["phone"].(map[string]any)["smsAllowed"] = true
+	if decision := decideBoundOperation(ctx, registration, boundOperationSMSSend); !decision.Allowed {
+		t.Fatalf("expected hosted-bound-soul/v1 provisioned sms policy to allow sms_send, got %+v", decision)
+	}
+}
+
+func TestBoundOperationPolicyDistinguishesCallerClasses(t *testing.T) {
+	scenarios := []struct {
+		name      string
+		principal *auth.Principal
+		want      boundCallerClass
+	}{
+		{
+			name: "bound body default",
+			principal: &auth.Principal{
+				Type:     auth.PrincipalTypeOAuthToken,
+				Identity: "agent1",
+				Claims:   &auth.Claims{Username: "agent1"},
+			},
+			want: boundCallerClassBoundBody,
+		},
+		{
+			name: "principal operator from delegated claim",
+			principal: &auth.Principal{
+				Type:     auth.PrincipalTypeOAuthToken,
+				Identity: "agent1",
+				Claims:   &auth.Claims{Username: "agent1", DelegatedBy: "operator"},
+			},
+			want: boundCallerClassPrincipalOperator,
+		},
+		{
+			name: "instance key",
+			principal: &auth.Principal{
+				Type:     auth.PrincipalTypeInstanceKey,
+				Identity: "instance",
+			},
+			want: boundCallerClassInstanceKey,
+		},
+		{
+			name: "allowlisted peer",
+			principal: &auth.Principal{
+				Type:     auth.PrincipalTypeOAuthToken,
+				Identity: "agent1",
+				Claims:   &auth.Claims{Username: "agent1", ClientClass: "allowlisted_peer"},
+			},
+			want: boundCallerClassAllowlistedPeer,
+		},
+		{
+			name: "public paid",
+			principal: &auth.Principal{
+				Type:     auth.PrincipalTypeOAuthToken,
+				Identity: "agent1",
+				Claims:   &auth.Claims{Username: "agent1", ClientClass: "public_paid"},
+			},
+			want: boundCallerClassPublicPaid,
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			ctx := auth.InjectToolContext(context.Background(), scenario.principal, "token")
+			if got := classifyBoundOperationCaller(ctx); got != scenario.want {
+				t.Fatalf("caller class: got %q want %q", got, scenario.want)
+			}
+		})
+	}
+}
+
+func TestBoundOperationPolicyDeniesPublicPaidAndRequiresPhoneEntitlement(t *testing.T) {
+	registration := map[string]any{
+		"version": "3",
+		"capabilityPolicy": map[string]any{
+			"version": "2026-05-16",
+			"operations": map[string]any{
+				"communication.email.send": map[string]any{
+					"enabled":       true,
+					"callerClasses": []any{"bound_body", "public_paid"},
+				},
+				"communication.sms.send": map[string]any{
+					"enabled":       true,
+					"callerClasses": []any{"bound_body"},
+				},
+			},
+		},
+		"callerAccessPolicy": map[string]any{
+			"classes": map[string]any{
+				"bound_body":  map[string]any{"enabled": true},
+				"public_paid": map[string]any{"enabled": true},
+			},
+		},
+	}
+
+	publicPaid := auth.InjectToolContext(context.Background(), &auth.Principal{
+		Type:     auth.PrincipalTypeOAuthToken,
+		Identity: "agent1",
+		Claims:   &auth.Claims{Username: "agent1", ClientClass: "public_paid"},
+	}, "token")
+	if decision := decideBoundOperation(publicPaid, registration, boundOperationEmailSend); decision.Allowed || decision.Reason != "public_paid_callers_denied_in_m1" {
+		t.Fatalf("expected public paid caller to be modeled but denied in M1, got %+v", decision)
+	}
+
+	boundBody := auth.InjectToolContext(context.Background(), &auth.Principal{
+		Type:     auth.PrincipalTypeOAuthToken,
+		Identity: "agent1",
+		Claims:   &auth.Claims{Username: "agent1"},
+	}, "token")
+	if decision := decideBoundOperation(boundBody, registration, boundOperationSMSSend); decision.Allowed || decision.Reason != "paid_or_provisioned_entitlement_required" {
+		t.Fatalf("expected sms_send to require paid/provisioned entitlement, got %+v", decision)
+	}
+
+	registration["capabilityPolicy"].(map[string]any)["operations"].(map[string]any)["communication.sms.send"].(map[string]any)["entitlement"] = map[string]any{"state": "provisioned"}
+	if decision := decideBoundOperation(boundBody, registration, boundOperationSMSSend); !decision.Allowed {
+		t.Fatalf("expected provisioned sms entitlement to allow operation, got %+v", decision)
+	}
+}

--- a/internal/mcpserver/cancellation_test.go
+++ b/internal/mcpserver/cancellation_test.go
@@ -44,7 +44,7 @@ func TestSmsSendStreamingHonorsCanceledContext(t *testing.T) {
 		case "/api/v1/soul/agents/" + agentID:
 			_, _ = w.Write([]byte(`{"version":"1","agent":{"agent_id":"` + agentID + `","domain":"test.example.com","local_id":"agent-eve","status":"active"}}`))
 		case "/api/v1/soul/agents/" + agentID + "/registration":
-			_, _ = w.Write([]byte(`{"version":"3","channels":{"phone":{"number":"+15550142","capabilities":["sms-send"],"verified":true}},"contactPreferences":{}}`))
+			_, _ = w.Write([]byte(`{"version":"3","channels":{"phone":{"number":"+15550142","capabilities":["sms-send"],"verified":true,"entitlement":{"state":"provisioned"}}},"contactPreferences":{},` + boundBodyPolicyJSONForTest("communication.sms.send") + `}`))
 		case "/api/v1/soul/comm/send":
 			_, _ = io.ReadAll(r.Body)
 			closeStarted.Do(func() { close(started) })

--- a/internal/mcpserver/email_tools.go
+++ b/internal/mcpserver/email_tools.go
@@ -149,7 +149,7 @@ func handleEmailReplyWithProgress(ctx context.Context, args json.RawMessage, emi
 		return toolErrorResult("invalid_request", "body is required", 400, nil)
 	}
 
-	deps, err := loadCommMailboxDependencies(ctx)
+	deps, err := loadCommMailboxDependencies(ctx, boundOperationEmailSend)
 	if err != nil {
 		return commMailboxToolResultFromError(err)
 	}

--- a/internal/mcpserver/identity_resources.go
+++ b/internal/mcpserver/identity_resources.go
@@ -13,7 +13,7 @@ func resourceChannels(ctx context.Context) ([]mcpruntime.ResourceContent, error)
 		return authResourceContentsFromError("agent://channels", err)
 	}
 
-	payload, err := whoamiChannelsPayload(ctx)
+	payload, err := authorizedAgentChannelsPayload(ctx, boundOperationChannelsRead)
 	if err != nil {
 		return resourceJSON("agent://channels", map[string]any{
 			"error": identityErrorPayload(err),
@@ -28,7 +28,7 @@ func resourceChannelPreferences(ctx context.Context) ([]mcpruntime.ResourceConte
 		return authResourceContentsFromError("agent://channels/preferences", err)
 	}
 
-	payload, err := whoamiChannelsPayload(ctx)
+	payload, err := authorizedAgentChannelsPayload(ctx, boundOperationChannelsRead)
 	if err != nil {
 		return resourceJSON("agent://channels/preferences", map[string]any{
 			"error": identityErrorPayload(err),

--- a/internal/mcpserver/identity_tools.go
+++ b/internal/mcpserver/identity_tools.go
@@ -42,7 +42,7 @@ func handleIdentityWhoami(ctx context.Context, args json.RawMessage) (*mcpruntim
 		return authToolResultFromError(err)
 	}
 
-	payload, err := whoamiChannelsPayload(ctx)
+	payload, err := authorizedAgentChannelsPayload(ctx, boundOperationIdentitySelfRead)
 	if err != nil {
 		return identityToolResultFromError(err)
 	}
@@ -111,7 +111,7 @@ func whoamiChannelsPayload(ctx context.Context) (map[string]any, error) {
 		return nil, &toolUserError{Code: "not_found", Message: "no bound soul found for this agent", Status: 404}
 	}
 
-	payload, err := agentChannelsPayload(ctx, client, agentID)
+	payload, _, err := agentChannelsPayloadWithRegistration(ctx, client, agentID)
 	if err != nil {
 		return nil, err
 	}
@@ -286,26 +286,32 @@ func agentPublicIdentityPayload(ctx context.Context, client *soulapi.Client, age
 }
 
 func agentChannelsPayload(ctx context.Context, client *soulapi.Client, agentID string) (map[string]any, error) {
+	payload, _, err := agentChannelsPayloadWithRegistration(ctx, client, agentID)
+	return payload, err
+}
+
+func agentChannelsPayloadWithRegistration(ctx context.Context, client *soulapi.Client, agentID string) (map[string]any, map[string]any, error) {
 	if client == nil {
-		return nil, errors.New("soul api client is nil")
+		return nil, nil, errors.New("soul api client is nil")
 	}
 	agentID = normalizeSoulAgentID(agentID)
 	if agentID == "" {
-		return nil, &toolUserError{Code: "invalid_request", Message: "missing agentId", Status: 400}
+		return nil, nil, &toolUserError{Code: "invalid_request", Message: "missing agentId", Status: 400}
 	}
 
 	agentAny, err := client.DoJSON(ctx, "GET", "/api/v1/soul/agents/"+url.PathEscape(agentID), nil, "", nil)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	agentEnvelope, _ := agentAny.(map[string]any)
 	agent, _ := agentEnvelope["agent"].(map[string]any)
 
 	regAny, err := client.DoJSON(ctx, "GET", "/api/v1/soul/agents/"+url.PathEscape(agentID)+"/registration", nil, "", nil)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	reg, _ := regAny.(map[string]any)
+	reg = normalizeSoulReadRegistrationEnvelope(reg)
 
 	channels, _ := reg["channels"].(map[string]any)
 	contactPreferences, _ := reg["contactPreferences"].(map[string]any)
@@ -328,7 +334,7 @@ func agentChannelsPayload(ctx context.Context, client *soulapi.Client, agentID s
 			return contactPreferences
 		}(),
 	}
-	return out, nil
+	return out, reg, nil
 }
 
 func identityToolResultFromError(err error) (*mcpruntime.ToolResult, error) {

--- a/internal/mcpserver/identity_verify_tools.go
+++ b/internal/mcpserver/identity_verify_tools.go
@@ -87,7 +87,7 @@ func handleMessageScopedIdentityVerify(ctx context.Context, client *soulapi.Clie
 		return authToolResultFromError(err)
 	}
 
-	message, source, err := findCommunicationMessage(ctx, token, messageID)
+	message, source, err := findCommunicationMessage(ctx, token, messageID, boundOperationForIdentityVerifyMailboxRead(channel))
 	if err != nil {
 		return identityVerifyMessageResultFromError(err)
 	}
@@ -246,14 +246,14 @@ func findCommunicationNotification(ctx context.Context, bearerToken string, mess
 	return nil, nil
 }
 
-func findCommunicationMessage(ctx context.Context, bearerToken string, messageID string) (map[string]any, string, error) {
+func findCommunicationMessage(ctx context.Context, bearerToken string, messageID string, mailboxReadOperation boundOperation) (map[string]any, string, error) {
 	messageID = strings.TrimSpace(messageID)
 	if messageID == "" {
 		return nil, "", nil
 	}
 
 	if isHostMailboxMessageRef(messageID) {
-		message, err := findHostMailboxMessage(ctx, messageID)
+		message, err := findHostMailboxMessage(ctx, messageID, mailboxReadOperation)
 		if err != nil {
 			if isHostMailboxNotFound(err) {
 				return nil, "lesser-host-mailbox", nil
@@ -270,8 +270,19 @@ func findCommunicationMessage(ctx context.Context, bearerToken string, messageID
 	return notification, "lesser-notification", nil
 }
 
-func findHostMailboxMessage(ctx context.Context, messageID string) (map[string]any, error) {
-	deps, err := loadCommMailboxDependencies(ctx, boundOperationChannelsRead)
+func boundOperationForIdentityVerifyMailboxRead(channel string) boundOperation {
+	switch strings.ToLower(strings.TrimSpace(channel)) {
+	case "phone":
+		return boundOperationSMSRead
+	case "email", "ens":
+		return boundOperationEmailRead
+	default:
+		return ""
+	}
+}
+
+func findHostMailboxMessage(ctx context.Context, messageID string, operation boundOperation) (map[string]any, error) {
+	deps, err := loadCommMailboxDependencies(ctx, operation)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/mcpserver/identity_verify_tools.go
+++ b/internal/mcpserver/identity_verify_tools.go
@@ -294,7 +294,69 @@ func findHostMailboxMessage(ctx context.Context, messageID string, operation bou
 	if message == nil {
 		return nil, errors.New("unexpected mailbox message response")
 	}
+	if err := authorizeFetchedHostMailboxMessage(ctx, message, operation); err != nil {
+		return nil, err
+	}
 	return message, nil
+}
+
+func authorizeFetchedHostMailboxMessage(ctx context.Context, message map[string]any, initiallyAuthorizedOperation boundOperation) error {
+	actualOperation := boundOperationForHostMailboxMessage(message)
+	if actualOperation == "" {
+		return &toolUserError{
+			Code:    "operation_not_allowed",
+			Message: "operation is not allowed by current bound-body policy",
+			Status:  403,
+			Details: map[string]any{
+				"source": "bound_body_operation_policy",
+				"reason": "mailbox_channel_policy_required",
+			},
+		}
+	}
+	if actualOperation == initiallyAuthorizedOperation {
+		return nil
+	}
+	_, err := authorizedAgentChannelsPayload(ctx, actualOperation)
+	return err
+}
+
+func boundOperationForHostMailboxMessage(message map[string]any) boundOperation {
+	switch hostMailboxMessageChannel(message) {
+	case "email":
+		return boundOperationEmailRead
+	case "sms":
+		return boundOperationSMSRead
+	case "voice", "voicemail":
+		return boundOperationVoiceRead
+	default:
+		return ""
+	}
+}
+
+func hostMailboxMessageChannel(message map[string]any) string {
+	if message == nil {
+		return ""
+	}
+	if channel := notificationChannel(message); channel != "" {
+		return channel
+	}
+	for _, key := range []string{"channelType", "channel_type", "type"} {
+		if value := strings.ToLower(strings.TrimSpace(stringFromMap(message, key))); value != "" {
+			return value
+		}
+	}
+	for _, container := range []string{"communication", "data", "payload"} {
+		child, _ := message[container].(map[string]any)
+		if child == nil {
+			continue
+		}
+		for _, key := range []string{"channelType", "channel_type", "type"} {
+			if value := strings.ToLower(strings.TrimSpace(stringFromMap(child, key))); value != "" {
+				return value
+			}
+		}
+	}
+	return ""
 }
 
 func isHostMailboxMessageRef(messageID string) bool {

--- a/internal/mcpserver/identity_verify_tools.go
+++ b/internal/mcpserver/identity_verify_tools.go
@@ -271,7 +271,7 @@ func findCommunicationMessage(ctx context.Context, bearerToken string, messageID
 }
 
 func findHostMailboxMessage(ctx context.Context, messageID string) (map[string]any, error) {
-	deps, err := loadCommMailboxDependencies(ctx)
+	deps, err := loadCommMailboxDependencies(ctx, boundOperationChannelsRead)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/mcpserver/inbox_resources.go
+++ b/internal/mcpserver/inbox_resources.go
@@ -3,6 +3,7 @@ package mcpserver
 import (
 	"context"
 	"encoding/json"
+	"strings"
 
 	mcpruntime "github.com/theory-cloud/apptheory/runtime/mcp"
 )
@@ -42,7 +43,7 @@ func resourceVoicemail(ctx context.Context) ([]mcpruntime.ResourceContent, error
 }
 
 func resourceMailboxList(ctx context.Context, uri string, opts commMailboxListOptions) (map[string]any, error) {
-	deps, err := loadCommMailboxDependencies(ctx)
+	deps, err := loadCommMailboxDependencies(ctx, boundOperationForMailboxResource(opts))
 	if err != nil {
 		contents, resErr := commMailboxResourceContentsFromError(uri, err)
 		if resErr != nil {
@@ -59,6 +60,19 @@ func resourceMailboxList(ctx context.Context, uri string, opts commMailboxListOp
 		return resourceContentsPayload(contents), nil
 	}
 	return out, nil
+}
+
+func boundOperationForMailboxResource(opts commMailboxListOptions) boundOperation {
+	switch strings.ToLower(strings.TrimSpace(opts.ChannelType)) {
+	case "email":
+		return boundOperationEmailRead
+	case "sms":
+		return boundOperationSMSRead
+	case "voice", "voicemail":
+		return boundOperationVoiceRead
+	default:
+		return boundOperationChannelsRead
+	}
 }
 
 func resourceContentsPayload(contents []mcpruntime.ResourceContent) map[string]any {

--- a/internal/mcpserver/inbox_tools.go
+++ b/internal/mcpserver/inbox_tools.go
@@ -42,7 +42,7 @@ func handleEmailRead(ctx context.Context, args json.RawMessage) (*mcpruntime.Too
 	archived := optionalBoolArg(args, "archived")
 	deleted := optionalBoolArg(args, "deleted")
 
-	deps, err := loadCommMailboxDependencies(ctx)
+	deps, err := loadCommMailboxDependencies(ctx, boundOperationEmailRead)
 	if err != nil {
 		return commMailboxToolResultFromError(err)
 	}
@@ -95,7 +95,7 @@ func handleEmailGet(ctx context.Context, args json.RawMessage) (*mcpruntime.Tool
 	if err := json.Unmarshal(args, &in); err != nil {
 		return nil, invalidParams("invalid args: " + err.Error())
 	}
-	deps, err := loadCommMailboxDependencies(ctx)
+	deps, err := loadCommMailboxDependencies(ctx, boundOperationEmailRead)
 	if err != nil {
 		return commMailboxToolResultFromError(err)
 	}
@@ -114,7 +114,7 @@ func handleEmailGetContent(ctx context.Context, args json.RawMessage) (*mcprunti
 	if err := json.Unmarshal(args, &in); err != nil {
 		return nil, invalidParams("invalid args: " + err.Error())
 	}
-	deps, err := loadCommMailboxDependencies(ctx)
+	deps, err := loadCommMailboxDependencies(ctx, boundOperationEmailRead)
 	if err != nil {
 		return commMailboxToolResultFromError(err)
 	}
@@ -158,7 +158,7 @@ func handleEmailSearch(ctx context.Context, args json.RawMessage) (*mcpruntime.T
 	archived := optionalBoolArg(args, "archived")
 	deleted := optionalBoolArg(args, "deleted")
 
-	deps, err := loadCommMailboxDependencies(ctx)
+	deps, err := loadCommMailboxDependencies(ctx, boundOperationEmailRead)
 	if err != nil {
 		return commMailboxToolResultFromError(err)
 	}
@@ -220,7 +220,7 @@ func handleEmailDelete(ctx context.Context, args json.RawMessage) (*mcpruntime.T
 		return nil, invalidParams("invalid action (expected delete or archive)")
 	}
 
-	deps, err := loadCommMailboxDependencies(ctx)
+	deps, err := loadCommMailboxDependencies(ctx, boundOperationEmailManage)
 	if err != nil {
 		return commMailboxToolResultFromError(err)
 	}
@@ -247,7 +247,7 @@ func handleEmailReadState(ctx context.Context, args json.RawMessage, action stri
 	if err := json.Unmarshal(args, &in); err != nil {
 		return nil, invalidParams("invalid args: " + err.Error())
 	}
-	deps, err := loadCommMailboxDependencies(ctx)
+	deps, err := loadCommMailboxDependencies(ctx, boundOperationEmailManage)
 	if err != nil {
 		return commMailboxToolResultFromError(err)
 	}
@@ -280,7 +280,7 @@ func handleSmsRead(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolR
 	archived := optionalBoolArg(args, "archived")
 	deleted := optionalBoolArg(args, "deleted")
 
-	deps, err := loadCommMailboxDependencies(ctx)
+	deps, err := loadCommMailboxDependencies(ctx, boundOperationSMSRead)
 	if err != nil {
 		return commMailboxToolResultFromError(err)
 	}
@@ -338,7 +338,7 @@ func handleVoicemailRead(ctx context.Context, args json.RawMessage) (*mcpruntime
 	archived := optionalBoolArg(args, "archived")
 	deleted := optionalBoolArg(args, "deleted")
 
-	deps, err := loadCommMailboxDependencies(ctx)
+	deps, err := loadCommMailboxDependencies(ctx, boundOperationVoiceRead)
 	if err != nil {
 		return commMailboxToolResultFromError(err)
 	}

--- a/internal/mcpserver/mailbox_host_tools.go
+++ b/internal/mcpserver/mailbox_host_tools.go
@@ -41,12 +41,12 @@ type commMailboxListOptions struct {
 	Deleted         *bool
 }
 
-func loadCommMailboxDependencies(ctx context.Context) (*commMailboxDependencies, error) {
+func loadCommMailboxDependencies(ctx context.Context, operation boundOperation) (*commMailboxDependencies, error) {
 	if _, err := requireOAuthBearer(ctx); err != nil {
 		return nil, err
 	}
 
-	identity, err := whoamiChannelsPayload(ctx)
+	identity, err := authorizedAgentChannelsPayload(ctx, operation)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/mcpserver/outbound_comm_tools.go
+++ b/internal/mcpserver/outbound_comm_tools.go
@@ -138,7 +138,7 @@ func loadCommSendDependencies(ctx context.Context, channel string) (*commSendDep
 		return nil, res, resErr
 	}
 
-	identity, err := whoamiChannelsPayload(ctx)
+	identity, err := authorizedAgentChannelsPayload(ctx, boundOperationForOutboundChannel(channel))
 	if err != nil {
 		res, resErr := identityToolResultFromError(err)
 		return nil, res, resErr
@@ -171,6 +171,19 @@ func loadCommSendDependencies(ctx context.Context, channel string) (*commSendDep
 		commBearer: commBearer,
 		advisory:   commBoundaryAdvisoryForChannel(ctx, client, agentID, channel),
 	}, nil, nil
+}
+
+func boundOperationForOutboundChannel(channel string) boundOperation {
+	switch strings.ToLower(strings.TrimSpace(channel)) {
+	case "email":
+		return boundOperationEmailSend
+	case "sms":
+		return boundOperationSMSSend
+	case "voice":
+		return boundOperationVoiceRead
+	default:
+		return boundOperation(strings.TrimSpace(channel))
+	}
 }
 
 func requireCommAPIBearer(ctx context.Context) (string, error) {


### PR DESCRIPTION
## Milestone

Project 32 M1 / lesser-body #218 — enforce capability and caller policy per bound-body operation.

Closes #218 after the cross-repo M1 gates are accepted.

## Classification

Security / scope-profile / tool-surface semantic tightening / MCP-contract-adjacent / lesser-integration / host-delegation.

## Surfaces affected

- Private communication tools: `email_send`, `email_reply`, email mailbox read/manage tools, `sms_send`, `sms_read`, `voicemail_read`.
- Self-channel surfaces: `identity_whoami`, `agent://channels`, `agent://channels/preferences`.
- Host mailbox lookup used by message-scoped `identity_verify`.
- Host policy consumption through Soul Comm contactability (`hosted-bound-soul/v1`) when registration does not already embed an explicit operation policy.
- Documentation for MCP and security behavior.

## Specialist walks referenced

- Tool surface: no tool names, input schemas, output schemas, scope declarations, or profile declarations changed. This is a fail-closed semantic tightening for souled private operations.
- MCP contract: `.well-known/mcp.json`, OAuth protected-resource metadata, and JSON-RPC envelopes are unchanged. Denials use existing tool/resource error paths with sanitized `operation_not_allowed` payloads.
- Lesser integration: OAuth bearer validation and Lesser `/api/v1/souls/bound/me` verification remain required before policy evaluation. No SSM, DynamoDB, or Lesser REST shape changes.
- Host delegation: policy denial happens before any lesser-host `/api/v1/soul/comm/*` send/mailbox call. Communication delivery remains delegated to lesser-host.
- Framework: no AppTheory/TableTheory patches.

## Consumer impact

Souled MCP clients still discover the same tools, resources, and prompts. Calls to private communication or self-channel operations now require an explicit Host effective policy or equivalent operation policy in addition to the existing JWT scope/profile and Lesser-bound-soul checks. A bound soul with only channel presence/capabilities is denied.

M1 models `principal_operator`, `bound_body`, `instance_key`, `allowlisted_peer`, and `public_paid`; `public_paid` is always denied in M1. No public x402 invocation path is implemented.

## Tasks

- [x] Enforce binding + capability policy + caller access/payment policy per private bound-body operation.
- [x] Consume Host `hosted-bound-soul/v1` effective policy through Soul Comm contactability.
- [x] Keep public paid caller modeled/denied; no public x402 invocation.
- [x] Fail closed with sanitized denial details and no host comm call on denial.
- [x] Add regression coverage for binding-only denial, caller-class distinction, public-paid denial, and phone entitlement handling.
- [x] Update operator/MCP/security docs.

## Validation

- `git diff --check`
- `go test ./...`
- `go vet ./...`
- `gofmt -l .` (empty)
- `scripts/build.sh`

No CDK changes; `cdk synth` not run.

## Stage rollout plan (handoff to deploy-body)

- [ ] Merged to main after review and cross-repo M1 gates
- [ ] Deployed to lab / dev
- [ ] Lab soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live with explicit operator authorization

## Cross-repo coordination

Draft/merge gate: enforcement must not merge until Host #312/#313 and Lesser #985 are ready or explicitly accepted by Arch.

Current coordination evidence as of PR open:

- Host: equaltoai/lesser-host#312/#313 have PR equaltoai/lesser-host#318 open, defining `hosted-bound-soul/v1` effective policy and Soul Comm contactability.
- Lesser: equaltoai/lesser#985 has PR equaltoai/lesser#986 open, documenting Lesser API/OAuth/ActivityPub boundary responsibilities.
- Body: this PR remains draft until Arch accepts the cross-repo boundary or the upstream gates are ready.

## Advisor-brief authorization

Aron explicitly authorized execution in-session on 2026-05-16 after Arch relayed the assignment email without a provenance signature. Body ACKed Arch by email (`delivery-e3e396dad9c9a711`) and ACKed #218 in GitHub comment `4468411693`.
