### PR TITLE
test(mcp): add compact payload gates

### DIFF
--- a/internal/mcpapp/inbox_tools_test.go
+++ b/internal/mcpapp/inbox_tools_test.go
@@ -65,9 +65,11 @@ func TestLBM3_InboxToolsUseHostMailbox(t *testing.T) {
 						"to":{"address":"agent@example.com"},
 						"subject":"Hi",
 						"preview":"Hello preview",
+						"body":"` + strings.Repeat("full mailbox body ", 240) + `",
 						"content":{"available":true,"bytes":11,"mimeType":"text/plain","sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","contentHref":"/content"},
 						"state":{"read":false,"archived":false,"deleted":false},
-						"createdAt":"2026-03-04T12:00:00Z"
+						"createdAt":"2026-03-04T12:00:00Z",
+						"debugPayload":{"large":"` + strings.Repeat("mailbox-debug ", 320) + `"}
 					}],
 					"count":1,
 					"hasMore":true,
@@ -122,6 +124,7 @@ func TestLBM3_InboxToolsUseHostMailbox(t *testing.T) {
 	}
 	sessionID := initResp.Headers["mcp-session-id"][0]
 
+	responseBytes := map[int]int{}
 	callTool := func(id int, name string, arguments map[string]any) map[string]any {
 		t.Helper()
 		callParams, _ := json.Marshal(map[string]any{"name": name, "arguments": arguments})
@@ -132,6 +135,7 @@ func TestLBM3_InboxToolsUseHostMailbox(t *testing.T) {
 		if resp.Status != 200 {
 			t.Fatalf("%s: status=%d body=%s", name, resp.Status, string(resp.Body))
 		}
+		responseBytes[id] = len(resp.Body)
 		var rpc mcpruntime.Response
 		_ = json.Unmarshal(resp.Body, &rpc)
 		if rpc.Error != nil {
@@ -155,6 +159,11 @@ func TestLBM3_InboxToolsUseHostMailbox(t *testing.T) {
 	if msg["messageId"] != "comm-delivery-email" || msg["hostMessageId"] != "comm-msg-email" || msg["body"] != "Hello preview" || msg["bodyIsPreview"] != true {
 		t.Fatalf("unexpected email message: %+v", msg)
 	}
+	for _, alias := range []string{"messageId", "messageRef", "deliveryId", "hostMessageId"} {
+		if value, _ := msg[alias].(string); value == "" {
+			t.Fatalf("expected mailbox compatibility alias %q to remain populated, got %+v", alias, msg)
+		}
+	}
 	if _, ok := msg["raw"]; ok {
 		t.Fatalf("raw field should be absent by default: %+v", msg)
 	}
@@ -164,6 +173,7 @@ func TestLBM3_InboxToolsUseHostMailbox(t *testing.T) {
 	if emailRead["nextCursor"] != "cursor-2" || emailRead["nextSince"] != "cursor-2" {
 		t.Fatalf("expected cursor aliases, got %+v", emailRead)
 	}
+	assertMCPPayloadBudget(t, "email_read default mailbox preview large fixture", responseBytes[2], 6500)
 
 	emailReadRaw := callTool(20, "email_read", map[string]any{"folder": "inbox", "limit": 10, "include_raw": true})
 	rawMessages, _ := emailReadRaw["messages"].([]any)
@@ -174,6 +184,12 @@ func TestLBM3_InboxToolsUseHostMailbox(t *testing.T) {
 	if _, ok := rawMsg["raw"]; ok {
 		t.Fatalf("include_raw=true should use _raw, not raw: %+v", rawMsg)
 	}
+	assertMCPPayloadIncrease(t,
+		"email_read default mailbox preview large fixture",
+		responseBytes[2],
+		"email_read include_raw expanded fixture",
+		responseBytes[20],
+	)
 
 	smsRead := callTool(3, "sms_read", map[string]any{"limit": 10})
 	smsMessages, _ := smsRead["messages"].([]any)

--- a/internal/mcpapp/payload_measurement_test.go
+++ b/internal/mcpapp/payload_measurement_test.go
@@ -1,0 +1,44 @@
+package mcpapp_test
+
+import "testing"
+
+func assertMCPPayloadBudget(t testing.TB, name string, gotBytes int, budgetBytes int) {
+	t.Helper()
+	t.Logf("%s jsonrpc_payload_bytes=%d budget_bytes=%d", name, gotBytes, budgetBytes)
+	if gotBytes <= 0 {
+		t.Fatalf("%s payload measurement did not capture bytes: %d", name, gotBytes)
+	}
+	if gotBytes > budgetBytes {
+		t.Fatalf("%s JSON-RPC payload bytes %d exceed explicit budget %d; do not silently truncate fields",
+			name,
+			gotBytes,
+			budgetBytes,
+		)
+	}
+}
+
+func assertMCPPayloadIncrease(t testing.TB, compactName string, compactBytes int, expandedName string, expandedBytes int) {
+	t.Helper()
+	t.Logf("%s jsonrpc_payload_bytes=%d; %s jsonrpc_payload_bytes=%d",
+		compactName,
+		compactBytes,
+		expandedName,
+		expandedBytes,
+	)
+	if compactBytes <= 0 || expandedBytes <= 0 {
+		t.Fatalf("payload measurement missing bytes: %s=%d %s=%d",
+			compactName,
+			compactBytes,
+			expandedName,
+			expandedBytes,
+		)
+	}
+	if expandedBytes <= compactBytes {
+		t.Fatalf("%s should be larger than %s when opt-in raw/expanded payloads are requested: expanded=%d compact=%d",
+			expandedName,
+			compactName,
+			expandedBytes,
+			compactBytes,
+		)
+	}
+}

--- a/internal/mcpapp/social_tools_test.go
+++ b/internal/mcpapp/social_tools_test.go
@@ -573,6 +573,7 @@ func TestM5_ConversationsReadUsesCompactBoundedDefaults(t *testing.T) {
 	}
 	sessionID := initResp.Headers["mcp-session-id"][0]
 
+	responseBytes := map[int]int{}
 	call := func(id int, args map[string]any) map[string]any {
 		t.Helper()
 		callParams, _ := json.Marshal(map[string]any{"name": "conversations_read", "arguments": args})
@@ -583,6 +584,7 @@ func TestM5_ConversationsReadUsesCompactBoundedDefaults(t *testing.T) {
 		if resp.Status != 200 {
 			t.Fatalf("conversations_read: status=%d body=%s", resp.Status, string(resp.Body))
 		}
+		responseBytes[id] = len(resp.Body)
 		var rpc mcpruntime.Response
 		if err := json.Unmarshal(resp.Body, &rpc); err != nil {
 			t.Fatalf("unmarshal conversations_read: %v", err)
@@ -623,6 +625,7 @@ func TestM5_ConversationsReadUsesCompactBoundedDefaults(t *testing.T) {
 	if content, _ := lastPost["content"].(string); len([]rune(content)) > 500 {
 		t.Fatalf("expected bounded lastPost content, got %d runes", len([]rune(content)))
 	}
+	assertMCPPayloadBudget(t, "conversations_read default compact large fixture", responseBytes[2], 7000)
 
 	rawData := call(3, map[string]any{"limit": 200, "include_raw": true})
 	if gotQueries[1] != "limit=80" {
@@ -633,6 +636,12 @@ func TestM5_ConversationsReadUsesCompactBoundedDefaults(t *testing.T) {
 	if _, ok := rawConversation["_raw"].(map[string]any); !ok {
 		t.Fatalf("expected include_raw=true to expose _raw, got %+v", rawConversation)
 	}
+	assertMCPPayloadIncrease(t,
+		"conversations_read default compact large fixture",
+		responseBytes[2],
+		"conversations_read include_raw expanded fixture",
+		responseBytes[3],
+	)
 }
 
 func TestM5_NotificationsReadReturnsStructuredNotifications(t *testing.T) {
@@ -818,6 +827,7 @@ func TestM5_NotificationsReadOmitsRawByDefaultAndExposesDiagnosticsWhenRequested
 	}
 	sessionID := initResp.Headers["mcp-session-id"][0]
 
+	responseBytes := map[int]int{}
 	call := func(id int, args map[string]any) map[string]any {
 		t.Helper()
 		callParams, _ := json.Marshal(map[string]any{"name": "notifications_read", "arguments": args})
@@ -828,6 +838,7 @@ func TestM5_NotificationsReadOmitsRawByDefaultAndExposesDiagnosticsWhenRequested
 		if resp.Status != 200 {
 			t.Fatalf("notifications_read: status=%d body=%s", resp.Status, string(resp.Body))
 		}
+		responseBytes[id] = len(resp.Body)
 
 		var rpc mcpruntime.Response
 		if err := json.Unmarshal(resp.Body, &rpc); err != nil {
@@ -872,6 +883,7 @@ func TestM5_NotificationsReadOmitsRawByDefaultAndExposesDiagnosticsWhenRequested
 	if _, ok := defaultData["diagnostics"]; ok {
 		t.Fatalf("diagnostics should be opt-in by default, got %+v", defaultData["diagnostics"])
 	}
+	assertMCPPayloadBudget(t, "notifications_read default compact large fixture", responseBytes[2], 7000)
 
 	diagnosticData := call(3, map[string]any{"limit": 20, "include_diagnostics": true})
 	diagnostics, _ := diagnosticData["diagnostics"].(map[string]any)
@@ -891,6 +903,12 @@ func TestM5_NotificationsReadOmitsRawByDefaultAndExposesDiagnosticsWhenRequested
 	if _, ok := rawNotification["raw"]; ok {
 		t.Fatalf("include_raw=true should use _raw, not raw: %+v", rawNotification)
 	}
+	assertMCPPayloadIncrease(t,
+		"notifications_read default compact large fixture",
+		responseBytes[2],
+		"notifications_read include_raw expanded fixture",
+		responseBytes[4],
+	)
 }
 
 func TestM5_NotificationsReadSupportsCommunicationInboundFilter(t *testing.T) {

--- a/internal/mcpserver/read_params_test.go
+++ b/internal/mcpserver/read_params_test.go
@@ -123,6 +123,163 @@ func TestToolStructuredFirstResultKeepsFullDataStructured(t *testing.T) {
 	}
 }
 
+func TestToolStructuredFirstResultCompactOptInNamesOmissionsAndExpansionRefs(t *testing.T) {
+	const heavyPostSentinel = "FULL_HEAVY_POST_BODY_SHOULD_NOT_APPEAR_IN_COMPACT_TEXT"
+	const heavyAccountSentinel = "FULL_HEAVY_ACCOUNT_NOTE_SHOULD_NOT_APPEAR_IN_COMPACT_TEXT"
+
+	fullData := map[string]any{
+		"view": "standard",
+		"items": []any{
+			map[string]any{
+				"id":        "post-1",
+				"postRef":   "post:post-1",
+				"createdAt": "2026-05-17T15:00:00Z",
+				"content":   heavyPostSentinel + " " + strings.Repeat("post body ", 500),
+				"account": map[string]any{
+					"id":         "acct-1",
+					"accountRef": "account:acct-1",
+					"note":       heavyAccountSentinel + " " + strings.Repeat("profile note ", 300),
+				},
+			},
+		},
+		"nextCursor": "cursor-post-1",
+	}
+	result, err := toolStructuredFirstResult(structuredFirstResultOptions{
+		Summary: "1 compact post",
+		Data:    fullData,
+		Text: map[string]any{
+			"view": "compact",
+			"items": []any{
+				map[string]any{
+					"postRef":    "post:post-1",
+					"accountRef": "account:acct-1",
+					"createdAt":  "2026-05-17T15:00:00Z",
+					"preview":    "short preview",
+				},
+			},
+			"omitted": []any{
+				map[string]any{
+					"path":   "items[].content",
+					"reason": "heavy_text",
+					"expand": map[string]any{
+						"ref":      "post:post-1",
+						"location": "structuredContent.data.items[0].content",
+					},
+				},
+				map[string]any{
+					"path":   "items[].account.note",
+					"reason": "profile_bio",
+					"expand": map[string]any{
+						"ref":      "account:acct-1",
+						"location": "structuredContent.data.items[0].account.note",
+					},
+				},
+			},
+			"budget": map[string]any{
+				"maxOutputBytes": 2048,
+				"enforcement":    "test_gate_only",
+				"truncation":     "none; gate fails instead of silently dropping fields",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("structured-first compact result: %v", err)
+	}
+
+	textJSON := result.Content[0].Text
+	for _, heavy := range []string{heavyPostSentinel, heavyAccountSentinel, "post body", "profile note"} {
+		if strings.Contains(textJSON, heavy) {
+			t.Fatalf("compact text leaked heavy field %q: %s", heavy, textJSON)
+		}
+	}
+
+	var text map[string]any
+	if err := json.Unmarshal([]byte(textJSON), &text); err != nil {
+		t.Fatalf("unmarshal compact text: %v", err)
+	}
+	if text["view"] != readViewCompact {
+		t.Fatalf("compact text view = %#v", text["view"])
+	}
+	items, _ := text["items"].([]any)
+	if len(items) != 1 {
+		t.Fatalf("compact text should retain one item ref, got %#v", text["items"])
+	}
+	item, _ := items[0].(map[string]any)
+	if item["postRef"] != "post:post-1" || item["accountRef"] != "account:acct-1" {
+		t.Fatalf("compact text lost stable refs: %#v", item)
+	}
+	if _, ok := item["content"]; ok {
+		t.Fatalf("compact text item must omit content: %#v", item)
+	}
+	if _, ok := item["account"]; ok {
+		t.Fatalf("compact text item must omit nested account payload: %#v", item)
+	}
+
+	omitted, _ := text["omitted"].([]any)
+	if len(omitted) != 2 {
+		t.Fatalf("expected two omitted-field records, got %#v", text["omitted"])
+	}
+	wantOmitted := map[string]string{
+		"items[].content":      "structuredContent.data.items[0].content",
+		"items[].account.note": "structuredContent.data.items[0].account.note",
+	}
+	for _, raw := range omitted {
+		record, _ := raw.(map[string]any)
+		path, _ := record["path"].(string)
+		expand, _ := record["expand"].(map[string]any)
+		location, _ := expand["location"].(string)
+		if wantOmitted[path] != location {
+			t.Fatalf("unexpected expansion metadata for omitted path %q: %#v", path, record)
+		}
+		delete(wantOmitted, path)
+	}
+	if len(wantOmitted) != 0 {
+		t.Fatalf("missing omitted-field records: %#v", wantOmitted)
+	}
+
+	data, _ := result.StructuredContent["data"].(map[string]any)
+	fullItems, _ := data["items"].([]any)
+	fullItem, _ := fullItems[0].(map[string]any)
+	if content, _ := fullItem["content"].(string); !strings.Contains(content, heavyPostSentinel) {
+		t.Fatalf("structuredContent.data must retain full post content, got %#v", fullItem["content"])
+	}
+	account, _ := fullItem["account"].(map[string]any)
+	if note, _ := account["note"].(string); !strings.Contains(note, heavyAccountSentinel) {
+		t.Fatalf("structuredContent.data must retain full account note, got %#v", account["note"])
+	}
+
+	compactMeasurement, err := measureToolResultPayload(result)
+	if err != nil {
+		t.Fatalf("measure compact result payload: %v", err)
+	}
+	standardResult, err := toolJSONResult(fullData, nil)
+	if err != nil {
+		t.Fatalf("standard tool result: %v", err)
+	}
+	standardMeasurement, err := measureToolResultPayload(standardResult)
+	if err != nil {
+		t.Fatalf("measure standard result payload: %v", err)
+	}
+	const compactTextBudgetBytes = 2048
+	t.Logf("compact structured-first text bytes=%d, envelope bytes=%d; standard envelope bytes=%d",
+		compactMeasurement.ContentTextBytes,
+		compactMeasurement.JSONRPCEnvelopeBytes,
+		standardMeasurement.JSONRPCEnvelopeBytes,
+	)
+	if compactMeasurement.ContentTextBytes > compactTextBudgetBytes {
+		t.Fatalf("compact text bytes %d exceed explicit budget %d; do not silently truncate",
+			compactMeasurement.ContentTextBytes,
+			compactTextBudgetBytes,
+		)
+	}
+	if compactMeasurement.JSONRPCEnvelopeBytes >= standardMeasurement.JSONRPCEnvelopeBytes {
+		t.Fatalf("compact structured-first envelope must be smaller than standard duplicated JSON: compact=%d standard=%d",
+			compactMeasurement.JSONRPCEnvelopeBytes,
+			standardMeasurement.JSONRPCEnvelopeBytes,
+		)
+	}
+}
+
 func TestToolStructuredFirstResultCanOptInDiagnostics(t *testing.T) {
 	result, err := toolStructuredFirstResult(structuredFirstResultOptions{
 		Data:               map[string]any{"ok": true},

--- a/internal/mcpserver/tool_results.go
+++ b/internal/mcpserver/tool_results.go
@@ -17,6 +17,13 @@ type structuredFirstResultOptions struct {
 	IncludeDiagnostics bool
 }
 
+type toolPayloadMeasurement struct {
+	ContentTextBytes       int
+	StructuredContentBytes int
+	ResultBytes            int
+	JSONRPCEnvelopeBytes   int
+}
+
 func toolStructuredFirstResult(opts structuredFirstResultOptions) (*mcpruntime.ToolResult, error) {
 	data := opts.Data
 	if data == nil {
@@ -67,4 +74,39 @@ func toolStructuredFirstResult(opts structuredFirstResultOptions) (*mcpruntime.T
 		}},
 		StructuredContent: structured,
 	}, nil
+}
+
+func measureToolResultPayload(result *mcpruntime.ToolResult) (toolPayloadMeasurement, error) {
+	if result == nil {
+		return toolPayloadMeasurement{}, fmt.Errorf("measure tool result payload: nil result")
+	}
+
+	measurement := toolPayloadMeasurement{}
+	for _, block := range result.Content {
+		if block.Type == "text" {
+			measurement.ContentTextBytes += len([]byte(block.Text))
+		}
+	}
+
+	if result.StructuredContent != nil {
+		b, err := json.Marshal(result.StructuredContent)
+		if err != nil {
+			return toolPayloadMeasurement{}, fmt.Errorf("measure structuredContent bytes: %w", err)
+		}
+		measurement.StructuredContentBytes = len(b)
+	}
+
+	resultBytes, err := json.Marshal(result)
+	if err != nil {
+		return toolPayloadMeasurement{}, fmt.Errorf("measure tool result bytes: %w", err)
+	}
+	measurement.ResultBytes = len(resultBytes)
+
+	envelopeBytes, err := mcpruntime.MarshalResponse(mcpruntime.NewResultResponse("payload_measurement_probe", result))
+	if err != nil {
+		return toolPayloadMeasurement{}, fmt.Errorf("measure JSON-RPC envelope bytes: %w", err)
+	}
+	measurement.JSONRPCEnvelopeBytes = len(envelopeBytes)
+
+	return measurement, nil
 }


### PR DESCRIPTION
## Milestone
Project 33 P0.2 — Add compact opt-in tests and payload measurement gates.

Closes #229.

## Classification
MCP-contract test coverage / operational reliability. No client-visible tool behavior, schema, scope, or profile changes.

## Surfaces affected
- `internal/mcpserver/tool_results.go` — adds an internal ToolResult payload measurement helper for tests/gates.
- `internal/mcpserver/read_params_test.go` — adds compact structured-first coverage for named omissions, stable refs, deterministic expansion locations, and explicit no-silent-truncation budget semantics.
- `internal/mcpapp/social_tools_test.go` — adds JSON-RPC payload gates for `conversations_read` and `notifications_read` large fixtures.
- `internal/mcpapp/inbox_tools_test.go` — adds JSON-RPC payload gates for `email_read` large mailbox fixtures and keeps mailbox compatibility aliases asserted.
- `internal/mcpapp/payload_measurement_test.go` — shared test assertions for explicit payload budgets and expanded/raw payload comparisons.

## Specialist walks referenced
- Tool surface: not required; this does not add/remove tools, change registration, or alter declared scopes/profiles.
- MCP contract: contract-adjacent test coverage only; no `.well-known`, OAuth metadata, JSON-RPC envelope, tool schema, or default behavior changes.
- Lesser integration: not touched.
- Host delegation: not changed; mailbox test fixture only verifies existing Host mailbox read shape and aliases.
- Framework: idiomatic AppTheory MCP JSON-RPC marshal helper usage; no AppTheory/TableTheory patch.

## Consumer impact
- MCP clients: no runtime behavior change. Existing default/standard responses remain covered by current tests.
- Operators: no deployment/configuration change.
- Sibling repos: no Lesser/Host/Soul coordination required for this test-only gate.

## Tasks
- [x] Tests assert compact outputs omit named heavy fields but preserve stable refs and deterministic expansion metadata.
- [x] Payload measurement captured for representative large read tools.
- [x] Standard/default behavior remains compatible with existing output-schema and behavior tests.
- [x] Private reachability denial detail remains visible; identity/private reachability paths were not touched.
- [x] No compact default flip, no Lesser/Host/AppTheory rewrite, no AGENTS/hot-context slimming, and no mailbox alias removal.

## Representative payload-size evidence
From focused `go test -count=1 -v` runs:

- Structured-first compact probe: compact text `641` bytes, compact JSON-RPC envelope `10077` bytes, standard duplicated JSON-RPC envelope `18619` bytes.
- `conversations_read` large fixture: default compact JSON-RPC payload `1805` bytes under explicit `7000` byte budget; `include_raw` expanded payload `15633` bytes.
- `notifications_read` large fixture: default compact JSON-RPC payload `2753` bytes under explicit `7000` byte budget; `include_raw` expanded payload `15763` bytes.
- `email_read` large mailbox fixture: default preview JSON-RPC payload `3132` bytes under explicit `6500` byte budget; `include_raw` expanded payload `22055` bytes.

## Validation
- `gofmt -l .` (empty)
- `git diff --check`
- `go test ./...`
- `go vet ./...`
- `bash scripts/build.sh`
- Targeted evidence:
  - `go test -count=1 -v ./internal/mcpserver -run 'TestToolStructuredFirstResultCompactOptInNamesOmissionsAndExpansionRefs'`
  - `go test -count=1 -v ./internal/mcpapp -run 'TestM5_ConversationsReadUsesCompactBoundedDefaults|TestM5_NotificationsReadOmitsRawByDefaultAndExposesDiagnosticsWhenRequested|TestLBM3_InboxToolsUseHostMailbox'`

## Compatibility notes
- Existing default behavior is unchanged; this PR adds tests and an internal measurement helper only.
- `view=compact` is not made default, and no production read tool starts advertising new view parameters in this PR.
- Raw/debug expansion remains opt-in via existing `include_raw` behavior.
- Mailbox aliases `messageId`, `messageRef`, `deliveryId`, and `hostMessageId` remain asserted.
- Diagnostics remain opt-in; no new default diagnostic payloads.

## Stage rollout plan (handoff to deploy-body)
- [ ] Merged to main
- [ ] Deployed to lab / dev
- [ ] Lab soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
None for this P0.2 test-gate PR.

## Advisor-brief authorization
Arch assignment `delivery-ee2a52de33b25a17` activated #229 after #238 merged. Proceeding under the standing user authorization for Arch-assigned Project 33 milestones; PR packet will be emailed to Arch.
