### PR TITLE
feat(mcp): compact social read opt-ins

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -352,8 +352,8 @@ Scope key:
 |------|-------|-------------|
 | `echo` | Read | Echo back the provided message. |
 | `profile_read` | Read | Read the authenticated agent's profile. |
-| `timeline_read` | Read | Read from home, local, or federated timeline. |
-| `post_search` | Read | Search posts. |
+| `timeline_read` | Read | Read from home, local, or federated timeline; supports opt-in compact `StatusRef` view. |
+| `post_search` | Read | Search posts; supports opt-in compact `StatusRef` view. |
 | `post_get` | Read | Expand a compact social `StatusRef` through Lesser's status read route. |
 | `followers_list` | Read | List the agent's followers. |
 | `following_list` | Read | List accounts the agent follows. |
@@ -412,8 +412,16 @@ fields (`id`, `acct`, `displayName`, and `url`) and report `missingFields` rathe
 values include `id`, `url`, `authorRef`, `createdAt`, `visibility`, `contentPreview`, and a `contentTruncated` marker.
 When a compact status omits full content, its `omitted[]` record points at `post_get` with the status id and the desired
 `view`. `post_get(id, view=standard)` returns normalized status fields from Lesser's `GET /api/v1/statuses/{id}` route;
-`post_get(id, view=full)` returns the upstream Lesser status payload for audit/debug expansion. Timeline/search defaults
-remain unchanged until their own compact opt-in migrations land.
+`post_get(id, view=full)` returns the upstream Lesser status payload for audit/debug expansion.
+
+`timeline_read` and `post_search` now advertise opt-in `view=compact` plus `preview_chars` and `max_output_bytes`.
+Their omitted-`view` default and `view=standard` / `view=full` behavior preserves the current upstream-shaped response.
+Compact timeline/search responses return `StatusRef` lists, compact `AccountRef` search account matches, list-level
+omitted-field metadata, and concise structured-first text that points clients to `structuredContent.data` instead of
+duplicating every compact entry in `content[0].text`. The default compact budgets target `timeline_read(limit=5,
+view=compact)` under 6 KB and `post_search(limit=10, view=compact)` under 8 KB as MCP JSON-RPC responses. If a compact
+response exceeds its default or caller-supplied `max_output_bytes`, body returns a `response_too_large` tool error with
+measured byte details rather than silently dropping fields.
 
 Notes:
 
@@ -496,9 +504,9 @@ Notes:
   `nextCursor`, `notes`, and `state`; communication send/reply schemas explicitly include `messageId`, `status`, and
   caller-visible `idempotencyKey` fields so clients can reconcile host-delegated delivery without bypassing
   lesser-host idempotency or logging recipient PII.
-- `timeline_read` remains bounded by caller `limit`/cursor and upstream-shaped in M0 because current baseline evidence
-  points to mailbox and notification bloat, not timeline unusability. If Ops probes show timeline truncation/timeout,
-  timeline compacting should be scoped as a follow-up MCP-contract change rather than silently changed inside M0.
+- `timeline_read` remains upstream-shaped by default for compatibility. Use `view=compact` for bounded `StatusRef`
+  lists with deterministic `post_get` expansion metadata. `post_search` follows the same opt-in model for status
+  search results. Neither tool silently flips defaults to compact.
 - Mailbox, memory, and skills read tools publish MCP annotations in `tools/list`: read-only hints for mailbox
   reads/search/content fetches, `memory_query`, `soul_read`, `skills_catalog`, and `skill_bundle_get`; destructive hints
   for send/reply/delete tools; and idempotent hints for mailbox read-state mutation tools. `memory_append` remains an

--- a/internal/mcpapp/social_tools_test.go
+++ b/internal/mcpapp/social_tools_test.go
@@ -2,12 +2,14 @@ package mcpapp_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
 	"strings"
 	"testing"
 
+	apptheory "github.com/theory-cloud/apptheory/runtime"
 	mcpruntime "github.com/theory-cloud/apptheory/runtime/mcp"
 	"github.com/theory-cloud/apptheory/testkit"
 
