### PR TITLE
feat(mcp): add shared read shaping baseline

### DIFF
--- a/docs/m0-baseline-probe.md
+++ b/docs/m0-baseline-probe.md
@@ -59,7 +59,7 @@ full M0 closure evidence.
 The probe treats semantic failure payloads as failures, not successful MCP transport:
 
 - message-scoped `identity_verify` must return `messageFound:true` and `verified:true`;
-- `notifications_read` default calls must include diagnostics and must not expose `raw` or `_raw` notification payloads;
+- `notifications_read` probe calls request `include_diagnostics=true` and must not expose `raw` or `_raw` notification payloads;
 - `email_read`, `sms_read`, and `voicemail_read` must not return an empty page with `hasMore:true`, and any
   `hasMore:true` page must include `nextCursor`.
 - when `PROBE_M0_CLOSURE=true`, a list-returned notification ID must pass the semantic workflow
@@ -75,7 +75,7 @@ The report must include:
 - pass/fail/skip per probe;
 - elapsed time per probe;
 - approximate payload size for large read paths;
-- `notifications_read.diagnostics` timing/size fields;
+- `notifications_read.diagnostics` timing/size fields when probes request `include_diagnostics=true`;
 - whether default notification output omitted raw/debug payloads;
 - whether the run is smoke-only or closure-mode (`SUMMARY.mode` and `SUMMARY.closureReady`);
 - for closure-mode runs, notification workflow details: selected notification type/id (redacted), direct Lesser
@@ -87,7 +87,7 @@ The report must include:
 
 M0 is not closed until Ops reports repeatable baseline usability in the deployed environment:
 
-- `notifications_read({"since":"", "limit":30})` no longer times out;
+- `notifications_read({"since":"", "limit":30, "include_diagnostics":true})` no longer times out;
 - Host mailbox messageRef verification works where authoritative sender provenance exists;
 - email/SMS/voicemail filtered pagination is sane;
 - identity lookup/verify and timestamp-since notification reads do not regress;

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -384,6 +384,28 @@ Scope key:
 | `identity_lookup` | Read | Resolve a public soul identity by full agent ID, ENS name, a current-instance local ID such as `medic`, an explicit remote ActivityPub handle such as `@steward@remote.example`, or a canonical actor URL such as `https://remote.example/users/steward`; returns public identity summary only. |
 | `identity_verify` | Read | Verify that a recent communication matches a resolved soul identity using public ENS resolution plus authoritative message provenance. Private email/phone verification fails closed unless Host supplies authoritative sender-identifier provenance. |
 
+### Shared read-tool shaping parameters
+
+Project 33 introduces a shared, opt-in vocabulary for large read tools. A tool advertises these parameters in its
+`inputSchema` only after that tool implements the behavior; clients must not assume every read tool accepts every
+parameter during the migration. The shared names are:
+
+- `view` — optional projection selector. `standard` preserves the current response shape; `compact`, `summary`, and
+  `full` are per-tool opt-ins used only when advertised.
+- `fields` — optional list of top-level or dotted fields to return when a tool supports field projection.
+- `include` — optional list of related blocks to expand when the selected view omits them.
+- `preview_chars` — optional character budget for previews, with `0` meaning the tool default.
+- `max_output_bytes` — optional caller budget for the MCP tool result. Tools that honor it report omitted/truncated
+  metadata rather than silently dropping fields.
+- `include_diagnostics` — optional timing/size diagnostics for Ops probes. It defaults to `false` for user-facing
+  reads; diagnostics are never emitted by default for large read tools.
+
+Structured-first result shaping is additive. Existing tools that use `content[0].text` as JSON keep their current
+`standard` behavior until explicitly migrated. New compact/summary responses should keep `content[0].text` concise
+(JSON summaries and locators for text-only clients) while preserving authoritative full data in
+`structuredContent.data`. If diagnostics are requested, concise text should point to `structuredContent.diagnostics`
+rather than duplicating timing/size payloads.
+
 Notes:
 
 - Social tools require an **OAuth JWT** bearer token (not just an instance key) because they call the Lesser API on behalf
@@ -408,8 +430,9 @@ Notes:
 - `notifications_read` omits full upstream `raw` notification objects by default and accepts optional
   `include_raw=true`, which returns `_raw` on each notification for expensive audit/debug use. Default notifications
   contain compact `actor`, bounded `targetPost`, optional bounded `communication` summaries, normalized read state
