### PR TITLE
feat(mcp): compact conversation reads

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -357,6 +357,7 @@ Scope key:
 | `post_get` | Read | Expand a compact social `StatusRef` through Lesser's status read route. |
 | `followers_list` | Read | List the agent's followers. |
 | `following_list` | Read | List accounts the agent follows. |
+| `conversations_read` | Read | Read direct-message conversations; supports opt-in compact conversation refs without a `conversation_get` expansion promise. |
 | `notifications_read` | Read | Read recent notifications; supports opt-in compact notification refs. |
 | `notification_get` | Read | Expand a compact notification ref through Lesser's notification read route. |
 | `post_create` | Write | Create a new post. |
@@ -462,9 +463,17 @@ Notes:
   returns the upstream Lesser notification payload for audit/debug expansion. Omitted/default and `view=standard`
   list reads preserve the existing normalized response; `view=full` is an explicit debug/audit list view that includes
   upstream `_raw` payloads.
-- `conversations_read` defaults to `limit=20` (maximum `80`) and returns compact conversation summaries: id, unread
-  state, updated timestamp, compact participants, and bounded `lastPost`. It accepts optional `include_raw=true`, which
-  returns `_raw` for audit/debug use.
+- `conversations_read` defaults to `limit=20` (maximum `80`) and preserves the existing normalized conversation-list
+  response unless a view is requested. `conversations_read(view=compact)` is opt-in and returns compact conversation
+  summaries under `structuredContent.data.conversations[]`: stable conversation id, read/unread/update metadata,
+  `participantRefs`, and bounded `lastPostRef` previews. Conversation refs intentionally do **not** advertise
+  `conversation_get`; there is no single-conversation expansion route in body's local contract. `lastPostRef.expand`
+  uses `post_get(id, view=standard)` when Lesser supplies a stable post/status id; otherwise the ref reports missing
+  metadata instead of inventing an expansion path. `conversations_read(limit=10, view=compact)` targets a 6 KB MCP
+  JSON-RPC payload budget. If the compact response exceeds its default or caller-supplied `max_output_bytes`, body
+  returns `response_too_large` with measured byte details rather than silently dropping fields. `preview_chars` bounds
+  compact last-post previews. `include_raw=true` and `view=full` remain explicit audit/debug paths that include
+  upstream `_raw` conversation payloads; compact mode does not inline upstream raw payloads.
 - `skills_catalog` and `skill_bundle_get` are read-only Project 21 M4 skills tools backed by Lesser's authoritative
   skill publication contract. `skills_catalog` calls `GET /api/v1/skills/catalog`; `skill_bundle_get` calls
   `GET /api/v1/skills/{skillId}/revisions/{revisionNumber}/bundle` and accepts either `skill_id` + `revision_number`