@@ -144,6 +146,25 @@ func TestM5_ToolsListContainsCoreTools(t *testing.T) {
 	}
 	if !containsString(postGetSchema.Required, "id") {
 		t.Fatalf("post_get should require id, got %+v", postGetSchema.Required)
+	}
+	for _, toolName := range []string{"timeline_read", "post_search"} {
+		var schema struct {
+			Properties map[string]map[string]any `json:"properties"`
+		}
+		if err := json.Unmarshal(toolsByName[toolName].InputSchema, &schema); err != nil {
+			t.Fatalf("unmarshal %s schema: %v", toolName, err)
+		}
+		viewProp := schema.Properties["view"]
+		enum, _ := viewProp["enum"].([]any)
+		if !reflect.DeepEqual(enum, []any{"compact", "standard", "full"}) {
+			t.Fatalf("%s view enum = %+v", toolName, viewProp)
+		}
+		if propType, _ := schema.Properties["max_output_bytes"]["type"].(string); propType != "integer" {
+			t.Fatalf("%s max_output_bytes should be integer, got %+v", toolName, schema.Properties["max_output_bytes"])
+		}
+		if propType, _ := schema.Properties["preview_chars"]["type"].(string); propType != "integer" {
+			t.Fatalf("%s preview_chars should be integer, got %+v", toolName, schema.Properties["preview_chars"])
+		}
 	}
 	var conversationSchema struct {
 		Properties map[string]map[string]any `json:"properties"`
@@ -695,6 +716,265 @@ func TestM5_PostGetExpandsStatusRefViaLesserRoute(t *testing.T) {
 
 	if !reflect.DeepEqual(gotPaths, []string{"GET /api/v1/statuses/post-1", "GET /api/v1/statuses/post-1"}) {
 		t.Fatalf("unexpected Lesser status routes: %+v", gotPaths)
+	}
+}
+
+func TestM5_TimelineReadCompactUsesStatusRefsAndPayloadBudget(t *testing.T) {
+	t.Setenv("MCP_SESSION_TABLE", "")
+	t.Setenv("JWT_SECRET", "test")
+	auth.ResetForTests()
+
+	const contentTail = "TIMELINE_FULL_CONTENT_TAIL_SHOULD_NOT_APPEAR"
+	const accountNote = "TIMELINE_ACCOUNT_NOTE_SHOULD_NOT_APPEAR"
+	const debugPayload = "TIMELINE_DEBUG_PAYLOAD_SHOULD_NOT_APPEAR"
+
+	var gotQueries []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/api/v1/timelines/home" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		gotQueries = append(gotQueries, r.URL.RawQuery)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(socialStatusesFixtureJSON(5, "timeline", contentTail, accountNote, debugPayload)))
+	}))
+	defer server.Close()
+
+	t.Setenv("LESSER_API_BASE_URL", server.URL)
+	lesserapi.ResetForTests()
+
+	app, env, sessionID, authHeader := newSocialToolTestSession(t)
+
+	compact := callSocialTool(t, env, app, authHeader, sessionID, 2, "timeline_read", map[string]any{
+		"timeline": "home",
+		"limit":    5,
+		"view":     "compact",
+	})
+	if gotQueries[0] != "limit=5" {
+		t.Fatalf("expected compact timeline query limit=5, got %q", gotQueries[0])
+	}
+	assertMCPPayloadBudget(t, "timeline_read compact limit=5 large fixture", len(compact.ResponseBody), 6000)
+	for _, forbidden := range []string{contentTail, accountNote, debugPayload, "account note ", "debug payload "} {
+		if strings.Contains(string(compact.ResponseBody), forbidden) {
+			t.Fatalf("compact timeline response leaked %q: %s", forbidden, string(compact.ResponseBody))
+		}
+	}
+	data, _ := compact.Result.StructuredContent["data"].(map[string]any)
+	if data["view"] != "compact" || data["timeline"] != "home" || data["count"] != float64(5) {
+		t.Fatalf("unexpected compact timeline metadata: %+v", data)
+	}
+	statuses, _ := data["statuses"].([]any)
+	if len(statuses) != 5 {
+		t.Fatalf("expected 5 compact statuses, got %+v", data["statuses"])
+	}
+	firstStatus, _ := statuses[0].(map[string]any)
+	if firstStatus["id"] != "timeline-1" || firstStatus["url"] == "" || firstStatus["visibility"] != "public" {
+		t.Fatalf("unexpected compact status ref: %+v", firstStatus)
+	}
+	if preview, _ := firstStatus["contentPreview"].(string); preview == "" || len([]rune(preview)) > 160 || strings.Contains(preview, contentTail) {
+		t.Fatalf("expected bounded compact preview without tail, got %q (%d runes)", preview, len([]rune(preview)))
+	}
+	if firstStatus["contentTruncated"] != true {
+		t.Fatalf("expected contentTruncated marker, got %+v", firstStatus)
+	}
+	authorRef, _ := firstStatus["authorRef"].(map[string]any)
+	if authorRef["id"] != "acct-timeline-1" || authorRef["acct"] != "timeline1@example.com" || authorRef["displayName"] != "Timeline 1" {
+		t.Fatalf("unexpected authorRef: %+v", authorRef)
+	}
+	if _, ok := authorRef["note"]; ok {
+		t.Fatalf("authorRef must not inline upstream account note: %+v", authorRef)
+	}
+	expand, _ := firstStatus["expand"].(map[string]any)
+	expandArgs, _ := expand["arguments"].(map[string]any)
+	if expand["tool"] != "post_get" || expandArgs["id"] != "timeline-1" || expandArgs["view"] != "standard" {
+		t.Fatalf("unexpected compact expansion metadata: %+v", expand)
+	}
+	omitted, _ := firstStatus["omitted"].([]any)
+	if len(omitted) != 1 {
+		t.Fatalf("expected per-status omitted metadata, got %+v", firstStatus["omitted"])
+	}
+	omittedRecord, _ := omitted[0].(map[string]any)
+	omittedExpand, _ := omittedRecord["expand"].(map[string]any)
+	if omittedRecord["path"] != "content" || omittedExpand["tool"] != "post_get" || omittedExpand["resultPath"] != "structuredContent.data.status.content" {
+		t.Fatalf("unexpected omitted metadata: %+v", omittedRecord)
+	}
+	topOmitted, _ := data["omitted"].([]any)
+	if len(topOmitted) == 0 {
+		t.Fatalf("compact timeline should name list-level omitted fields: %+v", data)
+	}
+	var text map[string]any
+	if err := json.Unmarshal([]byte(compact.Result.Content[0].Text), &text); err != nil {
+		t.Fatalf("unmarshal compact text: %v", err)
+	}
+	if _, ok := text["statuses"]; ok {
+		t.Fatalf("compact text should use structured-first locator instead of duplicating statuses: %+v", text)
+	}
+	if locator, _ := text["data"].(map[string]any); locator["location"] != "structuredContent.data" {
+		t.Fatalf("expected structured data locator in compact text, got %+v", text)
+	}
+
+	standard := callSocialTool(t, env, app, authHeader, sessionID, 3, "timeline_read", map[string]any{
+		"timeline": "home",
+		"limit":    5,
+		"view":     "standard",
+	})
+	assertMCPPayloadIncrease(t,
+		"timeline_read compact limit=5 large fixture",
+		len(compact.ResponseBody),
+		"timeline_read standard large fixture",
+		len(standard.ResponseBody),
+	)
+	if !strings.Contains(string(standard.ResponseBody), contentTail) || !strings.Contains(string(standard.ResponseBody), accountNote) {
+		t.Fatalf("standard timeline response should preserve upstream shape/content")
+	}
+
+	defaultResult := callSocialTool(t, env, app, authHeader, sessionID, 4, "timeline_read", map[string]any{
+		"timeline": "home",
+		"limit":    5,
+	})
+	if _, ok := defaultResult.Result.StructuredContent["data"].([]any); !ok {
+		t.Fatalf("default timeline response must remain upstream array-shaped, got %+v", defaultResult.Result.StructuredContent["data"])
+	}
+}
+
+func TestM5_PostSearchCompactUsesStatusRefsAndPayloadBudget(t *testing.T) {
+	t.Setenv("MCP_SESSION_TABLE", "")
+	t.Setenv("JWT_SECRET", "test")
+	auth.ResetForTests()
+
+	const contentTail = "SEARCH_FULL_CONTENT_TAIL_SHOULD_NOT_APPEAR"
+	const accountNote = "SEARCH_ACCOUNT_NOTE_SHOULD_NOT_APPEAR"
+	const debugPayload = "SEARCH_DEBUG_PAYLOAD_SHOULD_NOT_APPEAR"
+
+	var gotQueries []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/api/v2/search" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		gotQueries = append(gotQueries, r.URL.RawQuery)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"statuses":` + socialStatusesFixtureJSON(10, "search", contentTail, accountNote, debugPayload) + `,
+			"accounts":[{"id":"acct-search-root","acct":"root@example.com","display_name":"Root","url":"https://example.com/@root","note":"` + accountNote + ` ` + strings.Repeat("search account note ", 100) + `"}],
+			"hashtags":[{"name":"mcp","url":"https://example.com/tags/mcp","history":[{"day":"1","uses":"100"}]}],
+			"debugPayload":{"large":"` + debugPayload + ` ` + strings.Repeat("debug payload ", 200) + `"}
+		}`))
+	}))
+	defer server.Close()
+
+	t.Setenv("LESSER_API_BASE_URL", server.URL)
+	lesserapi.ResetForTests()
+
+	app, env, sessionID, authHeader := newSocialToolTestSession(t)
+
+	compact := callSocialTool(t, env, app, authHeader, sessionID, 2, "post_search", map[string]any{
+		"query": "mcp",
+		"limit": 10,
+		"view":  "compact",
+	})
+	if compact.Result.IsError {
+		t.Fatalf("post_search compact returned tool error: %+v body=%s", compact.Result.StructuredContent, string(compact.ResponseBody))
+	}
+	if gotQueries[0] != "limit=10&q=mcp&type=statuses" {
+		t.Fatalf("expected compact search query, got %q", gotQueries[0])
+	}
+	assertMCPPayloadBudget(t, "post_search compact limit=10 large fixture", len(compact.ResponseBody), 8000)
+	for _, forbidden := range []string{contentTail, accountNote, debugPayload, "search account note ", "debug payload "} {
+		if strings.Contains(string(compact.ResponseBody), forbidden) {
+			t.Fatalf("compact search response leaked %q: %s", forbidden, string(compact.ResponseBody))
+		}
+	}
+
+	data, _ := compact.Result.StructuredContent["data"].(map[string]any)
+	if data["view"] != "compact" || data["query"] != "mcp" || data["count"] != float64(10) {
+		t.Fatalf("unexpected compact search metadata: %+v", data)
+	}
+	statuses, _ := data["statuses"].([]any)
+	if len(statuses) != 10 {
+		t.Fatalf("expected 10 compact statuses, got %+v", data["statuses"])
+	}
+	firstStatus, _ := statuses[0].(map[string]any)
+	if firstStatus["id"] != "search-1" || firstStatus["contentTruncated"] != true {
+		t.Fatalf("unexpected compact search status: %+v", firstStatus)
+	}
+	expand, _ := firstStatus["expand"].(map[string]any)
+	expandArgs, _ := expand["arguments"].(map[string]any)
+	if expand["tool"] != "post_get" || expandArgs["id"] != "search-1" || expandArgs["view"] != "standard" {
+		t.Fatalf("unexpected compact search expansion: %+v", expand)
+	}
+	accounts, _ := data["accounts"].([]any)
+	if len(accounts) != 1 {
+		t.Fatalf("expected compact account refs for search accounts, got %+v", data["accounts"])
+	}
+	accountRef, _ := accounts[0].(map[string]any)
+	if accountRef["id"] != "acct-search-root" || accountRef["acct"] != "root@example.com" || accountRef["displayName"] != "Root" {
+		t.Fatalf("unexpected compact search account ref: %+v", accountRef)
+	}
+	if _, ok := accountRef["note"]; ok {
+		t.Fatalf("search account ref must not inline upstream note: %+v", accountRef)
+	}
+	hashtags, _ := data["hashtags"].([]any)
+	if len(hashtags) != 1 {
+		t.Fatalf("expected compact hashtag summary, got %+v", data["hashtags"])
+	}
+	var text map[string]any
+	if err := json.Unmarshal([]byte(compact.Result.Content[0].Text), &text); err != nil {
+		t.Fatalf("unmarshal compact search text: %v", err)
+	}
+	if _, ok := text["statuses"]; ok {
+		t.Fatalf("compact search text should not duplicate statuses: %+v", text)
+	}
+
+	standard := callSocialTool(t, env, app, authHeader, sessionID, 3, "post_search", map[string]any{
+		"query": "mcp",
+		"limit": 10,
+		"view":  "standard",
+	})
+	assertMCPPayloadIncrease(t,
+		"post_search compact limit=10 large fixture",
+		len(compact.ResponseBody),
+		"post_search standard large fixture",
+		len(standard.ResponseBody),
+	)
+	if !strings.Contains(string(standard.ResponseBody), contentTail) || !strings.Contains(string(standard.ResponseBody), accountNote) {
+		t.Fatalf("standard search response should preserve upstream payload")
+	}
+}
+
+func TestM5_SocialCompactHonorsMaxOutputBytesTooLarge(t *testing.T) {
+	t.Setenv("MCP_SESSION_TABLE", "")
+	t.Setenv("JWT_SECRET", "test")
+	auth.ResetForTests()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/api/v1/timelines/home" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(socialStatusesFixtureJSON(5, "tiny-budget", "tail", "note", "debug")))
+	}))
+	defer server.Close()
+
+	t.Setenv("LESSER_API_BASE_URL", server.URL)
+	lesserapi.ResetForTests()
+
+	app, env, sessionID, authHeader := newSocialToolTestSession(t)
+
+	result := callSocialTool(t, env, app, authHeader, sessionID, 2, "timeline_read", map[string]any{
+		"timeline":         "home",
+		"limit":            5,
+		"view":             "compact",
+		"max_output_bytes": 1000,
+	})
+	if !result.Result.IsError {
+		t.Fatalf("expected response_too_large tool error, got %+v", result.Result)
+	}
+	errorPayload, _ := result.Result.StructuredContent["error"].(map[string]any)
+	if errorPayload["code"] != "response_too_large" || errorPayload["status"] != float64(413) {
+		t.Fatalf("unexpected too-large error payload: %+v", errorPayload)
+	}
+	details, _ := errorPayload["details"].(map[string]any)
+	if details["tool"] != "timeline_read" || details["maxOutputBytes"] != float64(1000) || details["measuredBytes"] == float64(0) {
+		t.Fatalf("unexpected too-large details: %+v", details)
 	}
 }
 
@@ -2086,4 +2366,104 @@ func TestM5_NotificationDismissSingleKeepsCursorAndHandlesNotFound(t *testing.T)
 	if !strings.Contains(strings.ToLower(rpc.Error.Message), "not found") {
 		t.Fatalf("expected not-found error message, got %+v", rpc.Error)
 	}
+}
+
+type socialToolCallResult struct {
+	ResponseBody []byte
+	RPC          mcpruntime.Response
+	Result       mcpruntime.ToolResult
+}
+
+func newSocialToolTestSession(t testing.TB) (*apptheory.App, *testkit.Env, string, string) {
+	t.Helper()
+
+	app, err := mcpapp.New("test", "dev")
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+	env := testkit.New()
+	token := newTestToken(t, "test", "agent1", []string{"read"})
+	authHeader := "Bearer " + token
+
+	initResp := invokeJSON(t, env, app, map[string][]string{"authorization": {authHeader}}, &mcpruntime.Request{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "initialize",
+	})
+	if initResp.Status != 200 {
+		t.Fatalf("initialize: status=%d body=%s", initResp.Status, string(initResp.Body))
+	}
+	return app, env, initResp.Headers["mcp-session-id"][0], authHeader
+}
+
+func callSocialTool(t testing.TB, env *testkit.Env, app *apptheory.App, authHeader string, sessionID string, id int, name string, args map[string]any) socialToolCallResult {
+	t.Helper()
+
+	callParams, _ := json.Marshal(map[string]any{"name": name, "arguments": args})
+	resp := invokeJSON(t, env, app, map[string][]string{
+		"authorization":  {authHeader},
+		"mcp-session-id": {sessionID},
+	}, &mcpruntime.Request{JSONRPC: "2.0", ID: id, Method: "tools/call", Params: callParams})
+	if resp.Status != 200 {
+		t.Fatalf("%s: status=%d body=%s", name, resp.Status, string(resp.Body))
+	}
+
+	var rpc mcpruntime.Response
+	if err := json.Unmarshal(resp.Body, &rpc); err != nil {
+		t.Fatalf("unmarshal %s: %v", name, err)
+	}
+	if rpc.Error != nil {
+		t.Fatalf("%s rpc error: %+v", name, rpc.Error)
+	}
+
+	var out mcpruntime.ToolResult
+	b, _ := json.Marshal(rpc.Result)
+	_ = json.Unmarshal(b, &out)
+	return socialToolCallResult{
+		ResponseBody: resp.Body,
+		RPC:          rpc,
+		Result:       out,
+	}
+}
+
+func socialStatusesFixtureJSON(count int, prefix string, contentTail string, accountNote string, debugPayload string) string {
+	var b strings.Builder
+	b.WriteString("[")
+	titlePrefix := strings.ToUpper(prefix[:1]) + prefix[1:]
+	for i := 1; i <= count; i++ {
+		if i > 1 {
+			b.WriteString(",")
+		}
+		content := strings.Repeat(fmt.Sprintf("%s content %02d ", prefix, i), 18) + contentTail
+		b.WriteString(fmt.Sprintf(`{
+			"id":"%s-%d",
+			"url":"https://example.com/@%s%d/%s-%d",
+			"created_at":"2026-05-17T17:%02d:00Z",
+			"visibility":"public",
+			"content":"%s",
+			"account":{
+				"id":"acct-%s-%d",
+				"username":"%s%d",
+				"acct":"%s%d@example.com",
+				"display_name":"%s %d",
+				"url":"https://example.com/@%s%d",
+				"note":"%s %s"
+			},
+			"debugPayload":{"large":"%s %s"}
+		}`,
+			prefix, i,
+			prefix, i, prefix, i,
+			i,
+			content,
+			prefix, i,
+			prefix, i,
+			prefix, i,
+			titlePrefix, i,
+			prefix, i,
+			accountNote, strings.Repeat("account note ", 80),
+			debugPayload, strings.Repeat("debug payload ", 80),
+		))
+	}
+	b.WriteString("]")
+	return b.String()
 }

--- a/internal/mcpserver/social_refs.go
+++ b/internal/mcpserver/social_refs.go
@@ -57,13 +57,20 @@ func compactSocialAccountRef(raw map[string]any) *AccountRef {
 }
 
 func compactSocialStatusRef(raw map[string]any) *StatusRef {
+	return compactSocialStatusRefWithPreview(raw, socialStatusContentPreviewRunes)
+}
+
+func compactSocialStatusRefWithPreview(raw map[string]any, previewRunes int) *StatusRef {
 	if raw == nil {
 		return nil
+	}
+	if previewRunes <= 0 {
+		previewRunes = socialStatusContentPreviewRunes
 	}
 
 	id := firstNonEmptyStringMap(raw, "id")
 	content := rawSocialStatusContent(raw)
-	preview, truncated := compactStringWithTruncation(content, socialStatusContentPreviewRunes)
+	preview, truncated := compactStringWithTruncation(content, previewRunes)
 
 	ref := &StatusRef{
 		ID:               id,

--- a/internal/mcpserver/social_tools.go
+++ b/internal/mcpserver/social_tools.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"sort"
 	"strconv"
@@ -33,6 +34,9 @@ const (
 	notificationCommPreviewRunes     = 240
 	conversationReadDefaultLimit     = 20
 	conversationReadMaxLimit         = 80
+	socialCompactListPreviewRunes    = 48
+	timelineCompactMaxOutputBytes    = 6000
+	postSearchCompactMaxOutputBytes  = 8000
 )
 
 var notificationCursorEventIDs = struct {
@@ -193,6 +197,14 @@ func handleProfileRead(ctx context.Context, args json.RawMessage) (*mcpruntime.T
 }
 
 func handleTimelineRead(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
+	readParams, err := parseSharedReadParams(args)
+	if err != nil {
+		return nil, invalidParams("invalid args: " + err.Error())
+	}
+	if err := validateSocialListReadView(readParams.View); err != nil {
+		return nil, invalidParams(err.Error())
+	}
+
 	var in struct {
 		Timeline string `json:"timeline"`
 		Since    string `json:"since,omitempty"`
@@ -240,10 +252,21 @@ func handleTimelineRead(ctx context.Context, args json.RawMessage) (*mcpruntime.
 	if err != nil {
 		return authToolResultFromError(err)
 	}
+	if readParams.View == readViewCompact {
+		return socialCompactTimelineResult(in.Timeline, strings.TrimSpace(in.Since), in.Limit, out, readParams)
+	}
 	return toolJSONResult(out, nil)
 }
 
 func handlePostSearch(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
+	readParams, err := parseSharedReadParams(args)
+	if err != nil {
+		return nil, invalidParams("invalid args: " + err.Error())
+	}
+	if err := validateSocialListReadView(readParams.View); err != nil {
+		return nil, invalidParams(err.Error())
+	}
+
 	var in struct {
 		Query string `json:"query"`
 		Limit int    `json:"limit,omitempty"`
@@ -276,7 +299,246 @@ func handlePostSearch(ctx context.Context, args json.RawMessage) (*mcpruntime.To
 	if err != nil {
 		return authToolResultFromError(err)
 	}
+	if readParams.View == readViewCompact {
+		return socialCompactPostSearchResult(in.Query, in.Limit, out, readParams)
+	}
 	return toolJSONResult(out, nil)
+}
+
+func validateSocialListReadView(view string) error {
+	switch strings.ToLower(strings.TrimSpace(view)) {
+	case "", readViewStandard, readViewFull, readViewCompact:
+		return nil
+	default:
+		return fmt.Errorf("invalid view (expected compact, standard, or full)")
+	}
+}
+
+func socialCompactTimelineResult(timeline string, since string, limit int, raw any, params sharedReadParams) (*mcpruntime.ToolResult, error) {
+	items, ok := raw.([]any)
+	if !ok {
+		return nil, fmt.Errorf("unexpected timeline response")
+	}
+
+	previewRunes := socialCompactPreviewRunes(params)
+	statuses, statusIDs, err := compactSocialStatusRefsFromItems(items, previewRunes)
+	if err != nil {
+		return nil, err
+	}
+	budget := socialCompactOutputBudget(params, timelineCompactMaxOutputBytes)
+	payload := map[string]any{
+		"view":     readViewCompact,
+		"timeline": timeline,
+		"count":    len(statuses),
+		"statuses": statuses,
+		"omitted":  socialCompactStatusListOmissions("statuses"),
+		"budget":   socialCompactBudgetMetadata(budget, previewRunes),
+	}
+	if strings.TrimSpace(since) != "" {
+		payload["since"] = strings.TrimSpace(since)
+	}
+	if limit > 0 {
+		payload["limit"] = limit
+	}
+
+	return socialCompactListToolResult("timeline_read", fmt.Sprintf("%d compact %s timeline statuses", len(statuses), timeline), payload, map[string]any{
+		"tool":      "timeline_read",
+		"view":      readViewCompact,
+		"timeline":  timeline,
+		"count":     len(statuses),
+		"statusIds": statusIDs,
+		"omitted":   socialCompactStatusListTextOmissions("statuses"),
+	}, budget)
+}
+
+func socialCompactPostSearchResult(query string, limit int, raw any, params sharedReadParams) (*mcpruntime.ToolResult, error) {
+	search, ok := raw.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("unexpected search response")
+	}
+	statusesRaw, ok := search["statuses"].([]any)
+	if !ok && search["statuses"] != nil {
+		return nil, fmt.Errorf("unexpected search statuses response")
+	}
+
+	previewRunes := socialCompactPreviewRunes(params)
+	statuses, statusIDs, err := compactSocialStatusRefsFromItems(statusesRaw, previewRunes)
+	if err != nil {
+		return nil, err
+	}
+	budget := socialCompactOutputBudget(params, postSearchCompactMaxOutputBytes)
+	payload := map[string]any{
+		"view":     readViewCompact,
+		"query":    query,
+		"count":    len(statuses),
+		"statuses": statuses,
+		"omitted":  socialCompactStatusListOmissions("statuses"),
+		"budget":   socialCompactBudgetMetadata(budget, previewRunes),
+	}
+	if limit > 0 {
+		payload["limit"] = limit
+	}
+	if accounts := compactSocialAccountRefsFromItems(search["accounts"]); len(accounts) > 0 {
+		payload["accounts"] = accounts
+	}
+	if hashtags := compactSocialHashtagsFromItems(search["hashtags"]); len(hashtags) > 0 {
+		payload["hashtags"] = hashtags
+	}
+
+	return socialCompactListToolResult("post_search", fmt.Sprintf("%d compact post search results", len(statuses)), payload, map[string]any{
+		"tool":      "post_search",
+		"view":      readViewCompact,
+		"query":     query,
+		"count":     len(statuses),
+		"statusIds": statusIDs,
+		"omitted":   socialCompactStatusListTextOmissions("statuses"),
+	}, budget)
+}
+
+func compactSocialStatusRefsFromItems(items []any, previewRunes int) ([]any, []string, error) {
+	statuses := make([]any, 0, len(items))
+	statusIDs := make([]string, 0, len(items))
+	for _, item := range items {
+		raw, ok := item.(map[string]any)
+		if !ok || raw == nil {
+			return nil, nil, fmt.Errorf("unexpected status item")
+		}
+		ref := compactSocialStatusRefWithPreview(raw, previewRunes)
+		if ref == nil {
+			return nil, nil, fmt.Errorf("unexpected empty status item")
+		}
+		statuses = append(statuses, ref)
+		if strings.TrimSpace(ref.ID) != "" {
+			statusIDs = append(statusIDs, strings.TrimSpace(ref.ID))
+		}
+	}
+	return statuses, statusIDs, nil
+}
+
+func compactSocialAccountRefsFromItems(raw any) []any {
+	items, ok := raw.([]any)
+	if !ok {
+		return nil
+	}
+	accounts := make([]any, 0, len(items))
+	for _, item := range items {
+		raw, ok := item.(map[string]any)
+		if !ok || raw == nil {
+			continue
+		}
+		ref := compactSocialAccountRef(raw)
+		if ref != nil {
+			accounts = append(accounts, ref)
+		}
+	}
+	return accounts
+}
+
+func compactSocialHashtagsFromItems(raw any) []any {
+	items, ok := raw.([]any)
+	if !ok {
+		return nil
+	}
+	hashtags := make([]any, 0, len(items))
+	for _, item := range items {
+		switch typed := item.(type) {
+		case string:
+			if value := strings.TrimSpace(typed); value != "" {
+				hashtags = append(hashtags, value)
+			}
+		case map[string]any:
+			hashtag := map[string]any{}
+			putIfNotEmpty(hashtag, "name", firstNonEmptyStringMap(typed, "name", "tag"))
+			putIfNotEmpty(hashtag, "url", firstNonEmptyStringMap(typed, "url"))
+			if len(hashtag) > 0 {
+				hashtags = append(hashtags, hashtag)
+			}
+		}
+	}
+	return hashtags
+}
+
+func socialCompactPreviewRunes(params sharedReadParams) int {
+	if params.PreviewChars > 0 {
+		return params.PreviewChars
+	}
+	return socialCompactListPreviewRunes
+}
+
+func socialCompactOutputBudget(params sharedReadParams, defaultBudget int) int {
+	if params.MaxOutputBytes > 0 {
+		return params.MaxOutputBytes
+	}
+	return defaultBudget
+}
+
+func socialCompactBudgetMetadata(maxOutputBytes int, previewRunes int) map[string]any {
+	return map[string]any{
+		"maxOutputBytes":      maxOutputBytes,
+		"contentPreviewRunes": previewRunes,
+		"enforcement":         "response_too_large",
+	}
+}
+
+func socialCompactStatusListOmissions(statusPath string) []any {
+	return []any{
+		map[string]any{
+			"path":      statusPath + "[].content",
+			"reason":    "content_preview",
+			"expansion": statusPath + "[].omitted[].expand",
+		},
+		map[string]any{
+			"path":      statusPath + "[].account",
+			"reason":    "author_ref_only",
+			"expansion": statusPath + "[].expand with post_get(id, view=full)",
+		},
+	}
+}
+
+func socialCompactStatusListTextOmissions(statusPath string) []any {
+	return []any{
+		map[string]any{
+			"path":      statusPath + "[].content",
+			"reason":    "content_preview",
+			"expansion": "structuredContent.data." + statusPath + "[].omitted[].expand",
+		},
+		map[string]any{
+			"path":      statusPath + "[].account",
+			"reason":    "author_ref_only",
+			"expansion": "structuredContent.data." + statusPath + "[].expand with view=full",
+		},
+	}
+}
+
+func socialCompactListToolResult(toolName string, summary string, payload map[string]any, text map[string]any, maxOutputBytes int) (*mcpruntime.ToolResult, error) {
+	result, err := toolStructuredFirstResult(structuredFirstResultOptions{
+		Summary: summary,
+		Data:    payload,
+		Text:    text,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if maxOutputBytes <= 0 {
+		return result, nil
+	}
+	measurement, err := measureToolResultPayload(result)
+	if err != nil {
+		return nil, err
+	}
+	if measurement.JSONRPCEnvelopeBytes <= maxOutputBytes {
+		return result, nil
+	}
+	return toolErrorResult("response_too_large", toolName+" compact response exceeds max_output_bytes", http.StatusRequestEntityTooLarge, map[string]any{
+		"tool":                 toolName,
+		"view":                 readViewCompact,
+		"measuredBytes":        measurement.JSONRPCEnvelopeBytes,
+		"maxOutputBytes":       maxOutputBytes,
+		"contentTextBytes":     measurement.ContentTextBytes,
+		"structuredBytes":      measurement.StructuredContentBytes,
+		"guidance":             "reduce limit or increase max_output_bytes",
+		"omittedFieldMetadata": "available under structuredContent.data.omitted for successful compact responses",
+	})
 }
 
 func handlePostGet(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
@@ -840,7 +1102,10 @@ func timelineReadDef() mcpruntime.ToolDef {
 			"properties":{
 				"timeline":{"type":"string","enum":["home","local","federated"]},
 				"since":{"type":"string"},
-				"limit":{"type":"integer","minimum":1,"maximum":200}
+				"limit":{"type":"integer","minimum":1,"maximum":200},
+				"view":{"type":"string","enum":["compact","standard","full"],"description":"Optional projection. Omitted/standard/full preserve the current upstream-shaped response; compact returns bounded StatusRef entries with post_get expansion metadata."},
+				"preview_chars":{"type":"integer","minimum":0,"description":"Optional compact content preview character budget. Zero means the tool default."},
+				"max_output_bytes":{"type":"integer","minimum":0,"description":"Optional compact MCP response budget. Compact responses that exceed the budget return response_too_large instead of silently dropping fields."}
 			},
 			"required":["timeline"]
 		}`),
