### PR TITLE
feat(mcp): add soul_read summary view

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -383,7 +383,7 @@ Scope key:
 | `sms_read` | Read | List inbound SMS metadata/previews from lesser-host's canonical mailbox. |
 | `voicemail_read` | Read | List inbound voice/voicemail metadata/previews from lesser-host's canonical mailbox. |
 | `identity_whoami` | Read | Return the current soul agent identity, channels, and contact preferences. |
-| `soul_read` | Read | Read a public soul identity bundle and, with explicit self-scope opt-in, bounded private mint-conversation data through Lesser. |
+| `soul_read` | Read | Read a public soul identity bundle with opt-in summary/standard/full views and, with explicit self-scope opt-in, bounded private mint-conversation data through Lesser. |
 | `identity_lookup` | Read | Resolve a public soul identity by full agent ID, ENS name, a current-instance local ID such as `medic`, an explicit remote ActivityPub handle such as `@steward@remote.example`, or a canonical actor URL such as `https://remote.example/users/steward`; returns public identity summary only. |
 | `identity_verify` | Read | Verify that a recent communication matches a resolved soul identity using public ENS resolution plus authoritative message provenance. Private email/phone verification fails closed unless Host supplies authoritative sender-identifier provenance. |
 
@@ -474,6 +474,17 @@ Notes:
   returns `response_too_large` with measured byte details rather than silently dropping fields. `preview_chars` bounds
   compact last-post previews. `include_raw=true` and `view=full` remain explicit audit/debug paths that include
   upstream `_raw` conversation payloads; compact mode does not inline upstream raw payloads.
+- `soul_read` advertises `view=summary|standard|full`. Omitted/default and `view=standard` preserve the existing public
+  soul bundle shape. `view=summary` is opt-in and returns bounded agent-facing essentials under
+  `structuredContent.data.souls[]`: stable identity/lifecycle fields, public capability names (not full capability
+  bodies), public channel availability markers, provenance/source markers, omission metadata, and deterministic
+  `soul_read(..., view=standard|full)` expansion refs. `soul_read(self=true, view=summary)` targets an 8 KB MCP
+  JSON-RPC payload budget; if a summary still exceeds that budget, body returns `response_too_large` with measured byte
+  details instead of silently dropping fields. Summary mode never inlines sanitized `_raw`, full
+  registration/capability/boundary/transparency payloads, private mint-conversation bodies, or private reachability data.
+  Private mint-conversation expansion remains explicit and is rejected for `view=summary`; use `view=standard` or
+  `view=full` with explicit `include_private` when private self expansion is required. `view=full` is an explicit
+  audit/debug view equivalent to requesting sanitized public raw payloads.
 - `skills_catalog` and `skill_bundle_get` are read-only Project 21 M4 skills tools backed by Lesser's authoritative
   skill publication contract. `skills_catalog` calls `GET /api/v1/skills/catalog`; `skill_bundle_get` calls
   `GET /api/v1/skills/{skillId}/revisions/{revisionNumber}/bundle` and accepts either `skill_id` + `revision_number`
@@ -540,12 +551,14 @@ Notes:
 - `soul_read` is the Project 21 public soul read-model tool. It accepts either `self=true` (the caller's
   OAuth-bound soul), or one of `agentId`, `ensName`, or `query` (full soul agent ID, ENS name, current-instance local
   ID, explicit `@user@domain` ActivityPub handle, or canonical actor URL), plus optional `limit` for search-backed
-  matches and `include_raw=true` for audit/debug. Raw audit payloads are sanitized before being returned; private
-  reachability fields such as email/phone channels and contact preferences are redacted even when `include_raw=true`.
-  `self=true` conflicts with `agentId`, `ensName`, and `query`.
+  matches, `view=summary|standard|full`, and `include_raw=true` for audit/debug. Omitted `view` and `view=standard`
+  preserve the existing public bundle shape; `view=summary` is the bounded agent-context shape; `view=full` includes
+  sanitized public raw payloads for audit/debug. Raw audit payloads are sanitized before being returned; private
+  reachability fields such as email/phone channels and contact preferences are redacted even when `include_raw=true` or
+  `view=full`. `self=true` conflicts with `agentId`, `ensName`, and `query`.
   Bare current-instance local IDs require trustworthy current-instance domain context; use a full soul `agentId`,
   ENS name, explicit handle, canonical actor URL, or `self=true` when that context is unavailable. The default response
-  is compact and returns `access` metadata plus `souls[]`, each with stable MCP blocks: `identity`, `registration`,
+  returns `access` metadata plus `souls[]`, each with stable MCP blocks: `identity`, `registration`,
   `capabilities`, `boundaries`, `transparency`, `channels`, `avatar`, `sources`, `sourceEndpoints`, and `deferred`.
 - `soul_read` composes from the most-specific public source available. When dedicated public `capabilities`,
   `boundaries`, or `transparency` endpoints are unavailable, it falls back to the same blocks in public registration