-  (`read` when Lesser exposes it, inferred from `unread` where needed), cursor/since metadata, and best-effort
-  `diagnostics` timing/size fields for Ops probes.
+  (`read` when Lesser exposes it, inferred from `unread` where needed), and cursor/since metadata.
+  `include_diagnostics=true` adds best-effort timing/size fields for Ops probes; user-facing default reads omit
+  diagnostics.
 - `conversations_read` defaults to `limit=20` (maximum `80`) and returns compact conversation summaries: id, unread
   state, updated timestamp, compact participants, and bounded `lastPost`. It accepts optional `include_raw=true`, which
   returns `_raw` for audit/debug use.

--- a/docs/security.md
+++ b/docs/security.md
@@ -112,6 +112,11 @@ actor-scoped MCP resource; lesser-host control-plane auth cannot derive the loca
 soul/body binding proof from that token. Lesser owns that self-scope proof, derives the bound Host `agentId`, and then
 uses managed instance trust to call Host.
 
+Large read-tool diagnostics are opt-in. User-facing default reads must not emit timing, byte-count, upstream-count, or
+other operational diagnostics unless the caller explicitly requests the tool's advertised diagnostic flag such as
+`include_diagnostics=true`. Diagnostic payloads remain sanitized operational metadata only; they must not include bearer
+tokens, instance keys, message bodies, private reachability details, or raw upstream objects.
+
 Private mint-conversation list responses are compact summaries only. Full `messages` and `producedDeclarations` content
 is returned only by explicit single-conversation reads and must not be logged. For explicit single reads, full private
 fields are preserved in `structuredContent.data`; the text `content` block omits those verbose fields to avoid

--- a/internal/mcpapp/social_tools_test.go
+++ b/internal/mcpapp/social_tools_test.go
@@ -106,6 +106,9 @@ func TestM5_ToolsListContainsCoreTools(t *testing.T) {
 	if propType, _ := notificationSchema.Properties["include_raw"]["type"].(string); propType != "boolean" {
 		t.Fatalf("notifications_read include_raw should be boolean, got %+v", notificationSchema.Properties["include_raw"])
 	}
+	if propType, _ := notificationSchema.Properties["include_diagnostics"]["type"].(string); propType != "boolean" {
+		t.Fatalf("notifications_read include_diagnostics should be boolean, got %+v", notificationSchema.Properties["include_diagnostics"])
+	}
 	typesProp := notificationSchema.Properties["types"]
 	items, _ := typesProp["items"].(map[string]any)
 	enum, _ := items["enum"].([]any)
@@ -764,7 +767,7 @@ func TestM5_NotificationsReadReturnsStructuredNotifications(t *testing.T) {
 	}
 }
 