@@ -855,7 +1120,10 @@ func postSearchDef() mcpruntime.ToolDef {
 			"type":"object",
 			"properties":{
 				"query":{"type":"string"},
-				"limit":{"type":"integer","minimum":1,"maximum":200}
+				"limit":{"type":"integer","minimum":1,"maximum":200},
+				"view":{"type":"string","enum":["compact","standard","full"],"description":"Optional projection. Omitted/standard/full preserve the current upstream-shaped response; compact returns bounded StatusRef entries with post_get expansion metadata."},
+				"preview_chars":{"type":"integer","minimum":0,"description":"Optional compact content preview character budget. Zero means the tool default."},
+				"max_output_bytes":{"type":"integer","minimum":0,"description":"Optional compact MCP response budget. Compact responses that exceed the budget return response_too_large instead of silently dropping fields."}
 			},
 			"required":["query"]
 		}`),


### PR DESCRIPTION
## Milestone
Project 33 P1.2 — compact opt-in `timeline_read` and `post_search`.

Closes #231.

## Classification
MCP-contract additive / existing tool behavior additive / social read payload compaction.

## Surfaces affected
- `internal/mcpserver/social_tools.go` — adds opt-in `view=compact` handling for `timeline_read` and `post_search`, compact response helpers, default/caller budget enforcement, and schema parameters.
- `internal/mcpserver/social_refs.go` — lets list compacting reuse the P1.1 `StatusRef` shape with a per-list preview budget while preserving the P1.1 default helper.
- `internal/mcpapp/social_tools_test.go` — adds discovery/schema checks, compact payload budget gates, default/standard compatibility checks, and too-large response coverage.
- `docs/mcp.md` — documents opt-in compact timeline/search behavior, budgets, structured-first response shape, and unchanged defaults.

## Tool-surface audit
- Tools modified: `timeline_read`, `post_search`.
- Group: social.
- Scope: read unchanged.
- Runtime profiles: unchanged; both tools remain available wherever social read tools are currently available.
- Input schema: additive optional `view`, `preview_chars`, and `max_output_bytes`.
- Output behavior:
  - Omitted `view`, `view=standard`, and `view=full` preserve the current upstream-shaped Lesser response.
  - `view=compact` returns bounded `StatusRef` lists with deterministic `post_get` expansion metadata.
  - `post_search(view=compact)` also returns compact `AccountRef` search account matches and compact hashtag summaries when Lesser supplies them.
- Side effects: none.
- Idempotency: not applicable (read-only).
- Static registration: unchanged; no dynamic tools.
- Communication-tool discipline: not applicable.

## MCP contract audit
- `.well-known/mcp.json` / `tools/list`: additive optional input schema parameters for existing tools.
- OAuth protected-resource metadata: unchanged.
- JSON-RPC request/response:
  - Existing default request and response shapes are preserved.
  - `view=compact` is opt-in and returns structured-first compact data under `structuredContent.data` with concise text locators.
  - Oversized compact responses return an explicit `response_too_large` tool error rather than silent field dropping.
- Compatibility classification: additive/backward-compatible. Existing clients that omit `view` continue to receive upstream-shaped results.
- Client impact: clients may opt into compact social lists; no client is required to update.
- Versioning: no MCP protocol version bump; no endpoint versioning required.

## Lesser-integration audit
- JWT secret handling: unchanged.
- DynamoDB reads: unchanged.
- Lesser REST API consumed: unchanged existing `GET /api/v1/timelines/*` and `GET /api/v2/search` calls.
- New Lesser endpoint required: no.
- Lesser-side code change needed: none.
- SSM exports / `soulEnabled` / deploy order: unchanged.

## Tasks
- [x] `timeline_read(limit=5, view=compact)` targets `<6 KB` MCP JSON-RPC payload or returns explicit truncation/omitted metadata.
- [x] `post_search(limit=10, view=compact)` targets `<8 KB` MCP JSON-RPC payload or returns explicit truncation/omitted metadata.
- [x] Compact list entries use P1.1 `StatusRef`/`AccountRef` shapes and deterministic `post_get` expansion metadata.
- [x] Standard/default behavior remains compatible; defaults are not flipped to compact.
- [x] `view=standard`/`view=full` remains available and upstream-shaped for these tools.
- [x] Large-limit/tiny-budget behavior is bounded by `max_output_bytes` with a clear `response_too_large` tool error.
- [x] Structured-first compact text avoids duplicating every compact entry while keeping `structuredContent.data` deterministic.
- [x] No Lesser/Host/AppTheory upstream compact projections, runtime rewrite, hot-context/AGENTS slimming, or mailbox alias removal.
- [x] Private reachability/identity paths were not touched.

## Representative payload-size evidence
From targeted validation on this branch:
- `timeline_read(limit=5, view=compact)` large fixture: `4400` JSON-RPC payload bytes (budget `6000`).
- `timeline_read(limit=5, view=standard)` same fixture: `30165` JSON-RPC payload bytes.
- `post_search(limit=10, view=compact)` large fixture: `7806` JSON-RPC payload bytes (budget `8000`).
- `post_search(limit=10, view=standard)` same fixture: `69433` JSON-RPC payload bytes.

## Representative compact/standard examples
- `timeline_read({timeline:"home", limit:5, view:"compact"})` returns `structuredContent.data.statuses[]` as compact `StatusRef` entries with `id`, `url`, `authorRef`, `createdAt`, `visibility`, bounded `contentPreview`, `contentTruncated`, `expand:{tool:"post_get", arguments:{id, view:"standard"}}`, and per-status `omitted[]` for full content.
- Compact timeline/search text includes summary metadata, status ids, omitted-field pointers, and `data:{location:"structuredContent.data"}` rather than duplicating all entries in text.
- `post_search({query:"mcp", limit:10, view:"compact"})` returns compact `statuses[]`, compact `accounts[]` as `AccountRef` where present, and compact hashtag summaries.
- `timeline_read({timeline:"home", limit:5})`, `timeline_read(..., view:"standard")`, and `timeline_read(..., view:"full")` preserve the existing upstream array response.
- `post_search({query:"mcp", limit:10})`, `post_search(..., view:"standard")`, and `post_search(..., view:"full")` preserve the existing upstream search response.
- `timeline_read(..., view:"compact", max_output_bytes:1000)` returns a `response_too_large` tool error with measured/max byte details.

## Validation
- Baseline on `main` before branch: `gofmt -l .`, `git diff --check`, `go test ./...`, `go vet ./...`, `bash scripts/build.sh` all passed.
- Branch validation:
  - `gofmt -l .` (empty)
  - `git diff --check`
  - `go test ./...`
  - `go vet ./...`
  - `bash scripts/build.sh`
- Targeted:
  - `go test -count=1 -v ./internal/mcpserver -run 'TestCompactSocial|TestSocialStatusStandard|TestParseSharedReadParams'`
  - `go test -count=1 -v ./internal/mcpapp -run 'TestM5_ToolsListContainsCoreTools|TestM5_ToolsProxyToLesserAPI|TestM5_TimelineReadCompactUsesStatusRefsAndPayloadBudget|TestM5_PostSearchCompactUsesStatusRefsAndPayloadBudget|TestM5_SocialCompactHonorsMaxOutputBytesTooLarge|TestM5_PostGetExpandsStatusRefViaLesserRoute'`

## Compatibility notes
- Existing defaults are unchanged and upstream-shaped.
- This is additive to discovery; existing clients can ignore the new optional parameters.
- `view=compact` is opt-in only.
- Private reachability/identity paths were not touched.
- No Host/Soul/AppTheory changes required.

## Stage rollout plan (handoff to deploy-body)
- [ ] Merged to main
- [ ] Deployed to lab / dev
- [ ] Lab soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
No Lesser-side code change required because the existing timeline/search routes are consumed unchanged. No Host/Soul/AppTheory changes required.

## Advisor-brief authorization
Arch activated #231 in issue comment `4472353292`; proceeding under standing user authorization for Arch-assigned Project 33 milestones. PR packet will be emailed to Arch.