--- a/internal/mcpapp/social_tools_test.go
+++ b/internal/mcpapp/social_tools_test.go
@@ -63,6 +63,9 @@ func TestM5_ToolsListContainsCoreTools(t *testing.T) {
 	if rpc.Error != nil {
 		t.Fatalf("tools/list error: %+v", rpc.Error)
 	}
+	if strings.Contains(string(listResp.Body), "conversation_get") {
+		t.Fatalf("tools/list must not advertise conversation_get without a real expansion route: %s", string(listResp.Body))
+	}
 
 	var result struct {
 		Tools []mcpruntime.ToolDef `json:"tools"`
@@ -77,6 +80,9 @@ func TestM5_ToolsListContainsCoreTools(t *testing.T) {
 	for _, tool := range result.Tools {
 		have[tool.Name] = true
 		toolsByName[tool.Name] = tool
+	}
+	if have["conversation_get"] {
+		t.Fatalf("conversation_get must not be advertised without a real expansion route")
 	}
 
 	for _, name := range []string{
@@ -204,6 +210,17 @@ func TestM5_ToolsListContainsCoreTools(t *testing.T) {
 	}
 	if propType, _ := conversationSchema.Properties["include_raw"]["type"].(string); propType != "boolean" {
 		t.Fatalf("conversations_read include_raw should be boolean, got %+v", conversationSchema.Properties["include_raw"])
+	}
+	viewProp = conversationSchema.Properties["view"]
+	enum, _ = viewProp["enum"].([]any)
+	if !reflect.DeepEqual(enum, []any{"compact", "standard", "full"}) {
+		t.Fatalf("conversations_read view enum = %+v", viewProp)
+	}
+	if propType, _ := conversationSchema.Properties["max_output_bytes"]["type"].(string); propType != "integer" {
+		t.Fatalf("conversations_read max_output_bytes should be integer, got %+v", conversationSchema.Properties["max_output_bytes"])
+	}
+	if propType, _ := conversationSchema.Properties["preview_chars"]["type"].(string); propType != "integer" {
+		t.Fatalf("conversations_read preview_chars should be integer, got %+v", conversationSchema.Properties["preview_chars"])
 	}
 }
 
@@ -1136,6 +1153,163 @@ func TestM5_ConversationsReadUsesCompactBoundedDefaults(t *testing.T) {
 		"conversations_read include_raw expanded fixture",
 		responseBytes[3],
 	)
+}
+
+func TestM5_ConversationsReadCompactRefsNoConversationGet(t *testing.T) {
+	t.Setenv("MCP_SESSION_TABLE", "")
+	t.Setenv("JWT_SECRET", "test")
+	auth.ResetForTests()
+
+	const contentTail = "CONVERSATION_FULL_CONTENT_TAIL_SHOULD_NOT_APPEAR"
+	const accountNote = "CONVERSATION_ACCOUNT_NOTE_SHOULD_NOT_APPEAR"
+	const debugPayload = "CONVERSATION_DEBUG_PAYLOAD_SHOULD_NOT_APPEAR"
+
+	var gotQueries []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/api/v1/conversations" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		gotQueries = append(gotQueries, r.URL.RawQuery)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(socialConversationsFixtureJSON(10, "conv", contentTail, accountNote, debugPayload)))
+	}))
+	defer server.Close()
+
+	t.Setenv("LESSER_API_BASE_URL", server.URL)
+	lesserapi.ResetForTests()
+
+	app, env, sessionID, authHeader := newSocialToolTestSession(t)
+
+	compact := callSocialTool(t, env, app, authHeader, sessionID, 2, "conversations_read", map[string]any{
+		"limit": 10,
+		"view":  "compact",
+	})
+	if compact.Result.IsError {
+		t.Fatalf("conversations_read compact returned tool error: %+v body=%s", compact.Result.StructuredContent, string(compact.ResponseBody))
+	}
+	assertMCPPayloadBudget(t, "conversations_read compact limit=10 large fixture", len(compact.ResponseBody), 6000)
+	for _, forbidden := range []string{contentTail, accountNote, debugPayload, "account note ", "debug payload ", "conversation_get"} {
+		if strings.Contains(string(compact.ResponseBody), forbidden) {
+			t.Fatalf("compact conversations response leaked or advertised %q: %s", forbidden, string(compact.ResponseBody))
+		}
+	}
+	if gotQueries[0] != "limit=10" {
+		t.Fatalf("expected compact limit query, got %q", gotQueries[0])
+	}
+	compactData, _ := compact.Result.StructuredContent["data"].(map[string]any)
+	if compactData["view"] != "compact" || compactData["count"] != float64(10) || compactData["includeRaw"] != false {
+		t.Fatalf("unexpected compact conversations metadata: %+v", compactData)
+	}
+	conversations, _ := compactData["conversations"].([]any)
+	if len(conversations) != 10 {
+		t.Fatalf("expected 10 compact conversations, got %+v", compactData["conversations"])
+	}
+	first, _ := conversations[0].(map[string]any)
+	if first["id"] != "conv-1" || first["unread"] != true || first["read"] != false || first["updatedAt"] == "" {
+		t.Fatalf("unexpected compact conversation metadata: %+v", first)
+	}
+	if _, ok := first["expand"]; ok {
+		t.Fatalf("conversation refs must not advertise conversation_get-style expansion: %+v", first)
+	}
+	participantRefs, _ := first["participantRefs"].([]any)
+	if len(participantRefs) != 2 {
+		t.Fatalf("expected participant refs, got %+v", first)
+	}
+	participant, _ := participantRefs[0].(map[string]any)
+	if participant["id"] != "acct-conv-1-a" || participant["acct"] != "conv1a@example.com" {
+		t.Fatalf("unexpected participant ref: %+v", participant)
+	}
+	if _, ok := participant["note"]; ok {
+		t.Fatalf("participant refs must not inline profile notes: %+v", participant)
+	}
+	lastPostRef, _ := first["lastPostRef"].(map[string]any)
+	if lastPostRef["id"] != "post-conv-1" || lastPostRef["contentTruncated"] != true {
+		t.Fatalf("unexpected lastPostRef: %+v", lastPostRef)
+	}
+	if preview, _ := lastPostRef["contentPreview"].(string); preview == "" || len([]rune(preview)) > 16 || strings.Contains(preview, contentTail) {
+		t.Fatalf("expected bounded last-post preview, got %q (%d runes)", preview, len([]rune(preview)))
+	}
+	postExpand, _ := lastPostRef["expand"].(map[string]any)
+	postArgs, _ := postExpand["arguments"].(map[string]any)
+	if postExpand["tool"] != "post_get" || postArgs["id"] != "post-conv-1" {
+		t.Fatalf("expected lastPostRef to expand through post_get, got %+v", postExpand)
+	}
+	topOmitted, _ := compactData["omitted"].([]any)
+	if len(topOmitted) < 3 {
+		t.Fatalf("expected list-level conversation omitted metadata, got %+v", compactData["omitted"])
+	}
+	if b, _ := json.Marshal(topOmitted); strings.Contains(string(b), "conversation_get") {
+		t.Fatalf("omitted metadata must not advertise conversation_get: %s", string(b))
+	}
+	var text map[string]any
+	if err := json.Unmarshal([]byte(compact.Result.Content[0].Text), &text); err != nil {
+		t.Fatalf("unmarshal compact text: %v", err)
+	}
+	if _, ok := text["conversations"]; ok {
+		t.Fatalf("compact text should use structured-first locator instead of duplicating conversations: %+v", text)
+	}
+	if locator, _ := text["data"].(map[string]any); locator["location"] != "structuredContent.data" {
+		t.Fatalf("expected structured data locator in compact text, got %+v", text)
+	}
+
+	previewCompact := callSocialTool(t, env, app, authHeader, sessionID, 3, "conversations_read", map[string]any{
+		"limit":            10,
+		"view":             "compact",
+		"preview_chars":    8,
+		"max_output_bytes": 6000,
+	})
+	previewData, _ := previewCompact.Result.StructuredContent["data"].(map[string]any)
+	previewBudget, _ := previewData["budget"].(map[string]any)
+	if previewBudget["contentPreviewRunes"] != float64(8) || previewBudget["maxOutputBytes"] != float64(6000) {
+		t.Fatalf("expected preview/max budget metadata to honor args, got %+v", previewBudget)
+	}
+	previewConversations, _ := previewData["conversations"].([]any)
+	previewFirst, _ := previewConversations[0].(map[string]any)
+	previewLast, _ := previewFirst["lastPostRef"].(map[string]any)
+	if preview, _ := previewLast["contentPreview"].(string); len([]rune(preview)) > 8 {
+		t.Fatalf("expected preview_chars=8 to be honored, got %q", preview)
+	}
+
+	defaultResult := callSocialTool(t, env, app, authHeader, sessionID, 4, "conversations_read", map[string]any{"limit": 10})
+	fullResult := callSocialTool(t, env, app, authHeader, sessionID, 5, "conversations_read", map[string]any{
+		"limit": 10,
+		"view":  "full",
+	})
+	fullData, _ := fullResult.Result.StructuredContent["data"].(map[string]any)
+	fullConversations, _ := fullData["conversations"].([]any)
+	fullConversation, _ := fullConversations[0].(map[string]any)
+	if _, ok := fullConversation["_raw"].(map[string]any); !ok || fullData["includeRaw"] != true {
+		t.Fatalf("view=full should preserve explicit raw/debug path, got %+v", fullData)
+	}
+	if !strings.Contains(string(fullResult.ResponseBody), debugPayload) || !strings.Contains(string(fullResult.ResponseBody), accountNote) {
+		t.Fatalf("view=full should expose upstream debug/account payloads")
+	}
+	assertMCPPayloadIncrease(t,
+		"conversations_read compact limit=10 large fixture",
+		len(compact.ResponseBody),
+		"conversations_read default normalized fixture",
+		len(defaultResult.ResponseBody),
+	)
+
+	tooLarge := callSocialTool(t, env, app, authHeader, sessionID, 6, "conversations_read", map[string]any{
+		"limit":            10,
+		"view":             "compact",
+		"max_output_bytes": 1000,
+	})
+	if !tooLarge.Result.IsError {
+		t.Fatalf("expected response_too_large conversation tool error, got %+v", tooLarge.Result)
+	}
+	errorPayload, _ := tooLarge.Result.StructuredContent["error"].(map[string]any)
+	if errorPayload["code"] != "response_too_large" || errorPayload["status"] != float64(413) {
+		t.Fatalf("unexpected too-large error payload: %+v", errorPayload)
+	}
+	details, _ := errorPayload["details"].(map[string]any)
+	if details["tool"] != "conversations_read" || details["maxOutputBytes"] != float64(1000) || details["measuredBytes"] == float64(0) {
+		t.Fatalf("unexpected too-large details: %+v", details)
+	}
+	if strings.Contains(string(tooLarge.ResponseBody), "conversation_get") {
+		t.Fatalf("too-large error must not advertise conversation_get: %s", string(tooLarge.ResponseBody))
+	}
 }
 
 func TestM5_NotificationsReadReturnsStructuredNotifications(t *testing.T) {
@@ -2759,6 +2933,72 @@ func socialNotificationsFixtureJSON(count int, prefix string, contentTail string
 		}`,
 			prefix, i,
 			i,
+			prefix, i,
+			prefix, i,
+			prefix, i,
+			titlePrefix, i,
+			prefix, i,
+			accountNote, strings.Repeat("account note ", 80),
+			prefix, i,
+			prefix, i, prefix, i,
+			i,
+			content,
+			debugPayload, strings.Repeat("debug payload ", 80),
+		))
+	}
+	b.WriteString("]")
+	return b.String()
+}
+
+func socialConversationsFixtureJSON(count int, prefix string, contentTail string, accountNote string, debugPayload string) string {
+	var b strings.Builder
+	b.WriteString("[")
+	titlePrefix := strings.ToUpper(prefix[:1]) + prefix[1:]
+	for i := 1; i <= count; i++ {
+		if i > 1 {
+			b.WriteString(",")
+		}
+		content := strings.Repeat(fmt.Sprintf("%s conversation content %02d ", prefix, i), 24) + contentTail
+		b.WriteString(fmt.Sprintf(`{
+			"id":"%s-%d",
+			"unread":%t,
+			"updated_at":"2026-05-17T18:%02d:00Z",
+			"accounts":[
+				{
+					"id":"acct-%s-%d-a",
+					"username":"%s%da",
+					"acct":"%s%da@example.com",
+					"display_name":"%s %d A",
+					"url":"https://example.com/@%s%da",
+					"note":"%s %s"
+				},
+				{
+					"id":"acct-%s-%d-b",
+					"username":"%s%db",
+					"acct":"%s%db@example.com",
+					"display_name":"%s %d B",
+					"url":"https://example.com/@%s%db",
+					"note":"%s %s"
+				}
+			],
+			"last_status":{
+				"id":"post-%s-%d",
+				"url":"https://example.com/@%s%da/post-%s-%d",
+				"created_at":"2026-05-17T17:%02d:00Z",
+				"visibility":"direct",
+				"content":"%s"
+			},
+			"debugPayload":{"large":"%s %s"}
+		}`,
+			prefix, i,
+			i%2 == 1,
+			i,
+			prefix, i,
+			prefix, i,
+			prefix, i,
+			titlePrefix, i,
+			prefix, i,
+			accountNote, strings.Repeat("account note ", 80),
 			prefix, i,
 			prefix, i,
 			prefix, i,

--- a/internal/mcpserver/social_tools.go
+++ b/internal/mcpserver/social_tools.go
@@ -36,6 +36,8 @@ const (
 	notificationCommPreviewRunes      = 240
 	conversationReadDefaultLimit      = 20
 	conversationReadMaxLimit          = 80
+	conversationCompactMaxOutputBytes = 6000
+	conversationCompactPreviewRunes   = 16
 	socialCompactListPreviewRunes     = 48
 	timelineCompactMaxOutputBytes     = 6000
 	postSearchCompactMaxOutputBytes   = 8000
@@ -697,6 +699,14 @@ func handleFollowingList(ctx context.Context, args json.RawMessage) (*mcpruntime
 }
 
 func handleConversationsRead(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
+	readParams, err := parseSharedReadParams(args)
+	if err != nil {
+		return nil, invalidParams("invalid args: " + err.Error())
+	}
+	if err := validateConversationReadView(readParams.View); err != nil {
+		return nil, invalidParams(err.Error())
+	}
+
 	var in struct {
 		Limit      int  `json:"limit,omitempty"`
 		IncludeRaw bool `json:"include_raw,omitempty"`
@@ -722,7 +732,8 @@ func handleConversationsRead(ctx context.Context, args json.RawMessage) (*mcprun
 	if err != nil {
 		return authToolResultFromError(err)
 	}
-	conversations, err := socialConversationsFromAPI(out, in.IncludeRaw)
+	includeRaw := (in.IncludeRaw || readParams.View == readViewFull) && readParams.View != readViewCompact
+	conversations, err := socialConversationsFromAPI(out, includeRaw)
 	if err != nil {
 		return nil, err
 	}
@@ -730,9 +741,218 @@ func handleConversationsRead(ctx context.Context, args json.RawMessage) (*mcprun
 		"conversations": conversations,
 		"count":         len(conversations),
 		"limit":         limit,
-		"includeRaw":    in.IncludeRaw,
+		"includeRaw":    includeRaw,
+	}
+	if readParams.View == readViewCompact {
+		return socialCompactConversationsResult(payload, conversations, readParams)
 	}
 	return toolJSONResult(payload, nil)
+}
+
+func validateConversationReadView(view string) error {
+	switch strings.ToLower(strings.TrimSpace(view)) {
+	case "", readViewStandard, readViewFull, readViewCompact:
+		return nil
+	default:
+		return fmt.Errorf("invalid view (expected compact, standard, or full)")
+	}
+}
+
+func socialCompactConversationsResult(standardPayload map[string]any, conversations []any, params sharedReadParams) (*mcpruntime.ToolResult, error) {
+	previewRunes := conversationCompactPreviewRunes
+	if params.PreviewChars > 0 {
+		previewRunes = params.PreviewChars
+	}
+
+	refs := make([]any, 0, len(conversations))
+	for _, item := range conversations {
+		raw, ok := item.(map[string]any)
+		if !ok || raw == nil {
+			return nil, fmt.Errorf("unexpected conversation item")
+		}
+		ref := compactSocialConversationRef(raw, previewRunes)
+		if ref == nil {
+			continue
+		}
+		refs = append(refs, ref)
+	}
+
+	budget := socialCompactOutputBudget(params, conversationCompactMaxOutputBytes)
+	payload := map[string]any{
+		"view":          readViewCompact,
+		"count":         len(refs),
+		"limit":         standardPayload["limit"],
+		"conversations": refs,
+		"includeRaw":    false,
+		"omitted":       compactConversationListOmissions(),
+		"budget":        socialCompactBudgetMetadata(budget, previewRunes),
+	}
+	text := map[string]any{
+		"tool":  "conversations_read",
+		"view":  readViewCompact,
+		"count": len(refs),
+	}
+	return toolStructuredFirstResultWithBudget("conversations_read", fmt.Sprintf("%d compact conversations", len(refs)), payload, text, nil, false, budget)
+}
+
+func compactSocialConversationRef(raw map[string]any, previewRunes int) map[string]any {
+	if raw == nil {
+		return nil
+	}
+	if previewRunes <= 0 {
+		previewRunes = conversationCompactPreviewRunes
+	}
+
+	id := strings.TrimSpace(firstNonEmptyStringMap(raw, "id"))
+	ref := map[string]any{}
+	putIfNotEmpty(ref, "id", id)
+	if unread, ok := firstBoolMap(raw, "unread", "is_unread", "isUnread"); ok {
+		ref["unread"] = unread
+		ref["read"] = !unread
+	}
+	if read, ok := firstBoolMap(raw, "read", "is_read", "isRead"); ok {
+		ref["read"] = read
+		if _, hasUnread := ref["unread"]; !hasUnread {
+			ref["unread"] = !read
+		}
+	}
+	putIfNotEmpty(ref, "updatedAt", firstNonEmptyStringMap(raw, "updatedAt", "updated_at"))
+	if participants := compactConversationParticipantRefs(raw["participants"]); len(participants) > 0 {
+		ref["participantRefs"] = participants
+	}
+	if post := firstMap(raw, "lastPost", "last_status", "lastStatus"); post != nil {
+		if postRef := compactConversationLastPostRef(post, previewRunes); postRef != nil {
+			ref["lastPostRef"] = postRef
+		}
+	}
+	missing := missingSocialRefFields(map[string]string{
+		"id":              id,
+		"updatedAt":       firstNonEmptyStringMap(raw, "updatedAt", "updated_at"),
+		"participantRefs": stableConversationRefValue(ref["participantRefs"]),
+		"lastPostRef":     stableConversationRefValue(ref["lastPostRef"]),
+	})
+	if _, hasRead := ref["read"]; !hasRead {
+		missing = append(missing, "read")
+	}
+	if len(missing) > 0 {
+		ref["missingFields"] = missing
+	}
+	if len(ref) == 0 {
+		return nil
+	}
+	return ref
+}
+
+func compactConversationParticipantRefs(raw any) []any {
+	items, ok := raw.([]any)
+	if !ok {
+		return nil
+	}
+	refs := make([]any, 0, len(items))
+	for _, item := range items {
+		raw, ok := item.(map[string]any)
+		if !ok || raw == nil {
+			continue
+		}
+		if ref := compactConversationParticipantRef(raw); ref != nil {
+			refs = append(refs, ref)
+		}
+	}
+	return refs
+}
+
+func compactConversationParticipantRef(raw map[string]any) map[string]any {
+	if raw == nil {
+		return nil
+	}
+	id := firstNonEmptyStringMap(raw, "id")
+	acct := firstNonEmptyStringMap(raw, "acct")
+	ref := map[string]any{}
+	putIfNotEmpty(ref, "id", id)
+	putIfNotEmpty(ref, "acct", acct)
+	missing := missingSocialRefFields(map[string]string{
+		"id":   id,
+		"acct": acct,
+	})
+	if len(missing) > 0 {
+		ref["missingFields"] = missing
+	}
+	if len(ref) == 0 {
+		return nil
+	}
+	return ref
+}
+
+func compactConversationLastPostRef(raw map[string]any, previewRunes int) map[string]any {
+	if raw == nil {
+		return nil
+	}
+	if previewRunes <= 0 {
+		previewRunes = conversationCompactPreviewRunes
+	}
+	id := firstNonEmptyStringMap(raw, "id")
+	content := rawSocialStatusContent(raw)
+	preview, truncated := compactStringWithTruncation(content, previewRunes)
+	ref := map[string]any{}
+	putIfNotEmpty(ref, "id", id)
+	putIfNotEmpty(ref, "createdAt", firstNonEmptyStringMap(raw, "createdAt", "created_at"))
+	putIfNotEmpty(ref, "visibility", firstNonEmptyStringMap(raw, "visibility"))
+	putIfNotEmpty(ref, "contentPreview", preview)
+	ref["contentTruncated"] = truncated
+	if id != "" {
+		ref["expand"] = socialPostGetExpansion(id, readViewStandard, "structuredContent.data.status")
+	} else if content != "" {
+		ref["missingFields"] = []string{"id"}
+		ref["omitted"] = []map[string]any{{
+			"path":   "content",
+			"reason": "missing_post_id_for_expansion",
+		}}
+	}
+	if len(ref) == 1 {
+		return nil
+	}
+	return ref
+}
+
+func stableConversationRefValue(value any) string {
+	if value == nil {
+		return ""
+	}
+	switch typed := value.(type) {
+	case string:
+		return strings.TrimSpace(typed)
+	case []any:
+		if len(typed) == 0 {
+			return ""
+		}
+		return "present"
+	case map[string]any:
+		if len(typed) == 0 {
+			return ""
+		}
+		return "present"
+	default:
+		return "present"
+	}
+}
+
+func compactConversationListOmissions() []any {
+	return []any{
+		map[string]any{
+			"path":   "conversations[].participants",
+			"reason": "participant_ref_only",
+		},
+		map[string]any{
+			"path":      "conversations[].lastPost.content",
+			"reason":    "last_post_preview",
+			"expansion": "structuredContent.data.conversations[].lastPostRef.expand when lastPostRef.id is present",
+		},
+		map[string]any{
+			"path":      "conversations[]._raw",
+			"reason":    "debug_payload",
+			"expansion": "call conversations_read with view=full or include_raw=true",
+		},
+	}
 }
 
 func handleNotificationsRead(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
@@ -1524,12 +1744,15 @@ func notificationGetDef() mcpruntime.ToolDef {
 func conversationsReadDef() mcpruntime.ToolDef {
 	return mcpruntime.ToolDef{
 		Name:        "conversations_read",
-		Description: "Read compact, bounded direct message conversation summaries. Use include_raw only for audit/debug.",
+		Description: "Read direct message conversation summaries. Use compact for bounded refs and include_raw/full only for audit/debug.",
 		InputSchema: json.RawMessage(`{
 			"type":"object",
 			"properties":{
 				"limit":{"type":"integer","minimum":1,"maximum":80},
-				"include_raw":{"type":"boolean","description":"Include verbose upstream conversation payloads under _raw. Defaults to false."}
+				"include_raw":{"type":"boolean","description":"Include verbose upstream conversation payloads under _raw. Defaults to false."},
+				"view":{"type":"string","enum":["compact","standard","full"],"description":"Optional projection. Omitted/standard preserve the current normalized response; full includes upstream _raw payloads; compact returns bounded conversation refs without a single-conversation expansion tool."},
+				"preview_chars":{"type":"integer","minimum":0,"description":"Optional compact last-post preview character budget. Zero means the tool default."},
+				"max_output_bytes":{"type":"integer","minimum":0,"description":"Optional compact MCP response budget. Compact responses that exceed the budget return response_too_large instead of silently dropping fields."}
 			}
 		}`),
 	}


### PR DESCRIPTION
## Milestone
Project 33 P1.4 — compact `conversations_read` without unsupported `conversation_get` promise

Closes #233.

## Classification
MCP-contract / tool-surface / lesser-integration / test-coverage / docs

## Surfaces affected
- `conversations_read` input schema and opt-in compact response projection
- Existing Lesser REST API consumption: `GET /api/v1/conversations`
- MCP docs and social tool discovery/schema tests

## Specialist walks referenced
- Tool surface: modifies `conversations_read` behavior only through opt-in `view=compact`; no new tool is registered.
- MCP contract: additive optional parameters (`view`, `preview_chars`, `max_output_bytes`); omitted/default behavior remains compatible; compact uses explicit `response_too_large` when over budget.
- Lesser integration: consumes the existing conversations list route; no new Lesser conversation route is added.
- Host/AppTheory/SSM: no changes.

## Consumer impact
- Existing clients that omit `view` continue to receive the existing normalized conversation list response.
- `view=compact` clients receive bounded conversation summaries under `structuredContent.data.conversations[]` with `participantRefs`, `lastPostRef`, and list-level omissions.
- `view=full` and `include_raw=true` remain explicit audit/debug paths that include upstream `_raw` payloads.
- No `conversation_get` tool is advertised, registered, or emitted in expansion metadata.

## Tasks
- [x] Add opt-in compact `conversations_read` refs with a 6 KB default budget
- [x] Preserve default/standard normalized behavior and explicit full/raw debug behavior
- [x] Avoid fake `conversation_get` expansion metadata
- [x] Use `post_get` expansion only for last posts with stable post ids
- [x] Validate `preview_chars` / `max_output_bytes` and prove they are honored
- [x] Update MCP docs and regression coverage

## Validation
- `gofmt -l .` (empty)
- `git diff --check`
- `go test ./...`
- `go vet ./...`
- `bash scripts/build.sh`
- Targeted: `go test -count=1 -v ./internal/mcpapp -run 'TestM5_ToolsListContainsCoreTools|TestM5_ToolsProxyToLesserAPI|TestM5_ConversationsReadUsesCompactBoundedDefaults|TestM5_ConversationsReadCompactRefsNoConversationGet|TestReadToolOutputSchemasAdvertisedInToolsListAndDiscovery|TestDroneRuntimeCapability'`

## Payload evidence
- `conversations_read(limit=10, view=compact)`: 5,619-byte MCP JSON-RPC payload against the large conversation fixture (budget 6,000 bytes)
- `conversations_read(limit=10)` default normalized response: 20,969-byte MCP JSON-RPC payload against the same fixture
- `conversations_read(limit=10, view=full)`: explicit debug path preserves upstream `_raw` payloads, including fixture debug/account fields
- `conversations_read(limit=10, view=compact, preview_chars=8, max_output_bytes=6000)`: response budget metadata reports `contentPreviewRunes=8` and previews honor the 8-rune bound
- `conversations_read(limit=10, view=compact, max_output_bytes=1000)`: returns `response_too_large` with measured byte fields instead of silently dropping fields

## Compact examples / omissions
- Conversation refs include `id`, `read`/`unread`, `updatedAt`, `participantRefs[]` (`id`, `acct`), and `lastPostRef` (`id`, `createdAt`, `visibility`, bounded `contentPreview`, `contentTruncated`).
- `lastPostRef.expand` uses `post_get(id, view=standard)` when a stable post id exists.
- List-level omissions call out `participants` as `participant_ref_only`, `lastPost.content` as `last_post_preview`, and `_raw` as available only by explicit `view=full` / `include_raw=true`.
- Compact responses and tools/list output are tested not to contain `conversation_get`.

## Compatibility notes
- No default compact flip.
- No new `conversation_get` registration, discovery entry, or expansion metadata.
- No Lesser, Host, AppTheory, SSM, runtime rewrite, advisor hot-context/AGENTS.md slimming, or mailbox alias changes.
- Compact mode does not inline upstream raw conversation payloads.

## Stage rollout plan (handoff to deploy-body)
- [ ] Merged to main
- [ ] Deployed to lab / dev
- [ ] Lab soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
No sibling repo code changes required. Body uses the existing Lesser `GET /api/v1/conversations` list route and intentionally does not require a new single-conversation route.

## Blockers / risks
- Compact payload margin depends on intentionally lean participant refs; callers can lower previews or limits, or raise `max_output_bytes`, when responses exceed their budget.
- There is no per-conversation expansion route by design in this milestone; clients should use `view=full` / `include_raw=true` for explicit list-level audit/debug expansion.

## Advisor / Arch authorization
Proceeding under standing user authorization for Arch-assigned Project 33 milestones. Arch activated P1.4 via issue #233 comment `4472459249` and advisor email `delivery-baa3ffdd58b76d56` on 2026-05-17.