--- a/internal/mcpapp/comm_contract_test.go
+++ b/internal/mcpapp/comm_contract_test.go
@@ -178,6 +178,11 @@ func TestLBM0_CommunicationToolSchemasMatchSpec(t *testing.T) {
 		expectPropType(t, s, "mintConversationLimit", "integer")
 		expectPropType(t, s, "limit", "integer")
 		expectPropType(t, s, "include_raw", "boolean")
+		view := expectPropType(t, s, "view", "string")
+		enum, _ := view["enum"].([]any)
+		if !reflect.DeepEqual(enum, []any{"summary", "standard", "full"}) {
+			t.Fatalf("soul_read view enum = %+v", view)
+		}
 	}
 
 	{

--- a/internal/mcpapp/identity_surfaces_test.go
+++ b/internal/mcpapp/identity_surfaces_test.go
@@ -1786,6 +1786,239 @@ func TestLBM1_SoulReadSelfModeVerifiesBoundCaller(t *testing.T) {
 	}
 }
 
+func TestP21_SoulReadSummaryStandardFullViews(t *testing.T) {
+	t.Setenv("MCP_SESSION_TABLE", "")
+	t.Setenv("JWT_SECRET", "test")
+	auth.ResetForTests()
+	lesserapi.ResetForTests()
+	soulapi.ResetForTests()
+	t.Cleanup(lesserapi.ResetForTests)
+	t.Cleanup(soulapi.ResetForTests)
+
+	const agentID = "0xfafafafafafafafafafafafafafafafafafafafafafafafafafafafafafafafa"
+	const privateEmail = "summary-private@example.test"
+	const privatePhone = "+15550199999"
+	const capabilityConstraint = "SUMMARY_CAPABILITY_CONSTRAINT_SHOULD_NOT_APPEAR"
+	const boundaryStatement = "SUMMARY_BOUNDARY_STATEMENT_SHOULD_NOT_APPEAR"
+	const transparencyPayload = "SUMMARY_TRANSPARENCY_PAYLOAD_SHOULD_NOT_APPEAR"
+	const selfDescription = "SUMMARY_SELF_DESCRIPTION_SHOULD_NOT_APPEAR"
+	installSoulBindingLookup(t, "agent1", agentID)
+
+	var privatePathCalled string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/souls/bound/me":
+			_, _ = w.Write([]byte(boundSelfResponse(agentID, "agent1", "test.example.com", "agent-summary")))
+		case "/api/v1/souls/bound/me/mint-conversations":
+			privatePathCalled = r.URL.Path
+			_, _ = w.Write([]byte(`{"conversations":[{"conversation_id":"mint-1","messages":"PRIVATE_MINT_BODY_SHOULD_NOT_APPEAR"}]}`))
+		case "/api/v1/soul/agents/" + agentID:
+			_, _ = w.Write([]byte(`{
+				"agent":{
+					"agent_id":"` + agentID + `",
+					"domain":"test.example.com",
+					"local_id":"agent-summary",
+					"ens_name":"agent-summary.lessersoul.eth",
+					"wallet":"0xabc",
+					"token_id":"42",
+					"status":"active",
+					"lifecycle_status":"active",
+					"lifecycle_reason":"operational",
+					"email":"` + privateEmail + `",
+					"phone":"` + privatePhone + `",
+					"updated_at":"2026-05-17T20:00:00Z"
+				}
+			}`))
+		case "/api/v1/soul/agents/" + agentID + "/registration":
+			_, _ = w.Write([]byte(`{
+				"version":"7",
+				"selfDescription":"` + selfDescription + ` ` + strings.Repeat("self description ", 120) + `",
+				"channels":{"ens":{"name":"agent-summary.lessersoul.eth"},"email":{"address":"` + privateEmail + `"},"phone":{"number":"` + privatePhone + `"}},
+				"avatar":{"current_style_id":"friendly","image":"https://example.com/avatar.png"},
+				"capabilities":[{"name":"social.post","constraints":"` + capabilityConstraint + `"},{"name":"memory.query","constraints":"` + capabilityConstraint + `"}]
+			}`))
+		case "/api/v1/soul/agents/" + agentID + "/capabilities":
+			_, _ = w.Write([]byte(`{"capabilities":[
+				{"name":"social.post","scope":"write","constraints":"` + capabilityConstraint + `","validation_ref":"cap-ref-1"},
+				{"name":"memory.query","scope":"read","constraints":"` + capabilityConstraint + `","validation_ref":"cap-ref-2"}
+			]}`))
+		case "/api/v1/soul/agents/" + agentID + "/boundaries":
+			_, _ = w.Write([]byte(`{"boundaries":[{"id":"b1","statement":"` + boundaryStatement + `","category":"safety","issued_at":"2026-05-17T20:00:00Z"}]}`))
+		case "/api/v1/soul/agents/" + agentID + "/transparency":
+			_, _ = w.Write([]byte(`{"transparency":{"audit":"` + transparencyPayload + `","source":"public"}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":{"message":"not found"}}`))
+		}
+	}))
+	defer server.Close()
+
+	t.Setenv("LESSER_API_BASE_URL", server.URL)
+	t.Setenv("LESSER_SOUL_API_BASE_URL", server.URL)
+	lesserapi.ResetForTests()
+	soulapi.ResetForTests()
+
+	app, err := mcpapp.New("test", "dev")
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+	env := testkit.New()
+	token := newTestToken(t, "test", "agent1", []string{"read"})
+	authHeader := "Bearer " + token
+
+	initResp := invokeJSON(t, env, app, map[string][]string{
+		"authorization": {authHeader},
+	}, &mcpruntime.Request{JSONRPC: "2.0", ID: 1, Method: "initialize"})
+	if initResp.Status != 200 {
+		t.Fatalf("initialize: status=%d body=%s", initResp.Status, string(initResp.Body))
+	}
+	sessionID := initResp.Headers["mcp-session-id"][0]
+
+	call := func(id int, args map[string]any) (mcpruntime.ToolResult, []byte) {
+		t.Helper()
+		callParams, _ := json.Marshal(map[string]any{"name": "soul_read", "arguments": args})
+		resp := invokeJSON(t, env, app, map[string][]string{
+			"authorization":  {authHeader},
+			"mcp-session-id": {sessionID},
+		}, &mcpruntime.Request{JSONRPC: "2.0", ID: id, Method: "tools/call", Params: callParams})
+		if resp.Status != 200 {
+			t.Fatalf("soul_read: status=%d body=%s", resp.Status, string(resp.Body))
+		}
+		var rpc mcpruntime.Response
+		if err := json.Unmarshal(resp.Body, &rpc); err != nil {
+			t.Fatalf("unmarshal soul_read response: %v", err)
+		}
+		if rpc.Error != nil {
+			t.Fatalf("soul_read rpc error: %+v", rpc.Error)
+		}
+		var out mcpruntime.ToolResult
+		b, _ := json.Marshal(rpc.Result)
+		_ = json.Unmarshal(b, &out)
+		return out, resp.Body
+	}
+
+	defaultOut, defaultBody := call(2, map[string]any{"self": true})
+	defaultData, _ := defaultOut.StructuredContent["data"].(map[string]any)
+	defaultSouls, _ := defaultData["souls"].([]any)
+	defaultSoul, _ := defaultSouls[0].(map[string]any)
+	if _, ok := defaultData["view"]; ok {
+		t.Fatalf("omitted/default soul_read should preserve existing top-level shape, got %+v", defaultData)
+	}
+	defaultCapabilities, _ := defaultSoul["capabilities"].([]any)
+	if len(defaultCapabilities) != 2 || defaultCapabilities[0].(map[string]any)["constraints"] != capabilityConstraint {
+		t.Fatalf("default soul_read should preserve full normalized capability bodies, got %+v", defaultCapabilities)
+	}
+
+	standardOut, standardBody := call(3, map[string]any{"self": true, "view": "standard"})
+	standardData, _ := standardOut.StructuredContent["data"].(map[string]any)
+	standardSouls, _ := standardData["souls"].([]any)
+	standardSoul, _ := standardSouls[0].(map[string]any)
+	if _, ok := standardSoul["private"]; ok {
+		t.Fatalf("standard self read without include_private should not include private blocks: %+v", standardSoul)
+	}
+	standardCapabilities, _ := standardSoul["capabilities"].([]any)
+	if len(standardCapabilities) != 2 || standardCapabilities[0].(map[string]any)["constraints"] != capabilityConstraint {
+		t.Fatalf("view=standard should preserve existing capability bodies, got %+v", standardCapabilities)
+	}
+
+	summaryOut, summaryBody := call(4, map[string]any{"self": true, "view": "summary"})
+	if summaryOut.IsError {
+		t.Fatalf("summary returned tool error: %+v", summaryOut.StructuredContent)
+	}
+	assertMCPPayloadBudget(t, "soul_read self summary large fixture", len(summaryBody), 8000)
+	for _, forbidden := range []string{capabilityConstraint, boundaryStatement, transparencyPayload, selfDescription, privateEmail, privatePhone, "PRIVATE_MINT_BODY_SHOULD_NOT_APPEAR", "\"_raw\"", "\"private\""} {
+		if strings.Contains(string(summaryBody), forbidden) {
+			t.Fatalf("summary leaked forbidden payload %q: %s", forbidden, string(summaryBody))
+		}
+	}
+	summaryData, _ := summaryOut.StructuredContent["data"].(map[string]any)
+	if summaryData["view"] != "summary" || summaryData["count"] != float64(1) {
+		t.Fatalf("unexpected summary metadata: %+v", summaryData)
+	}
+	summarySouls, _ := summaryData["souls"].([]any)
+	summarySoul, _ := summarySouls[0].(map[string]any)
+	identity, _ := summarySoul["identity"].(map[string]any)
+	if identity["agentId"] != agentID || identity["localId"] != "agent-summary" || identity["ensName"] != "agent-summary.lessersoul.eth" {
+		t.Fatalf("unexpected summary identity: %+v", identity)
+	}
+	caps, _ := summarySoul["capabilities"].(map[string]any)
+	names, _ := caps["names"].([]any)
+	if !reflect.DeepEqual(names, []any{"social.post", "memory.query"}) {
+		t.Fatalf("summary should expose capability names only, got %+v", caps)
+	}
+	channels, _ := summarySoul["channels"].(map[string]any)
+	email, _ := channels["email"].(map[string]any)
+	if email["status"] != "unavailable" || email["reason"] != "deferred_private_reachability" {
+		t.Fatalf("summary should preserve public channel availability without reachability data, got %+v", channels)
+	}
+	provenance, _ := summarySoul["provenance"].(map[string]any)
+	if provenance["registrationVersion"] != "7" {
+		t.Fatalf("expected summary provenance markers, got %+v", provenance)
+	}
+	expand, _ := summarySoul["expand"].(map[string]any)
+	standardExpand, _ := expand["standard"].(map[string]any)
+	standardArgs, _ := standardExpand["arguments"].(map[string]any)
+	fullExpand, _ := expand["full"].(map[string]any)
+	fullArgs, _ := fullExpand["arguments"].(map[string]any)
+	if standardExpand["tool"] != "soul_read" || standardArgs["self"] != true || standardArgs["view"] != "standard" {
+		t.Fatalf("unexpected standard expansion: %+v", standardExpand)
+	}
+	if fullExpand["tool"] != "soul_read" || fullArgs["self"] != true || fullArgs["view"] != "full" {
+		t.Fatalf("unexpected full expansion: %+v", fullExpand)
+	}
+	var summaryText map[string]any
+	if err := json.Unmarshal([]byte(summaryOut.Content[0].Text), &summaryText); err != nil {
+		t.Fatalf("unmarshal summary text: %v", err)
+	}
+	if _, ok := summaryText["souls"]; ok {
+		t.Fatalf("summary text should use structured-first locator, got %+v", summaryText)
+	}
+	if locator, _ := summaryText["data"].(map[string]any); locator["location"] != "structuredContent.data" {
+		t.Fatalf("expected structured data locator in summary text, got %+v", summaryText)
+	}
+
+	fullOut, fullBody := call(5, map[string]any{"self": true, "view": "full"})
+	fullData, _ := fullOut.StructuredContent["data"].(map[string]any)
+	fullSouls, _ := fullData["souls"].([]any)
+	fullSoul, _ := fullSouls[0].(map[string]any)
+	if _, ok := fullSoul["_raw"].(map[string]any); !ok {
+		t.Fatalf("view=full should expose sanitized _raw public payloads, got %+v", fullSoul)
+	}
+	if !strings.Contains(string(fullBody), capabilityConstraint) || !strings.Contains(string(fullBody), boundaryStatement) || !strings.Contains(string(fullBody), transparencyPayload) {
+		t.Fatalf("view=full should preserve full public debug payloads")
+	}
+	if strings.Contains(string(fullBody), privateEmail) || strings.Contains(string(fullBody), privatePhone) {
+		t.Fatalf("view=full leaked private reachability data: %s", string(fullBody))
+	}
+	if len(summaryBody) >= len(defaultBody) {
+		t.Fatalf("expected summary payload to be smaller than default: summary=%d default=%d", len(summaryBody), len(defaultBody))
+	}
+
+	privateSummary, privateSummaryBody := call(6, map[string]any{"self": true, "view": "summary", "include_private": []string{"mintConversations"}})
+	if !privateSummary.IsError {
+		t.Fatalf("summary with include_private should fail explicitly")
+	}
+	errPayload, _ := privateSummary.StructuredContent["error"].(map[string]any)
+	if errPayload["code"] != "invalid_request" || errPayload["status"] != float64(400) {
+		t.Fatalf("unexpected summary private error: %+v", errPayload)
+	}
+	if privatePathCalled != "" {
+		t.Fatalf("summary private rejection should not call private endpoint, got %q", privatePathCalled)
+	}
+
+	invalidString, _ := call(7, map[string]any{"self": true, "view": "tiny"})
+	if !invalidString.IsError {
+		t.Fatalf("invalid view string should be a tool error")
+	}
+	invalidNumber, _ := call(8, map[string]any{"self": true, "view": 17})
+	if !invalidNumber.IsError {
+		t.Fatalf("non-string view should be a tool error")
+	}
+	t.Logf("soul_read payload bytes default=%d standard=%d summary=%d full=%d private_summary_error=%d",
+		len(defaultBody), len(standardBody), len(summaryBody), len(fullBody), len(privateSummaryBody))
+}
+
 func TestLBM1_SoulReadComposesRegistrationFallbackBlocks(t *testing.T) {
 	t.Setenv("MCP_SESSION_TABLE", "")
 	t.Setenv("JWT_SECRET", "test")

--- a/internal/mcpserver/comm_tools.go
+++ b/internal/mcpserver/comm_tools.go
@@ -337,7 +337,8 @@ func soulReadDef() mcpruntime.ToolDef {
 				"mintConversationId":{"type":"string","maxLength":128,"description":"Opaque mint-conversation ID for an explicit single-conversation private self read. Requires include_private=[\"mintConversations\"]."},
 				"mintConversationLimit":{"type":"integer","minimum":1,"maximum":50,"description":"Maximum compact mint-conversation summaries for private self list reads. Defaults to 20 and does not affect public search match limit."},
 				"limit":{"type":"integer","minimum":1,"maximum":3,"description":"Maximum matches to compose when query resolves through search. Defaults to 1."},
-				"include_raw":{"type":"boolean","description":"Include sanitized raw public Host/Soul endpoint payloads under _raw for audit/debug use. Private reachability fields are redacted. Defaults to false."}
+				"include_raw":{"type":"boolean","description":"Include sanitized raw public Host/Soul endpoint payloads under _raw for audit/debug use. Private reachability fields are redacted. Defaults to false."},
+				"view":{"type":"string","enum":["summary","standard","full"],"description":"Optional projection. Omitted/standard preserve today's public soul_read bundle; summary returns bounded agent-facing essentials with expansion metadata; full includes sanitized _raw public endpoint payloads."}
 			}
 		}`),
 	}

--- a/internal/mcpserver/soul_read_tools.go
+++ b/internal/mcpserver/soul_read_tools.go
@@ -24,6 +24,7 @@ const (
 	soulReadPrivateDefaultConversationLimit = 20
 	soulReadPrivateMaxConversationLimit     = 50
 	soulReadPrivateConversationIDMaxLen     = 128
+	soulReadSummaryMaxOutputBytes           = 8000
 	// Keep Body's private single-read MCP response below AppTheory's stream
 	// event limit so callers receive a stable tool error before the MCP stream
 	// store is asked to persist an undeliverable event.
@@ -43,6 +44,7 @@ type soulReadInput struct {
 	MintConversationID    string   `json:"mintConversationId,omitempty"`
 	MintConversationLimit int      `json:"mintConversationLimit,omitempty"`
 	IncludeRaw            bool     `json:"include_raw,omitempty"`
+	View                  string   `json:"view,omitempty"`
 }
 
 type soulReadPrivateRequest struct {
@@ -55,6 +57,15 @@ func handleSoulRead(ctx context.Context, args json.RawMessage) (*mcpruntime.Tool
 	var in soulReadInput
 	if err := json.Unmarshal(args, &in); err != nil {
 		return toolErrorResult("invalid_request", "invalid args: "+err.Error(), 400, nil)
+	}
+	view := strings.ToLower(strings.TrimSpace(in.View))
+	if view == "" {
+		view = readViewStandard
+	}
+	switch view {
+	case readViewSummary, readViewStandard, readViewFull:
+	default:
+		return toolErrorResult("invalid_request", "invalid view (expected summary, standard, or full)", 400, map[string]any{"view": in.View})
 	}
 
 	agentIDInput := strings.TrimSpace(in.AgentID)
@@ -72,6 +83,12 @@ func handleSoulRead(ctx context.Context, args json.RawMessage) (*mcpruntime.Tool
 	privateReq, err := soulReadPrivateRequestFromInput(in)
 	if err != nil {
 		return identityToolResultFromError(err)
+	}
+	if view == readViewSummary && privateReq.IncludeMintConversations {
+		return toolErrorResult("invalid_request", "view=summary cannot include private blocks; use view=standard or view=full for explicit private expansion", 400, map[string]any{
+			"view":           view,
+			"includePrivate": in.IncludePrivate,
+		})
 	}
 	if ensNameInput != "" && !looksLikeENSName(ensNameInput) {
 		return toolErrorResult("invalid_request", "ensName must be a public ENS name", 400, map[string]any{"query": ensNameInput})
@@ -123,7 +140,8 @@ func handleSoulRead(ctx context.Context, args json.RawMessage) (*mcpruntime.Tool
 
 	souls := make([]any, 0, len(agentIDs))
 	for _, agentID := range agentIDs {
-		soul, err := soulReadPayload(ctx, client, agentID, in.IncludeRaw, privateReq)
+		includeRaw := (in.IncludeRaw || view == readViewFull) && view != readViewSummary
+		soul, err := soulReadPayload(ctx, client, agentID, includeRaw, privateReq)
 		if err != nil {
 			return identityToolResultFromError(err)
 		}
@@ -136,7 +154,229 @@ func handleSoulRead(ctx context.Context, args json.RawMessage) (*mcpruntime.Tool
 		"access": soulReadAccess(accessMode, privateReq.privateBlocks()),
 		"souls":  souls,
 	}
+	if view == readViewSummary {
+		return soulReadSummaryToolResult(soulReadSummaryPayload(payload, in, accessMode))
+	}
 	return soulReadToolResult(payload, privateReq)
+}
+
+func soulReadSummaryPayload(standardPayload map[string]any, in soulReadInput, accessMode string) map[string]any {
+	soulsRaw, _ := standardPayload["souls"].([]any)
+	summaries := make([]any, 0, len(soulsRaw))
+	for _, item := range soulsRaw {
+		soul, _ := item.(map[string]any)
+		if soul == nil {
+			continue
+		}
+		summaries = append(summaries, soulReadSummarySoul(soul, in, accessMode))
+	}
+	out := map[string]any{
+		"view":    readViewSummary,
+		"query":   standardPayload["query"],
+		"count":   len(summaries),
+		"access":  standardPayload["access"],
+		"souls":   summaries,
+		"omitted": soulReadSummaryOmissions(),
+		"budget": map[string]any{
+			"maxOutputBytes": soulReadSummaryMaxOutputBytes,
+			"enforcement":    "response_too_large",
+		},
+	}
+	return out
+}
+
+func soulReadSummarySoul(soul map[string]any, in soulReadInput, accessMode string) map[string]any {
+	identity, _ := soul["identity"].(map[string]any)
+	registration, _ := soul["registration"].(map[string]any)
+	channels, _ := soul["channels"].(map[string]any)
+	agentID := firstNonEmptyStringMap(identity, "agentId")
+
+	out := map[string]any{}
+	putIfNotEmpty(out, "agentId", agentID)
+	if id := soulReadSummaryIdentity(identity); len(id) > 0 {
+		out["identity"] = id
+	}
+	if lifecycle := soulReadSummaryLifecycle(identity); len(lifecycle) > 0 {
+		out["lifecycle"] = lifecycle
+	}
+	if capabilityNames := soulReadSummaryCapabilityNames(soul["capabilities"]); len(capabilityNames) > 0 {
+		out["capabilities"] = map[string]any{
+			"names": capabilityNames,
+			"count": len(capabilityNames),
+		}
+	}
+	if channelSummary := soulReadSummaryChannels(channels); len(channelSummary) > 0 {
+		out["channels"] = channelSummary
+	}
+	if provenance := soulReadSummaryProvenance(soul, registration); len(provenance) > 0 {
+		out["provenance"] = provenance
+	}
+	out["expand"] = soulReadSummaryExpansion(agentID, in, accessMode)
+	missing := missingSocialRefFields(map[string]string{
+		"agentId": agentID,
+	})
+	if len(missing) > 0 {
+		out["missingFields"] = missing
+	}
+	return out
+}
+
+func soulReadSummaryIdentity(identity map[string]any) map[string]any {
+	out := map[string]any{}
+	for _, key := range []string{"agentId", "domain", "localId", "ensName", "wallet", "tokenId", "status", "lifecycleStatus"} {
+		putFirstAny(out, key, identity, key)
+	}
+	return out
+}
+
+func soulReadSummaryLifecycle(identity map[string]any) map[string]any {
+	out := map[string]any{}
+	putFirstAny(out, "status", identity, "lifecycleStatus", "status")
+	putFirstAny(out, "reason", identity, "lifecycleReason")
+	putFirstAny(out, "updatedAt", identity, "updatedAt")
+	putFirstAny(out, "mintedAt", identity, "mintedAt")
+	return out
+}
+
+func soulReadSummaryCapabilityNames(raw any) []any {
+	items, _ := raw.([]any)
+	names := make([]any, 0, len(items))
+	seen := map[string]struct{}{}
+	for _, item := range items {
+		name := ""
+		switch typed := item.(type) {
+		case string:
+			name = typed
+		case map[string]any:
+			name = firstNonEmptyStringMap(typed, "name")
+		}
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		names = append(names, name)
+	}
+	return names
+}
+
+func soulReadSummaryChannels(channels map[string]any) map[string]any {
+	out := map[string]any{}
+	for _, key := range []string{"ens", "email", "phone"} {
+		channel, _ := channels[key].(map[string]any)
+		if channel == nil {
+			continue
+		}
+		summary := map[string]any{}
+		putFirstAny(summary, "status", channel, "status")
+		putFirstAny(summary, "reason", channel, "reason")
+		putFirstAny(summary, "name", channel, "name")
+		if len(summary) > 0 {
+			out[key] = summary
+		}
+	}
+	return out
+}
+
+func soulReadSummaryProvenance(soul map[string]any, registration map[string]any) map[string]any {
+	out := map[string]any{}
+	putFirstAny(out, "registrationVersion", registration, "version")
+	if sources, ok := soul["sources"].([]any); ok {
+		summary := make([]any, 0, len(sources))
+		for _, item := range sources {
+			source, _ := item.(map[string]any)
+			if source == nil {
+				continue
+			}
+			entry := map[string]any{}
+			putFirstAny(entry, "block", source, "block")
+			putFirstAny(entry, "status", source, "status")
+			putFirstAny(entry, "reason", source, "reason")
+			if len(entry) > 0 {
+				summary = append(summary, entry)
+			}
+		}
+		if len(summary) > 0 {
+			out["sources"] = summary
+		}
+	}
+	if deferred, ok := soul["deferred"].([]any); ok && len(deferred) > 0 {
+		out["deferredCount"] = len(deferred)
+	}
+	return out
+}
+
+func soulReadSummaryExpansion(agentID string, in soulReadInput, accessMode string) map[string]any {
+	return map[string]any{
+		"standard": soulReadExpansionRef(agentID, readViewStandard, in, accessMode),
+		"full":     soulReadExpansionRef(agentID, readViewFull, in, accessMode),
+	}
+}
+
+func soulReadExpansionRef(agentID string, view string, in soulReadInput, accessMode string) *SocialExpansionRef {
+	args := map[string]any{"view": view}
+	if strings.EqualFold(accessMode, "self") && in.Self {
+		args["self"] = true
+	} else if strings.TrimSpace(agentID) != "" {
+		args["agentId"] = strings.TrimSpace(agentID)
+	} else {
+		if query := strings.TrimSpace(firstNonEmpty(in.AgentID, in.ENSName, in.Query)); query != "" {
+			args["query"] = query
+		}
+	}
+	if in.IncludeRaw && view == readViewFull {
+		args["include_raw"] = true
+	}
+	return &SocialExpansionRef{
+		Tool:       "soul_read",
+		Arguments:  args,
+		ResultPath: "structuredContent.data",
+	}
+}
+
+func soulReadSummaryOmissions() []any {
+	return []any{
+		map[string]any{"path": "souls[].registration", "reason": "summary_identity_only", "expansion": "souls[].expand.standard"},
+		map[string]any{"path": "souls[].capabilities[].body", "reason": "capability_names_only", "expansion": "souls[].expand.standard"},
+		map[string]any{"path": "souls[].boundaries", "reason": "summary_omits_full_boundaries", "expansion": "souls[].expand.standard"},
+		map[string]any{"path": "souls[].transparency", "reason": "summary_omits_full_transparency", "expansion": "souls[].expand.standard"},
+		map[string]any{"path": "souls[]._raw", "reason": "debug_payload", "expansion": "souls[].expand.full"},
+		map[string]any{"path": "souls[].private", "reason": "private_blocks_not_in_summary", "expansion": "call soul_read with view=standard or view=full and explicit include_private"},
+	}
+}
+
+func soulReadSummaryToolResult(payload map[string]any) (*mcpruntime.ToolResult, error) {
+	result, err := toolStructuredFirstResult(structuredFirstResultOptions{
+		Summary: fmt.Sprintf("%d soul summaries", len(firstArrayFromAny(payload, "souls"))),
+		Data:    payload,
+		Text: map[string]any{
+			"tool":  "soul_read",
+			"view":  readViewSummary,
+			"count": payload["count"],
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	measurement, err := measureToolResultPayload(result)
+	if err != nil {
+		return nil, err
+	}
+	if measurement.JSONRPCEnvelopeBytes <= soulReadSummaryMaxOutputBytes {
+		return result, nil
+	}
+	return toolErrorResult("response_too_large", "soul_read summary response exceeds max_output_bytes", http.StatusRequestEntityTooLarge, map[string]any{
+		"tool":             "soul_read",
+		"view":             readViewSummary,
+		"measuredBytes":    measurement.JSONRPCEnvelopeBytes,
+		"maxOutputBytes":   soulReadSummaryMaxOutputBytes,
+		"contentTextBytes": measurement.ContentTextBytes,
+		"structuredBytes":  measurement.StructuredContentBytes,
+		"guidance":         "use view=standard or view=full for explicit expansion, or narrow the query",
+	})
 }
 
 func soulReadToolResult(payload map[string]any, privateReq soulReadPrivateRequest) (*mcpruntime.ToolResult, error) {


### PR DESCRIPTION
## Milestone
Project 33 P2.1 / #234 — add `soul_read` summary/standard/full views for MCP agent-context slimming.

Closes #234

## Classification
MCP-contract / tool-surface / identity read-tool shaping / test-coverage / docs

## Surfaces affected
- `soul_read` input schema now advertises `view=summary|standard|full`.
- `soul_read` JSON-RPC success output gains an opt-in `summary` projection; omitted/default and `view=standard` remain compatible with the existing public bundle.
- `view=full` explicitly enables sanitized public `_raw` audit/debug payloads.
- `docs/mcp.md` documents the new view semantics and summary budget.

## Specialist walks referenced
- Tool surface: additive read-scope `soul_read` schema/behavior refinement; no scope/profile loosening; static registration preserved.
- MCP contract: additive optional parameter plus opt-in response projection; default/omitted behavior remains compatible for existing clients.
- Lesser integration: existing Lesser/Soul read routes only; no public unauth endpoint behavior, SSM, Host, AppTheory, or runtime rewrite.
- Host delegation: not touched.
- Framework: idiomatic AppTheory MCP tool result helpers; no local framework patch.

## Consumer impact
- Existing MCP clients: no change when omitting `view`; `view=standard` mirrors today's public bundle.
- New/updated clients: can request `view=summary` for bounded agent-facing identity context, then expand deterministically through `soul_read(..., view=standard)` or `soul_read(..., view=full)`.
- Operators/sibling repos: no deployment contract or sibling-repo change required.

## Tasks
- [x] Advertise `soul_read.view` enum in discovery schema.
- [x] Preserve omitted/default and `view=standard` public bundle compatibility.
- [x] Add bounded `view=summary` with stable identity/lifecycle, capability names, channel availability, provenance/source markers, omissions, and expansion refs.
- [x] Keep private mint-conversation expansion explicit and fail closed for summary mode.
- [x] Keep `view=full` / `include_raw=true` explicit audit/debug with existing private reachability redaction.
- [x] Cover invalid string and non-string `view` inputs.
- [x] Update MCP documentation and payload-size evidence.

## Validation
- `gofmt -l .` (empty)
- `git diff --check`
- `go test ./...`
- `go vet ./...`
- `bash scripts/build.sh`
- Targeted: `go test -count=1 -v ./internal/mcpapp -run 'TestLBM0_CommunicationToolSchemasMatchSpec|TestP21_SoulReadSummaryStandardFullViews|TestLBM1_SoulReadSelfModeVerifiesBoundCaller|TestM2_SoulReadIncludeRawRedactsPrivateReachability'`
- Targeted: `go test -count=1 -v ./internal/mcpserver -run 'TestSoulRead'`

## Payload-size evidence
From `TestP21_SoulReadSummaryStandardFullViews` with a large public soul fixture:
- default/omitted: `11285` JSON-RPC bytes
- `view=standard`: `11285` JSON-RPC bytes
- `view=summary`: `2207` JSON-RPC bytes under the 8000-byte summary budget
- `view=full`: `18587` JSON-RPC bytes with explicit sanitized public `_raw`
- `view=summary` + `include_private=["mintConversations"]`: explicit `invalid_request` tool error, `589` JSON-RPC bytes, and no private Lesser endpoint call
- Existing private single-read text omission / delivery budget tests still pass via `TestSoulReadToolResult_PrivateSingleCompactsTextContent` and `TestSoulReadToolResult_PrivateSingleRejectsOversizeDelivery`.

## Summary shape / expansion example
```json
{
  "view": "summary",
  "count": 1,
  "souls": [
    {
      "identity": {"agentId": "...", "localId": "agent-summary", "ensName": "agent-summary.lessersoul.eth"},
      "lifecycle": {"status": "active", "reason": "operational"},
      "capabilities": {"names": ["social.post", "memory.query"], "count": 2},
      "channels": {"email": {"status": "unavailable", "reason": "deferred_private_reachability"}},
      "provenance": {"registrationVersion": "7", "sources": [{"block": "identity", "status": "available"}]},
      "expand": {
        "standard": {"tool": "soul_read", "arguments": {"self": true, "view": "standard"}, "resultPath": "structuredContent.data"},
        "full": {"tool": "soul_read", "arguments": {"self": true, "view": "full"}, "resultPath": "structuredContent.data"}
      }
    }
  ],
  "omitted": [
    {"path": "souls[].capabilities[].body", "reason": "capability_names_only", "expansion": "souls[].expand.standard"},
    {"path": "souls[]._raw", "reason": "debug_payload", "expansion": "souls[].expand.full"}
  ]
}
```

## Compatibility notes
- No default compact/summary flip: omitted `view` preserves the existing shape and full normalized public capability blocks.
- `view=summary` does not inline sanitized `_raw`, full registration/capability/boundary/transparency payloads, private mint-conversation bodies, or private email/phone reachability data.
- `view=full` and `include_raw=true` remain explicit audit/debug paths with existing private reachability redaction.
- `private_reachability_unavailable` and private single-read text omission behavior are unchanged.

## Stage rollout plan (handoff to deploy-body)
- [ ] Merged to main
- [ ] Deployed to lab / dev
- [ ] Lab soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
None required for this body-only additive MCP/tool-surface refinement.

## Advisor-brief authorization
Activated by Arch for Project 33 P2.1 via GitHub issue #234 and advisor email `delivery-4ea9eb5296f4df5b` from `arch@lessersoul.ai`; proceeding under standing user authorization for Arch-assigned milestones.

## Blockers / risks
- Hosted GitHub checks pending after PR creation.
- No deploy performed.