-func TestM5_NotificationsReadOmitsRawByDefaultAndExposesDiagnostics(t *testing.T) {
+func TestM5_NotificationsReadOmitsRawByDefaultAndExposesDiagnosticsWhenRequested(t *testing.T) {
 	t.Setenv("MCP_SESSION_TABLE", "")
 	t.Setenv("JWT_SECRET", "test")
 	installSoulBindingLookup(t, "agent1", "0x1111111111111111111111111111111111111111111111111111111111111111")
@@ -866,7 +869,12 @@ func TestM5_NotificationsReadOmitsRawByDefaultAndExposesDiagnostics(t *testing.T
 	if content, _ := post["content"].(string); len([]rune(content)) > 500 {
 		t.Fatalf("expected bounded targetPost content, got %d runes", len([]rune(content)))
 	}
-	diagnostics, _ := defaultData["diagnostics"].(map[string]any)
+	if _, ok := defaultData["diagnostics"]; ok {
+		t.Fatalf("diagnostics should be opt-in by default, got %+v", defaultData["diagnostics"])
+	}
+
+	diagnosticData := call(3, map[string]any{"limit": 20, "include_diagnostics": true})
+	diagnostics, _ := diagnosticData["diagnostics"].(map[string]any)
 	if diagnostics["upstreamCount"] != float64(1) || diagnostics["normalizedCount"] != float64(1) {
 		t.Fatalf("expected notification diagnostics counts, got %+v", diagnostics)
 	}
@@ -874,7 +882,7 @@ func TestM5_NotificationsReadOmitsRawByDefaultAndExposesDiagnostics(t *testing.T
 		t.Fatalf("expected response size diagnostics, got %+v", diagnostics)
 	}
 
-	rawData := call(3, map[string]any{"limit": 20, "include_raw": true})
+	rawData := call(4, map[string]any{"limit": 20, "include_raw": true})
 	rawNotifications, _ := rawData["notifications"].([]any)
 	rawNotification, _ := rawNotifications[0].(map[string]any)
 	if _, ok := rawNotification["_raw"].(map[string]any); !ok {

--- a/internal/mcpserver/read_params.go
+++ b/internal/mcpserver/read_params.go
@@ -51,14 +51,19 @@ func parseSharedReadParams(args json.RawMessage) (sharedReadParams, error) {
 		return out, nil
 	}
 
-	out.View = strings.ToLower(strings.TrimSpace(stringFromAny(raw["view"])))
-	if out.View != "" {
-		if _, ok := supportedReadViews[out.View]; !ok {
-			return out, fmt.Errorf("unsupported view %q", out.View)
+	view, ok, err := optionalStringFromAny(raw["view"], "view")
+	if err != nil {
+		return out, err
+	}
+	if ok {
+		out.View = strings.ToLower(strings.TrimSpace(view))
+		if out.View != "" {
+			if _, ok := supportedReadViews[out.View]; !ok {
+				return out, fmt.Errorf("unsupported view %q", out.View)
+			}
 		}
 	}
 
-	var err error
 	out.Fields, err = stringListFromAny(raw["fields"], "fields")
 	if err != nil {
 		return out, err
@@ -224,7 +229,13 @@ func optionalBoolFromAny(v any, name string) (bool, bool, error) {
 	return b, true, nil
 }
 
-func stringFromAny(v any) string {
-	s, _ := v.(string)
-	return s
+func optionalStringFromAny(v any, name string) (string, bool, error) {
+	if v == nil {
+		return "", false, nil
+	}
+	s, ok := v.(string)
+	if !ok {
+		return "", false, fmt.Errorf("%s must be a string", name)
+	}
+	return s, true, nil
 }

--- a/internal/mcpserver/read_params.go
+++ b/internal/mcpserver/read_params.go
@@ -1,0 +1,230 @@
+package mcpserver
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+const (
+	readViewCompact  = "compact"
+	readViewStandard = "standard"
+	readViewSummary  = "summary"
+	readViewFull     = "full"
+)
+
+var supportedReadViews = map[string]struct{}{
+	readViewCompact:  {},
+	readViewStandard: {},
+	readViewSummary:  {},
+	readViewFull:     {},
+}
+
+type sharedReadParams struct {
+	View               string   `json:"view,omitempty"`
+	Fields             []string `json:"fields,omitempty"`
+	Include            []string `json:"include,omitempty"`
+	PreviewChars       int      `json:"preview_chars,omitempty"`
+	MaxOutputBytes     int      `json:"max_output_bytes,omitempty"`
+	IncludeDiagnostics bool     `json:"include_diagnostics,omitempty"`
+}
+
+type sharedReadParamSchemaOptions struct {
+	Views              []string
+	Fields             bool
+	Include            bool
+	PreviewChars       bool
+	MaxOutputBytes     bool
+	IncludeDiagnostics bool
+}
+
+func parseSharedReadParams(args json.RawMessage) (sharedReadParams, error) {
+	var out sharedReadParams
+	if len(strings.TrimSpace(string(args))) == 0 || strings.TrimSpace(string(args)) == "null" {
+		return out, nil
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(args, &raw); err != nil {
+		return out, err
+	}
+	if raw == nil {
+		return out, nil
+	}
+
+	out.View = strings.ToLower(strings.TrimSpace(stringFromAny(raw["view"])))
+	if out.View != "" {
+		if _, ok := supportedReadViews[out.View]; !ok {
+			return out, fmt.Errorf("unsupported view %q", out.View)
+		}
+	}
+
+	var err error
+	out.Fields, err = stringListFromAny(raw["fields"], "fields")
+	if err != nil {
+		return out, err
+	}
+	out.Include, err = stringListFromAny(raw["include"], "include")
+	if err != nil {
+		return out, err
+	}
+	out.PreviewChars, err = nonNegativeIntFromAny(raw["preview_chars"], "preview_chars")
+	if err != nil {
+		return out, err
+	}
+	out.MaxOutputBytes, err = nonNegativeIntFromAny(raw["max_output_bytes"], "max_output_bytes")
+	if err != nil {
+		return out, err
+	}
+	if b, ok, err := optionalBoolFromAny(raw["include_diagnostics"], "include_diagnostics"); err != nil {
+		return out, err
+	} else if ok {
+		out.IncludeDiagnostics = b
+	}
+	return out, nil
+}
+
+func sharedReadParamSchemaProperties(opts sharedReadParamSchemaOptions) map[string]any {
+	props := map[string]any{}
+	if len(opts.Views) > 0 {
+		views := make([]any, 0, len(opts.Views))
+		seen := map[string]struct{}{}
+		for _, raw := range opts.Views {
+			view := strings.ToLower(strings.TrimSpace(raw))
+			if view == "" {
+				continue
+			}
+			if _, ok := supportedReadViews[view]; !ok {
+				continue
+			}
+			if _, ok := seen[view]; ok {
+				continue
+			}
+			seen[view] = struct{}{}
+			views = append(views, view)
+		}
+		if len(views) > 0 {
+			props["view"] = map[string]any{
+				"type":        "string",
+				"enum":        views,
+				"description": "Optional read projection. standard preserves the current response shape; compact/summary/full are opt-in per-tool migrations.",
+			}
+		}
+	}
+	if opts.Fields {
+		props["fields"] = map[string]any{
+			"type":        "array",
+			"items":       map[string]any{"type": "string"},
+			"description": "Optional allowlist of top-level or dotted fields to return when a tool supports field projection.",
+		}
+	}
+	if opts.Include {
+		props["include"] = map[string]any{
+			"type":        "array",
+			"items":       map[string]any{"type": "string"},
+			"description": "Optional named related blocks to include when they are omitted by the selected view.",
+		}
+	}
+	if opts.PreviewChars {
+		props["preview_chars"] = map[string]any{
+			"type":        "integer",
+			"minimum":     0,
+			"description": "Optional maximum characters for text previews. Zero means the tool default.",
+		}
+	}
+	if opts.MaxOutputBytes {
+		props["max_output_bytes"] = map[string]any{
+			"type":        "integer",
+			"minimum":     0,
+			"description": "Optional caller budget for the MCP tool result. Tools that honor it report omitted/truncated metadata instead of silently dropping fields.",
+		}
+	}
+	if opts.IncludeDiagnostics {
+		props["include_diagnostics"] = map[string]any{
+			"type":        "boolean",
+			"description": "Opt in to timing/size diagnostics. Defaults to false for user-facing reads.",
+		}
+	}
+	return props
+}
+
+func stringListFromAny(v any, name string) ([]string, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var rawValues []string
+	switch typed := v.(type) {
+	case []any:
+		rawValues = make([]string, 0, len(typed))
+		for _, item := range typed {
+			s, ok := item.(string)
+			if !ok {
+				return nil, fmt.Errorf("%s must contain strings", name)
+			}
+			rawValues = append(rawValues, s)
+		}
+	case []string:
+		rawValues = typed
+	case string:
+		rawValues = strings.Split(typed, ",")
+	default:
+		return nil, fmt.Errorf("%s must be a string array or comma-separated string", name)
+	}
+	out := make([]string, 0, len(rawValues))
+	seen := map[string]struct{}{}
+	for _, raw := range rawValues {
+		value := strings.TrimSpace(raw)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out, nil
+}
+
+func nonNegativeIntFromAny(v any, name string) (int, error) {
+	if v == nil {
+		return 0, nil
+	}
+	var n int
+	switch typed := v.(type) {
+	case float64:
+		if typed != float64(int(typed)) {
+			return 0, fmt.Errorf("%s must be an integer", name)
+		}
+		n = int(typed)
+	case int:
+		n = typed
+	case json.Number:
+		parsed, err := typed.Int64()
+		if err != nil {
+			return 0, fmt.Errorf("%s must be an integer", name)
+		}
+		n = int(parsed)
+	default:
+		return 0, fmt.Errorf("%s must be an integer", name)
+	}
+	if n < 0 {
+		return 0, fmt.Errorf("%s must be non-negative", name)
+	}
+	return n, nil
+}
+
+func optionalBoolFromAny(v any, name string) (bool, bool, error) {
+	if v == nil {
+		return false, false, nil
+	}
+	b, ok := v.(bool)
+	if !ok {
+		return false, false, fmt.Errorf("%s must be a boolean", name)
+	}
+	return b, true, nil
+}
+
+func stringFromAny(v any) string {
+	s, _ := v.(string)
+	return s
+}

--- a/internal/mcpserver/read_params_test.go
+++ b/internal/mcpserver/read_params_test.go
@@ -1,0 +1,160 @@
+package mcpserver
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestParseSharedReadParamsNormalizesOptInShape(t *testing.T) {
+	params, err := parseSharedReadParams(json.RawMessage(`{
+		"view":"Compact",
+		"fields":["id","actor.name","id",""],
+		"include":"replies, media , replies",
+		"preview_chars":120,
+		"max_output_bytes":8192,
+		"include_diagnostics":true
+	}`))
+	if err != nil {
+		t.Fatalf("parse shared read params: %v", err)
+	}
+	if params.View != readViewCompact {
+		t.Fatalf("view = %q, want %q", params.View, readViewCompact)
+	}
+	if !reflect.DeepEqual(params.Fields, []string{"id", "actor.name"}) {
+		t.Fatalf("fields = %#v", params.Fields)
+	}
+	if !reflect.DeepEqual(params.Include, []string{"replies", "media"}) {
+		t.Fatalf("include = %#v", params.Include)
+	}
+	if params.PreviewChars != 120 || params.MaxOutputBytes != 8192 || !params.IncludeDiagnostics {
+		t.Fatalf("unexpected numeric/diagnostic params: %+v", params)
+	}
+}
+
+func TestParseSharedReadParamsRejectsInvalidShape(t *testing.T) {
+	for name, raw := range map[string]string{
+		"view":                `{"view":"dense"}`,
+		"fields":              `{"fields":["id",3]}`,
+		"preview_chars":       `{"preview_chars":-1}`,
+		"max_output_bytes":    `{"max_output_bytes":1.25}`,
+		"include_diagnostics": `{"include_diagnostics":"yes"}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := parseSharedReadParams(json.RawMessage(raw)); err == nil {
+				t.Fatalf("expected invalid %s to fail", name)
+			}
+		})
+	}
+}
+
+func TestSharedReadParamSchemaPropertiesAreAdditiveFragments(t *testing.T) {
+	props := sharedReadParamSchemaProperties(sharedReadParamSchemaOptions{
+		Views:              []string{readViewStandard, readViewCompact, "invalid", readViewCompact},
+		Fields:             true,
+		Include:            true,
+		PreviewChars:       true,
+		MaxOutputBytes:     true,
+		IncludeDiagnostics: true,
+	})
+	for _, name := range []string{"view", "fields", "include", "preview_chars", "max_output_bytes", "include_diagnostics"} {
+		if _, ok := props[name]; !ok {
+			t.Fatalf("missing schema property %q in %#v", name, props)
+		}
+	}
+	view, _ := props["view"].(map[string]any)
+	enum, _ := view["enum"].([]any)
+	if !reflect.DeepEqual(enum, []any{readViewStandard, readViewCompact}) {
+		t.Fatalf("view enum = %#v", enum)
+	}
+}
+
+func TestToolStructuredFirstResultKeepsFullDataStructured(t *testing.T) {
+	result, err := toolStructuredFirstResult(structuredFirstResultOptions{
+		Summary: "2 compact posts",
+		Data: map[string]any{
+			"items": []any{map[string]any{"id": "post-1", "content": "full text"}},
+		},
+		Text: map[string]any{
+			"items":       []any{map[string]any{"id": "post-1"}},
+			"omitted":     []any{"items[].content"},
+			"data":        "caller cannot override data locator",
+			"diagnostics": "caller cannot emit diagnostics without opt-in",
+		},
+		Structured: map[string]any{
+			"source": "test",
+			"data":   "caller cannot override structured data",
+		},
+		Diagnostics: map[string]any{"responseBytes": 1234},
+	})
+	if err != nil {
+		t.Fatalf("structured-first result: %v", err)
+	}
+	if len(result.Content) != 1 || result.Content[0].Type != "text" {
+		t.Fatalf("unexpected content blocks: %+v", result.Content)
+	}
+	var text map[string]any
+	if err := json.Unmarshal([]byte(result.Content[0].Text), &text); err != nil {
+		t.Fatalf("text content should remain JSON for text-only clients: %v", err)
+	}
+	if text["summary"] != "2 compact posts" {
+		t.Fatalf("summary = %#v", text["summary"])
+	}
+	dataLocator, _ := text["data"].(map[string]any)
+	if dataLocator["location"] != "structuredContent.data" {
+		t.Fatalf("data locator = %#v", dataLocator)
+	}
+	if _, ok := text["diagnostics"]; ok {
+		t.Fatalf("diagnostics must be opt-in in text payload: %#v", text)
+	}
+	if result.StructuredContent["source"] != "test" {
+		t.Fatalf("structured source = %#v", result.StructuredContent["source"])
+	}
+	if _, ok := result.StructuredContent["diagnostics"]; ok {
+		t.Fatalf("diagnostics must be opt-in in structured content: %#v", result.StructuredContent)
+	}
+	data, _ := result.StructuredContent["data"].(map[string]any)
+	items, _ := data["items"].([]any)
+	item, _ := items[0].(map[string]any)
+	if item["content"] != "full text" {
+		t.Fatalf("structuredContent.data must retain full payload, got %#v", data)
+	}
+}
+
+func TestToolStructuredFirstResultCanOptInDiagnostics(t *testing.T) {
+	result, err := toolStructuredFirstResult(structuredFirstResultOptions{
+		Data:               map[string]any{"ok": true},
+		Diagnostics:        map[string]any{"responseBytes": 42},
+		IncludeDiagnostics: true,
+	})
+	if err != nil {
+		t.Fatalf("structured-first result: %v", err)
+	}
+	if _, ok := result.StructuredContent["diagnostics"]; !ok {
+		t.Fatalf("expected opt-in diagnostics in structured content: %#v", result.StructuredContent)
+	}
+	var text map[string]any
+	if err := json.Unmarshal([]byte(result.Content[0].Text), &text); err != nil {
+		t.Fatalf("unmarshal text: %v", err)
+	}
+	diagLocator, _ := text["diagnostics"].(map[string]any)
+	if diagLocator["location"] != "structuredContent.diagnostics" {
+		t.Fatalf("diagnostics locator = %#v", diagLocator)
+	}
+}
+
+func TestToolJSONResultCompatibilityRemainsWrappedData(t *testing.T) {
+	payload := map[string]any{"hello": "world"}
+	result, err := toolJSONResult(payload, nil)
+	if err != nil {
+		t.Fatalf("toolJSONResult: %v", err)
+	}
+	if !strings.Contains(result.Content[0].Text, `"hello":"world"`) {
+		t.Fatalf("content text changed: %s", result.Content[0].Text)
+	}
+	data, _ := result.StructuredContent["data"].(map[string]any)
+	if data["hello"] != "world" {
+		t.Fatalf("structuredContent.data changed: %#v", result.StructuredContent)
+	}
+}

--- a/internal/mcpserver/read_params_test.go
+++ b/internal/mcpserver/read_params_test.go
@@ -36,6 +36,7 @@ func TestParseSharedReadParamsNormalizesOptInShape(t *testing.T) {
 func TestParseSharedReadParamsRejectsInvalidShape(t *testing.T) {
 	for name, raw := range map[string]string{
 		"view":                `{"view":"dense"}`,
+		"view_type":           `{"view":3}`,
 		"fields":              `{"fields":["id",3]}`,
 		"preview_chars":       `{"preview_chars":-1}`,
 		"max_output_bytes":    `{"max_output_bytes":1.25}`,

--- a/internal/mcpserver/social_tools.go
+++ b/internal/mcpserver/social_tools.go
@@ -413,11 +413,12 @@ func handleConversationsRead(ctx context.Context, args json.RawMessage) (*mcprun
 
 func handleNotificationsRead(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
 	var in struct {
-		Types      []string `json:"types,omitempty"`
-		Since      *string  `json:"since"`
-		Cursor     string   `json:"cursor,omitempty"`
-		Limit      int      `json:"limit,omitempty"`
-		IncludeRaw bool     `json:"include_raw,omitempty"`
+		Types              []string `json:"types,omitempty"`
+		Since              *string  `json:"since"`
+		Cursor             string   `json:"cursor,omitempty"`
+		Limit              int      `json:"limit,omitempty"`
+		IncludeRaw         bool     `json:"include_raw,omitempty"`
+		IncludeDiagnostics bool     `json:"include_diagnostics,omitempty"`
 	}
 	if err := json.Unmarshal(args, &in); err != nil {
 		return nil, invalidParams("invalid args: " + err.Error())
@@ -507,14 +508,16 @@ func handleNotificationsRead(ctx context.Context, args json.RawMessage) (*mcprun
 		"notifications": notifications,
 		"includeRaw":    in.IncludeRaw,
 	}
-	attachNotificationReadDiagnostics(payload, notificationReadDiagnostics{
-		API:             apiDuration,
-		Normalize:       normalizeDuration,
-		Total:           time.Since(startedAt),
-		UpstreamCount:   len(list),
-		NormalizedCount: len(notifications),
-		RawIncluded:     in.IncludeRaw,
-	})
+	if in.IncludeDiagnostics {
+		attachNotificationReadDiagnostics(payload, notificationReadDiagnostics{
+			API:             apiDuration,
+			Normalize:       normalizeDuration,
+			Total:           time.Since(startedAt),
+			UpstreamCount:   len(list),
+			NormalizedCount: len(notifications),
+			RawIncluded:     in.IncludeRaw,
+		})
+	}
 	return toolJSONResult(payload, nil)
 }
 
@@ -839,7 +842,8 @@ func notificationsReadDef() mcpruntime.ToolDef {
 				"since":{"type":"string"},
 				"cursor":{"type":"string"},
 				"limit":{"type":"integer","minimum":1,"maximum":80},
-				"include_raw":{"type":"boolean","description":"Include verbose upstream notification payloads under _raw for audit/debug use. Defaults to false and increases response size."}
+				"include_raw":{"type":"boolean","description":"Include verbose upstream notification payloads under _raw for audit/debug use. Defaults to false and increases response size."},
+				"include_diagnostics":{"type":"boolean","description":"Include timing and response-size diagnostics for Ops probes. Defaults to false."}
 			}
 		}`),
 	}

--- a/internal/mcpserver/tool_results.go
+++ b/internal/mcpserver/tool_results.go
@@ -1,0 +1,70 @@
+package mcpserver
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	mcpruntime "github.com/theory-cloud/apptheory/runtime/mcp"
+)
+
+type structuredFirstResultOptions struct {
+	Summary            string
+	Data               any
+	Text               map[string]any
+	Structured         map[string]any
+	Diagnostics        map[string]any
+	IncludeDiagnostics bool
+}
+
+func toolStructuredFirstResult(opts structuredFirstResultOptions) (*mcpruntime.ToolResult, error) {
+	data := opts.Data
+	if data == nil {
+		data = map[string]any{}
+	}
+
+	structured := map[string]any{"data": data}
+	for key, value := range opts.Structured {
+		key = strings.TrimSpace(key)
+		if key == "" || key == "data" || key == "diagnostics" {
+			continue
+		}
+		structured[key] = value
+	}
+	if opts.IncludeDiagnostics && opts.Diagnostics != nil {
+		structured["diagnostics"] = opts.Diagnostics
+	}
+	if _, err := json.Marshal(structured); err != nil {
+		return nil, fmt.Errorf("marshal structured-first tool result: %w", err)
+	}
+
+	textPayload := map[string]any{}
+	if summary := strings.TrimSpace(opts.Summary); summary != "" {
+		textPayload["summary"] = summary
+	} else {
+		textPayload["summary"] = "Result available in structuredContent.data"
+	}
+	for key, value := range opts.Text {
+		key = strings.TrimSpace(key)
+		if key == "" || key == "data" || key == "diagnostics" {
+			continue
+		}
+		textPayload[key] = value
+	}
+	textPayload["data"] = map[string]any{"location": "structuredContent.data"}
+	if opts.IncludeDiagnostics && opts.Diagnostics != nil {
+		textPayload["diagnostics"] = map[string]any{"location": "structuredContent.diagnostics"}
+	}
+
+	b, err := json.Marshal(textPayload)
+	if err != nil {
+		return nil, fmt.Errorf("marshal structured-first tool text: %w", err)
+	}
+	return &mcpruntime.ToolResult{
+		Content: []mcpruntime.ContentBlock{{
+			Type: "text",
+			Text: string(b),
+		}},
+		StructuredContent: structured,
+	}, nil
+}

--- a/scripts/m0_baseline_mcp_probe.py
+++ b/scripts/m0_baseline_mcp_probe.py
@@ -477,7 +477,7 @@ def workflow_read_args(notification_type: str = "") -> dict[str, Any]:
             limit = max(1, min(80, int(raw_limit)))
         except ValueError as exc:
             raise ProbeError(f"invalid PROBE_NOTIFICATION_WORKFLOW_LIMIT {raw_limit!r}") from exc
-    args: dict[str, Any] = {"limit": limit}
+    args: dict[str, Any] = {"limit": limit, "include_diagnostics": True}
     if notification_type:
         args["types"] = [notification_type]
     return args
@@ -742,17 +742,17 @@ def main() -> int:
     else:
         skip("identity_verify messageRef", "missing PROBE_MESSAGE_REF")
 
-    run_probe("notifications_read limit=20", lambda: probe_notifications_read("notifications_read limit=20", {"limit": 20}))
+    run_probe("notifications_read limit=20", lambda: probe_notifications_read("notifications_read limit=20", {"limit": 20, "include_diagnostics": True}))
     run_probe(
         "notifications_read since empty limit=30",
-        lambda: probe_notifications_read("notifications_read since empty limit=30", {"since": "", "limit": 30}),
+        lambda: probe_notifications_read("notifications_read since empty limit=30", {"since": "", "limit": 30, "include_diagnostics": True}),
     )
     since = env("PROBE_NOTIFICATION_SINCE", notification_since_default())
     for typ in ("mention", "reply"):
         run_probe(
             f"notifications_read {typ} timestamp",
             lambda typ=typ: probe_notifications_read(
-                f"notifications_read {typ} timestamp", {"since": since, "limit": 30, "types": [typ]}
+                f"notifications_read {typ} timestamp", {"since": since, "limit": 30, "types": [typ], "include_diagnostics": True}
             ),
         )
 


### PR DESCRIPTION
## Milestone
Project 33 P0.1 / #228 — shared read params + structured-first result helper.

Closes #228.

## Classification
MCP-contract stability + tool-surface-adjacent + operational reliability.

## Surfaces affected
- `notifications_read` input schema adds optional `include_diagnostics`.
- `notifications_read` default output no longer includes diagnostics; probes opt in explicitly.
- New internal shared read-param vocabulary helpers for future compact/summary migrations.
- New structured-first result helper that keeps concise JSON text locators and authoritative `structuredContent.data`.
- Docs/probe guidance for opt-in diagnostics and shared read shaping.

## Specialist walks referenced
- Advisor brief: Arch assignment email `delivery-ea8b6e7cb859994d`, Project 33 P0.1 / #228.
- MCP contract: additive optional input parameter; semantic refinement to keep diagnostics opt-in; no OAuth metadata or JSON-RPC envelope change.
- Tool surface: no new tools, no scope/profile changes, no dynamic registration; one read tool schema is additively expanded.
- Lesser/Host/AppTheory: no runtime rewrites or sibling-repo contract changes.

## Consumer impact
- Default/standard notification data remains compact and compatible for normal clients; raw payloads still require `include_raw=true`.
- Ops/probe clients that need timing/size data must pass `include_diagnostics=true`.
- Future compact/summary migrations can use the shared vocabulary without forcing every read tool to adopt every parameter immediately.

## Tasks
- [x] Define shared read params: `view`, `fields`, `include`, `preview_chars`, `max_output_bytes`, `include_diagnostics`.
- [x] Add structured-first result helper beside existing `toolJSONResult`.
- [x] Preserve default/standard behavior; no compact default flip.
- [x] Keep diagnostics opt-in for large read tools.
- [x] Avoid Lesser/Host/AppTheory rewrites and AGENTS/hot-context slimming.
- [x] Preserve private reachability fail-closed discipline (identity paths not changed; docs retain constraint).

## Validation
- [x] `git diff --check`
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (empty)
- [x] `python3 -m py_compile scripts/m0_baseline_mcp_probe.py`
- [x] `bash scripts/build.sh`
- [x] Targeted: `go test ./internal/mcpserver`
- [x] Targeted: `go test ./internal/mcpapp -run 'TestM5_ToolsListContainsCoreTools|TestM5_NotificationsRead'`

## Stage rollout plan (handoff to deploy-body)
- [ ] Merged to main
- [ ] Deployed to lab / dev
- [ ] Lab soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
None for this milestone. P0.1 intentionally avoids Lesser/Host/AppTheory runtime rewrites.

## Advisor-brief authorization
Arch activated Project 33 P0.1 / #228 under the standing user objective for Arch-assigned milestones. Review packet will be emailed to Arch once this PR is ready.