### PR TITLE
feat(mcp): compact email mailbox reads

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -371,7 +371,7 @@ Scope key:
 | `skills_catalog` | Read | List approved skill bundles from Lesser's authoritative skills catalog, preserving bundle digests, provenance, install hints, and exposure metadata. |
 | `skill_bundle_get` | Read | Fetch a selected approved Lesser skill bundle and optionally report local install-state verification from caller-supplied local file bytes. When `MCP_TASK_TABLE` is configured, this read-only tool also supports optional task-backed execution. |
 | `email_send` | Write | Send a new email through lesser-host on behalf of the authenticated soul agent; use `email_reply` for mailbox replies. |
-| `email_read` | Read | List email metadata/previews from lesser-host's canonical Soul Comm Mailbox. |
+| `email_read` | Read | List email metadata/previews from lesser-host's canonical Soul Comm Mailbox; supports opt-in compact mailbox refs. |
 | `email_get` | Read | Get email metadata/state by opaque host `messageId`/`messageRef`. |
 | `email_get_content` | Read | Explicitly fetch full email content for a specific mailbox message. |
 | `email_search` | Read | Run bounded host metadata/preview search over the email mailbox. |
@@ -521,14 +521,27 @@ Notes:
   Verbose upstream mailbox payloads are omitted by default. `email_read`, `email_get`, `email_search`, `sms_read`,
   and `voicemail_read` accept optional `include_raw=true` for audit/debug use cases, which adds the upstream payload
   under `_raw` on each returned message.
+- `email_read` advertises opt-in `view=compact|standard|full`. Omitted/default and `view=standard` preserve the
+  existing mailbox list shape, including compatibility aliases (`messageId`, `messageRef`, `deliveryId`,
+  `hostMessageId`, `channel`/`channelType`), preview-as-`body` plus `bodyIsPreview`, `nextCursor`/`nextSince`, notes,
+  and filter echo fields. `email_read(view=compact)` returns compact mailbox refs with canonical `messageRef`,
+  `channelType`, subject/preview, content availability metadata, read/archive/delete state, page cursor metadata,
+  omission records, and deterministic expansion refs to `email_get` and
+  `email_get_content`. Compact mode does not duplicate preview into `body`, does not include `_raw`, and does not inline
+  full message bodies. `email_read(folder=inbox, limit=10, view=compact)` targets an 8 KB MCP JSON-RPC payload budget;
+  if a compact response exceeds that budget, body returns `response_too_large` with measured byte details.
+  `view=full` and `include_raw=true` are explicit audit/debug paths for sanitized mailbox metadata only: list responses
+  still do not fetch or inline full email bodies, and `email_get_content` remains the only full-body path.
 - `email_send` starts a new outbound email. It accepts optional `idempotencyKey` for retry-safe new sends, but it does
   not accept `messageId` or `inReplyTo`; those legacy reply/message-reference fields are rejected locally with a
   structured `invalid_request` tool error before lesser-host is called. To reply to an inbound mailbox message, use
   `email_reply` with the opaque mailbox `messageId` returned by `email_read`, `email_search`, `email_get`, or
   notification `communication.messageId`.
-- Mailbox and memory tools use dual MCP result surfaces: `content[0].text` contains the JSON payload for text-reading
-  clients, and `structuredContent` contains the same typed fields directly (for example `messages` or `events` at the
-  top level) rather than nesting them under a `data` wrapper.
+- Mailbox and memory tools use dual MCP result surfaces in standard/default mode: `content[0].text` contains the JSON
+  payload for text-reading clients, and `structuredContent` contains the same typed fields directly (for example
+  `messages` or `events` at the top level) rather than nesting them under a `data` wrapper. Compact mailbox list views
+  keep the flat top-level `structuredContent` shape but use concise text with a locator to `structuredContent` instead
+  of duplicating every compact message in `content[0].text`.
 - Selected tools now publish MCP `outputSchema` metadata in `tools/list` and `.well-known/mcp.json`. The schema
   describes the tool's `structuredContent` success shape, not the full JSON-RPC envelope: memory query tools describe
   direct top-level fields such as `events`, while selected identity, soul, and skills tools that use the generic

--- a/internal/mcpapp/comm_contract_test.go
+++ b/internal/mcpapp/comm_contract_test.go
@@ -198,6 +198,11 @@ func TestLBM0_CommunicationToolSchemasMatchSpec(t *testing.T) {
 		expectPropType(t, s, "archived", "boolean")
 		expectPropType(t, s, "includeDeleted", "boolean")
 		expectPropType(t, s, "deleted", "boolean")
+		view := expectPropType(t, s, "view", "string")
+		enum, _ := view["enum"].([]any)
+		if !reflect.DeepEqual(enum, []any{"compact", "standard", "full"}) {
+			t.Fatalf("email_read view enum = %+v", view)
+		}
 		limit := expectPropType(t, s, "limit", "integer")
 		if limit["maximum"] != float64(100) {
 			t.Fatalf("email_read limit.maximum: want 100 got %#v", limit["maximum"])

--- a/internal/mcpapp/inbox_tools_test.go
+++ b/internal/mcpapp/inbox_tools_test.go
@@ -2,12 +2,14 @@ package mcpapp_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
+	apptheory "github.com/theory-cloud/apptheory/runtime"
 	mcpruntime "github.com/theory-cloud/apptheory/runtime/mcp"
 	"github.com/theory-cloud/apptheory/testkit"
 
@@ -28,6 +30,7 @@ func TestLBM3_InboxToolsUseHostMailbox(t *testing.T) {
 	var gotAuth []string
 	var listQueries []string
 	var statePaths []string
+	var contentPathCalls int
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -50,31 +53,7 @@ func TestLBM3_InboxToolsUseHostMailbox(t *testing.T) {
 					_, _ = w.Write([]byte(`{"messages":[],"count":0,"hasMore":false}`))
 					return
 				}
-				_, _ = w.Write([]byte(`{
-					"instanceSlug":"inst1",
-					"agentId":"` + agentID + `",
-					"messages":[{
-						"messageRef":"comm-delivery-email",
-						"deliveryId":"comm-delivery-email",
-						"messageId":"comm-msg-email",
-						"threadId":"comm-thread-email",
-						"direction":"inbound",
-						"channelType":"email",
-						"status":"delivered",
-						"from":{"address":"alice@example.com"},
-						"to":{"address":"agent@example.com"},
-						"subject":"Hi",
-						"preview":"Hello preview",
-						"body":"` + strings.Repeat("full mailbox body ", 240) + `",
-						"content":{"available":true,"bytes":11,"mimeType":"text/plain","sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","contentHref":"/content"},
-						"state":{"read":false,"archived":false,"deleted":false},
-						"createdAt":"2026-03-04T12:00:00Z",
-						"debugPayload":{"large":"` + strings.Repeat("mailbox-debug ", 320) + `"}
-					}],
-					"count":1,
-					"hasMore":true,
-					"nextCursor":"cursor-2"
-				}`))
+				_, _ = w.Write([]byte(mailboxEmailListFixture(agentID, 10)))
 			case "sms":
 				_, _ = w.Write([]byte(`{"messages":[{"messageRef":"comm-delivery-sms","deliveryId":"comm-delivery-sms","messageId":"comm-msg-sms","threadId":"comm-thread-sms","direction":"inbound","channelType":"sms","status":"delivered","from":{"number":"+15550142"},"preview":"sms preview","content":{"available":true},"state":{"read":false,"archived":false,"deleted":false},"createdAt":"2026-03-04T12:05:00Z"}],"count":1,"hasMore":false}`))
 			case "voice":
@@ -87,6 +66,7 @@ func TestLBM3_InboxToolsUseHostMailbox(t *testing.T) {
 			_, _ = w.Write([]byte(`{"message":{"messageRef":"comm-delivery-email","deliveryId":"comm-delivery-email","messageId":"comm-msg-email","threadId":"comm-thread-email","direction":"inbound","channelType":"email","status":"delivered","from":{"address":"alice@example.com"},"to":{"address":"agent@example.com"},"subject":"Hi","preview":"Hello preview","content":{"available":true},"state":{"read":false,"archived":false,"deleted":false},"createdAt":"2026-03-04T12:00:00Z"}}`))
 		case r.URL.Path == "/api/v1/soul/comm/mailbox/"+agentID+"/messages/comm-delivery-email/content" && r.Method == http.MethodGet:
 			gotAuth = append(gotAuth, r.Header.Get("Authorization"))
+			contentPathCalls++
 			_, _ = w.Write([]byte(`{"instanceSlug":"inst1","agentId":"` + agentID + `","messageRef":"comm-delivery-email","deliveryId":"comm-delivery-email","messageId":"comm-msg-email","contentType":"text/plain","sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","bytes":11,"body":"Full body"}`))
 		case strings.HasPrefix(r.URL.Path, "/api/v1/soul/comm/mailbox/"+agentID+"/messages/comm-delivery-email/") && r.Method == http.MethodPost:
 			gotAuth = append(gotAuth, r.Header.Get("Authorization"))
@@ -152,11 +132,11 @@ func TestLBM3_InboxToolsUseHostMailbox(t *testing.T) {
 
 	emailRead := callTool(2, "email_read", map[string]any{"folder": "inbox", "limit": 10, "unreadOnly": true})
 	messages, _ := emailRead["messages"].([]any)
-	if len(messages) != 1 {
-		t.Fatalf("expected 1 email message, got %+v", messages)
+	if len(messages) != 10 {
+		t.Fatalf("expected 10 email messages, got %+v", messages)
 	}
 	msg, _ := messages[0].(map[string]any)
-	if msg["messageId"] != "comm-delivery-email" || msg["hostMessageId"] != "comm-msg-email" || msg["body"] != "Hello preview" || msg["bodyIsPreview"] != true {
+	if msg["messageId"] != "comm-delivery-email-00" || msg["hostMessageId"] != "comm-msg-email-00" || msg["body"] != "Hello preview 00" || msg["bodyIsPreview"] != true {
 		t.Fatalf("unexpected email message: %+v", msg)
 	}
 	for _, alias := range []string{"messageId", "messageRef", "deliveryId", "hostMessageId"} {
@@ -173,7 +153,9 @@ func TestLBM3_InboxToolsUseHostMailbox(t *testing.T) {
 	if emailRead["nextCursor"] != "cursor-2" || emailRead["nextSince"] != "cursor-2" {
 		t.Fatalf("expected cursor aliases, got %+v", emailRead)
 	}
-	assertMCPPayloadBudget(t, "email_read default mailbox preview large fixture", responseBytes[2], 6500)
+	if strings.Contains(mustJSON(t, emailRead), "FULL_MAILBOX_BODY_SHOULD_NOT_APPEAR") {
+		t.Fatalf("default email_read must not inline full mailbox body: %+v", emailRead)
+	}
 
 	emailReadRaw := callTool(20, "email_read", map[string]any{"folder": "inbox", "limit": 10, "include_raw": true})
 	rawMessages, _ := emailReadRaw["messages"].([]any)
@@ -184,12 +166,96 @@ func TestLBM3_InboxToolsUseHostMailbox(t *testing.T) {
 	if _, ok := rawMsg["raw"]; ok {
 		t.Fatalf("include_raw=true should use _raw, not raw: %+v", rawMsg)
 	}
+	if strings.Contains(mustJSON(t, emailReadRaw), "FULL_MAILBOX_BODY_SHOULD_NOT_APPEAR") {
+		t.Fatalf("include_raw list response must sanitize full mailbox body: %+v", emailReadRaw)
+	}
 	assertMCPPayloadIncrease(t,
 		"email_read default mailbox preview large fixture",
 		responseBytes[2],
 		"email_read include_raw expanded fixture",
 		responseBytes[20],
 	)
+
+	emailReadStandard := callTool(24, "email_read", map[string]any{"folder": "inbox", "limit": 10, "view": "standard", "unreadOnly": true})
+	standardMessages, _ := emailReadStandard["messages"].([]any)
+	standardMsg, _ := standardMessages[0].(map[string]any)
+	if standardMsg["messageId"] != "comm-delivery-email-00" || standardMsg["messageRef"] != "comm-delivery-email-00" || standardMsg["deliveryId"] != "comm-delivery-email-00" || standardMsg["hostMessageId"] != "comm-msg-email-00" {
+		t.Fatalf("view=standard should preserve mailbox aliases, got %+v", standardMsg)
+	}
+	if standardMsg["channel"] != "email" || standardMsg["channelType"] != "email" || standardMsg["body"] != "Hello preview 00" || standardMsg["bodyIsPreview"] != true {
+		t.Fatalf("view=standard should preserve channel/body preview compatibility, got %+v", standardMsg)
+	}
+	if emailReadStandard["nextCursor"] != "cursor-2" || emailReadStandard["nextSince"] != "cursor-2" || emailReadStandard["unreadOnly"] != true {
+		t.Fatalf("view=standard should preserve cursor/filter echo fields, got %+v", emailReadStandard)
+	}
+
+	emailReadCompact := callTool(25, "email_read", map[string]any{"folder": "inbox", "limit": 10, "view": "compact"})
+	assertMCPPayloadBudget(t, "email_read compact mailbox fixture", responseBytes[25], 8000)
+	compactMessages, _ := emailReadCompact["messages"].([]any)
+	compactMsg, _ := compactMessages[0].(map[string]any)
+	if emailReadCompact["view"] != "compact" || len(compactMessages) != 10 {
+		t.Fatalf("unexpected compact list metadata: %+v", emailReadCompact)
+	}
+	if compactMsg["messageRef"] != "comm-delivery-email-00" || compactMsg["channelType"] != "email" || compactMsg["preview"] != "Hello preview 00" {
+		t.Fatalf("unexpected compact message ref/preview: %+v", compactMsg)
+	}
+	if _, ok := compactMsg["body"]; ok {
+		t.Fatalf("compact message must not duplicate preview into body: %+v", compactMsg)
+	}
+	for _, forbidden := range []string{"messageId", "deliveryId", "hostMessageId", "channel", "_raw"} {
+		if _, ok := compactMsg[forbidden]; ok {
+			t.Fatalf("compact message should omit %s, got %+v", forbidden, compactMsg)
+		}
+	}
+	expand, _ := compactMsg["expand"].(map[string]any)
+	metadataExpand, _ := expand["metadata"].(map[string]any)
+	metadataArgs, _ := metadataExpand["arguments"].(map[string]any)
+	contentExpand, _ := expand["content"].(map[string]any)
+	contentArgs, _ := contentExpand["arguments"].(map[string]any)
+	if metadataExpand["tool"] != "email_get" || metadataArgs["messageId"] != "comm-delivery-email-00" {
+		t.Fatalf("unexpected compact metadata expansion: %+v", metadataExpand)
+	}
+	if contentExpand["tool"] != "email_get_content" || contentArgs["messageId"] != "comm-delivery-email-00" {
+		t.Fatalf("unexpected compact content expansion: %+v", contentExpand)
+	}
+	if strings.Contains(mustJSON(t, emailReadCompact), "FULL_MAILBOX_BODY_SHOULD_NOT_APPEAR") || strings.Contains(mustJSON(t, emailReadCompact), "mailbox-debug") {
+		t.Fatalf("compact email_read leaked full/raw fixture data: %+v", emailReadCompact)
+	}
+
+	emailReadFull := callTool(26, "email_read", map[string]any{"folder": "inbox", "limit": 10, "view": "full"})
+	fullMessages, _ := emailReadFull["messages"].([]any)
+	fullMsg, _ := fullMessages[0].(map[string]any)
+	if emailReadFull["view"] != "full" {
+		t.Fatalf("view=full should be explicit, got %+v", emailReadFull)
+	}
+	if _, ok := fullMsg["_raw"].(map[string]any); !ok {
+		t.Fatalf("view=full should expose sanitized _raw metadata, got %+v", fullMsg)
+	}
+	if !strings.Contains(mustJSON(t, emailReadFull), "mailbox-debug") {
+		t.Fatalf("view=full should preserve verbose audit metadata")
+	}
+	if strings.Contains(mustJSON(t, emailReadFull), "FULL_MAILBOX_BODY_SHOULD_NOT_APPEAR") {
+		t.Fatalf("view=full list response must not inline full mailbox body: %+v", emailReadFull)
+	}
+
+	listCallsBeforeInvalidView := len(listQueries)
+	invalidView := callToolAllowError(t, env, app, authHeader, sessionID, 27, "email_read", map[string]any{"folder": "inbox", "view": "summary"})
+	if !invalidView.IsError {
+		t.Fatalf("unsupported view should return a tool error")
+	}
+	invalidViewPayload, _ := invalidView.StructuredContent["error"].(map[string]any)
+	if invalidViewPayload["code"] != "invalid_request" || invalidViewPayload["status"] != float64(400) {
+		t.Fatalf("unexpected unsupported view error: %+v", invalidViewPayload)
+	}
+	invalidNumber := callToolAllowError(t, env, app, authHeader, sessionID, 28, "email_read", map[string]any{"folder": "inbox", "view": 7})
+	if !invalidNumber.IsError {
+		t.Fatalf("non-string view should return a tool error")
+	}
+	if len(listQueries) != listCallsBeforeInvalidView {
+		t.Fatalf("invalid view calls should fail before lesser-host mailbox list, before=%d after=%d", listCallsBeforeInvalidView, len(listQueries))
+	}
+	t.Logf("email_read payload bytes default=%d standard=%d compact=%d full=%d include_raw=%d",
+		responseBytes[2], responseBytes[24], responseBytes[25], responseBytes[26], responseBytes[20])
 
 	smsRead := callTool(3, "sms_read", map[string]any{"limit": 10})
 	smsMessages, _ := smsRead["messages"].([]any)
@@ -225,9 +291,15 @@ func TestLBM3_InboxToolsUseHostMailbox(t *testing.T) {
 		t.Fatalf("expected email_get include_raw=true to expose _raw, got %+v", emailGetRawMessage)
 	}
 
+	if contentPathCalls != 0 {
+		t.Fatalf("email_read/email_get metadata paths must not fetch full content, content calls=%d", contentPathCalls)
+	}
 	content := callTool(6, "email_get_content", map[string]any{"messageId": "comm-delivery-email"})
 	if content["body"] != "Full body" || content["messageId"] != "comm-delivery-email" {
 		t.Fatalf("unexpected content response: %+v", content)
+	}
+	if contentPathCalls != 1 {
+		t.Fatalf("email_get_content should be the only full-body path, content calls=%d", contentPathCalls)
 	}
 
 	readState := callTool(7, "email_mark_read", map[string]any{"messageId": "comm-delivery-email"})
@@ -264,4 +336,67 @@ func TestLBM3_InboxToolsUseHostMailbox(t *testing.T) {
 			t.Fatalf("expected mailbox query %q in %s", want, combinedQueries)
 		}
 	}
+}
+
+func callToolAllowError(t *testing.T, env *testkit.Env, app *apptheory.App, authHeader string, sessionID string, id int, name string, arguments map[string]any) mcpruntime.ToolResult {
+	t.Helper()
+	callParams, _ := json.Marshal(map[string]any{"name": name, "arguments": arguments})
+	resp := invokeJSON(t, env, app, map[string][]string{
+		"authorization":  {authHeader},
+		"mcp-session-id": {sessionID},
+	}, &mcpruntime.Request{JSONRPC: "2.0", ID: id, Method: "tools/call", Params: callParams})
+	if resp.Status != 200 {
+		t.Fatalf("%s: status=%d body=%s", name, resp.Status, string(resp.Body))
+	}
+	var rpc mcpruntime.Response
+	if err := json.Unmarshal(resp.Body, &rpc); err != nil {
+		t.Fatalf("unmarshal %s response: %v", name, err)
+	}
+	if rpc.Error != nil {
+		t.Fatalf("%s rpc error: %+v", name, rpc.Error)
+	}
+	var out mcpruntime.ToolResult
+	b, _ := json.Marshal(rpc.Result)
+	_ = json.Unmarshal(b, &out)
+	return out
+}
+
+func mailboxEmailListFixture(agentID string, count int) string {
+	var b strings.Builder
+	_, _ = fmt.Fprintf(&b, `{"instanceSlug":"inst1","agentId":%q,"messages":[`, agentID)
+	for i := range count {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		suffix := fmt.Sprintf("%02d", i)
+		_, _ = fmt.Fprintf(&b, `{
+			"messageRef":"comm-delivery-email-%s",
+			"deliveryId":"comm-delivery-email-%s",
+			"messageId":"comm-msg-email-%s",
+			"threadId":"comm-thread-email",
+			"direction":"inbound",
+			"channelType":"email",
+			"status":"delivered",
+			"from":{"address":"alice-%s@example.com","displayName":"Alice %s"},
+			"to":{"address":"agent@example.com"},
+			"subject":"Hi %s",
+			"preview":"Hello preview %s",
+			"body":"FULL_MAILBOX_BODY_SHOULD_NOT_APPEAR %s %s",
+			"content":{"available":true,"bytes":2048,"mimeType":"text/plain","sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","contentHref":"/content","body":"FULL_MAILBOX_BODY_SHOULD_NOT_APPEAR content %s"},
+			"state":{"read":false,"archived":false,"deleted":false},
+			"createdAt":"2026-03-04T12:00:00Z",
+			"debugPayload":{"large":"%s"}
+		}`, suffix, suffix, suffix, suffix, suffix, suffix, suffix, suffix, strings.Repeat("full mailbox body ", 120), suffix, strings.Repeat("mailbox-debug ", 80))
+	}
+	_, _ = fmt.Fprintf(&b, `],"count":%d,"hasMore":true,"nextCursor":"cursor-2"}`, count)
+	return b.String()
+}
+
+func mustJSON(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal test payload: %v", err)
+	}
+	return string(b)
 }

--- a/internal/mcpserver/comm_tools.go
+++ b/internal/mcpserver/comm_tools.go
@@ -95,7 +95,8 @@ func emailReadDef() mcpruntime.ToolDef {
 				"limit":{"type":"integer","minimum":1,"maximum":100},
 				"cursor":{"type":"string"},
 				"since":{"type":"string","description":"Legacy alias for cursor."},
-				"threadId":{"type":"string"}
+				"threadId":{"type":"string"},
+				"view":{"type":"string","enum":["compact","standard","full"],"description":"Optional projection. Omitted/standard preserve today's mailbox list shape; compact returns bounded refs/previews with email_get/email_get_content expansion metadata; full includes sanitized _raw mailbox metadata without fetching full bodies."}
 			}
 		}`),
 	}

--- a/internal/mcpserver/inbox_tools.go
+++ b/internal/mcpserver/inbox_tools.go
@@ -13,6 +13,18 @@ import (
 )
 
 func handleEmailRead(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
+	readParams, err := parseSharedReadParams(args)
+	if err != nil {
+		return toolErrorResult("invalid_request", "invalid args: "+err.Error(), 400, nil)
+	}
+	view := readParams.View
+	if view == "" {
+		view = readViewStandard
+	}
+	if err := validateMailboxListReadView(view); err != nil {
+		return toolErrorResult("invalid_request", err.Error(), 400, map[string]any{"view": view})
+	}
+
 	var in struct {
 		Folder          string `json:"folder,omitempty"`
 		UnreadOnly      bool   `json:"unreadOnly,omitempty"`
@@ -51,12 +63,13 @@ func handleEmailRead(ctx context.Context, args json.RawMessage) (*mcpruntime.Too
 	if in.Folder == "sent" {
 		direction = "outbound"
 	}
+	includeRaw := (in.IncludeRaw || view == readViewFull) && view != readViewCompact
 
 	out, err := listHostMailboxMessages(ctx, deps, commMailboxListOptions{
 		ChannelType:     "email",
 		Direction:       direction,
 		UnreadOnly:      in.UnreadOnly,
-		IncludeRaw:      in.IncludeRaw,
+		IncludeRaw:      includeRaw,
 		IncludeArchived: in.IncludeArchived,
 		IncludeDeleted:  in.IncludeDeleted,
 		Archived:        archived,
@@ -84,6 +97,12 @@ func handleEmailRead(ctx context.Context, args json.RawMessage) (*mcpruntime.Too
 	}
 	out["cursor"] = strings.TrimSpace(in.Cursor)
 	out["since"] = strings.TrimSpace(in.Since)
+	if view == readViewCompact {
+		return compactMailboxListToolResult("email_read", mailboxCompactListResult(out))
+	}
+	if view == readViewFull {
+		out["view"] = readViewFull
+	}
 	return toolJSONResult(out, out)
 }
 

--- a/internal/mcpserver/mailbox_host_tools.go
+++ b/internal/mcpserver/mailbox_host_tools.go
@@ -15,8 +15,9 @@ import (
 )
 
 const (
-	mailboxDefaultLimit = 20
-	mailboxMaxLimit     = 100
+	mailboxDefaultLimit          = 20
+	mailboxMaxLimit              = 100
+	mailboxCompactMaxOutputBytes = 8000
 )
 
 type commMailboxDependencies struct {
@@ -312,14 +313,14 @@ func normalizeMailboxMessage(raw any, includeRaw bool) map[string]any {
 		"preview":       preview,
 		"body":          preview,
 		"bodyIsPreview": true,
-		"content":       mapFromAny(m["content"]),
+		"content":       sanitizeMailboxRawContent(mapFromAny(m["content"])),
 		"state":         mapFromAny(m["state"]),
 		"createdAt":     createdAt,
 		"receivedAt":    createdAt,
 		"updatedAt":     strings.TrimSpace(stringFromMap(m, "updatedAt")),
 	}
 	if includeRaw {
-		out["_raw"] = m
+		out["_raw"] = sanitizeMailboxRawMessage(m)
 	}
 	if strings.EqualFold(strings.TrimSpace(fmt.Sprint(out["direction"])), "outbound") {
 		out["sentAt"] = createdAt
@@ -408,12 +409,205 @@ func validateMailboxReadFilters(unreadOnly bool, read *bool) error {
 	return nil
 }
 
+func validateMailboxListReadView(view string) error {
+	switch strings.ToLower(strings.TrimSpace(view)) {
+	case readViewCompact, readViewStandard, readViewFull:
+		return nil
+	default:
+		return fmt.Errorf("invalid view (expected compact, standard, or full)")
+	}
+}
+
 func mailboxListNotes() map[string]any {
 	return map[string]any{
 		"authority":       "lesser-host Soul Comm Mailbox",
 		"bodyField":       "body is a redacted preview in list/get results; call email_get_content for full content when content.available is true",
 		"messageIdRef":    "messageId is an opaque host messageRef suitable for get/content/state/reply calls",
 		"legacySinceName": "nextSince is an alias of nextCursor for older clients; pass it back as cursor or since",
+	}
+}
+
+func mailboxCompactListResult(standard map[string]any) map[string]any {
+	messagesRaw, _ := standard["messages"].([]any)
+	messages := make([]any, 0, len(messagesRaw))
+	for _, item := range messagesRaw {
+		message, _ := item.(map[string]any)
+		if message == nil {
+			continue
+		}
+		messages = append(messages, compactMailboxMessage(message))
+	}
+
+	out := map[string]any{
+		"source":     standard["source"],
+		"view":       readViewCompact,
+		"messages":   messages,
+		"count":      standard["count"],
+		"hasMore":    standard["hasMore"],
+		"nextCursor": standard["nextCursor"],
+		"filters":    mailboxCompactFilters(standard),
+		"notes": map[string]any{
+			"authority":    "lesser-host Soul Comm Mailbox",
+			"messageRef":   "messageRef is the canonical opaque host reference for email_get, email_get_content, state, and reply calls",
+			"preview":      "compact preview is not duplicated into body; call email_get_content for full content when content.available is true",
+			"standardView": "call email_read with view=standard for compatibility aliases and repeated legacy notes",
+		},
+		"omitted": compactMailboxListOmissions(),
+	}
+	if v := strings.TrimSpace(stringFromMap(standard, "folder")); v != "" {
+		out["folder"] = v
+	}
+	return out
+}
+
+func compactMailboxMessage(message map[string]any) map[string]any {
+	messageRef := strings.TrimSpace(stringFromMap(message, "messageRef"))
+	out := map[string]any{
+		"messageRef":  messageRef,
+		"channelType": strings.TrimSpace(stringFromMap(message, "channelType")),
+		"content":     compactMailboxContent(mapFromAny(message["content"])),
+		"state":       compactMailboxState(mapFromAny(message["state"])),
+	}
+	putIfNotEmpty(out, "direction", stringFromMap(message, "direction"))
+	putIfNotEmpty(out, "status", stringFromMap(message, "status"))
+	putIfNotEmpty(out, "threadId", stringFromMap(message, "threadId"))
+	putIfNotEmpty(out, "subject", stringFromMap(message, "subject"))
+	putIfNotEmpty(out, "preview", stringFromMap(message, "preview"))
+	putIfNotEmpty(out, "createdAt", stringFromMap(message, "createdAt"))
+	putIfNotEmpty(out, "updatedAt", stringFromMap(message, "updatedAt"))
+	if strings.EqualFold(strings.TrimSpace(stringFromMap(message, "direction")), "outbound") {
+		putIfNotEmpty(out, "sentAt", stringFromMap(message, "sentAt"))
+	}
+	if messageRef != "" {
+		out["expand"] = map[string]any{
+			"metadata": SocialExpansionRef{
+				Tool:       "email_get",
+				Arguments:  map[string]any{"messageId": messageRef, "include_raw": false},
+				ResultPath: "structuredContent.message",
+			},
+			"content": SocialExpansionRef{
+				Tool:       "email_get_content",
+				Arguments:  map[string]any{"messageId": messageRef},
+				ResultPath: "structuredContent",
+			},
+		}
+	} else {
+		out["missingFields"] = []any{"messageRef"}
+	}
+	return out
+}
+
+func compactMailboxContent(content map[string]any) map[string]any {
+	out := map[string]any{}
+	if v, ok := content["available"]; ok {
+		out["available"] = v
+	}
+	return out
+}
+
+func compactMailboxState(state map[string]any) map[string]any {
+	out := map[string]any{}
+	for _, key := range []string{"read", "archived", "deleted"} {
+		if v, ok := state[key]; ok {
+			out[key] = v
+		}
+	}
+	return out
+}
+
+func mailboxCompactFilters(standard map[string]any) map[string]any {
+	filters := map[string]any{}
+	for _, key := range []string{"folder", "query", "unreadOnly", "read", "includeArchived", "archived", "includeDeleted", "deleted", "cursor", "since"} {
+		if v, ok := standard[key]; ok {
+			filters[key] = v
+		}
+	}
+	return filters
+}
+
+func compactMailboxListOmissions() []any {
+	return []any{
+		map[string]any{"path": "messages[].messageId", "reason": "compatibility_alias", "expansion": "call email_read with view=standard"},
+		map[string]any{"path": "messages[].deliveryId", "reason": "compatibility_alias", "expansion": "call email_read with view=standard"},
+		map[string]any{"path": "messages[].hostMessageId", "reason": "compatibility_alias", "expansion": "call email_read with view=standard"},
+		map[string]any{"path": "messages[].channel", "reason": "compatibility_alias", "expansion": "use messages[].channelType or call email_read with view=standard"},
+		map[string]any{"path": "messages[].body", "reason": "full_body_not_in_list", "expansion": "messages[].expand.content"},
+		map[string]any{"path": "messages[]._raw", "reason": "debug_payload", "expansion": "call email_read with view=full"},
+		map[string]any{"path": "notes.legacySinceName", "reason": "legacy_note", "expansion": "call email_read with view=standard"},
+	}
+}
+
+func compactMailboxListToolResult(toolName string, payload map[string]any) (*mcpruntime.ToolResult, error) {
+	textPayload := map[string]any{
+		"summary": fmt.Sprintf("%d compact mailbox messages", len(firstArrayFromAny(payload, "messages"))),
+		"tool":    toolName,
+		"view":    readViewCompact,
+		"count":   payload["count"],
+		"data":    map[string]any{"location": "structuredContent"},
+	}
+	b, err := json.Marshal(textPayload)
+	if err != nil {
+		return nil, fmt.Errorf("marshal compact mailbox tool text: %w", err)
+	}
+	result := &mcpruntime.ToolResult{
+		Content: []mcpruntime.ContentBlock{{
+			Type: "text",
+			Text: string(b),
+		}},
+		StructuredContent: payload,
+	}
+	measurement, err := measureToolResultPayload(result)
+	if err != nil {
+		return nil, err
+	}
+	if measurement.JSONRPCEnvelopeBytes <= mailboxCompactMaxOutputBytes {
+		return result, nil
+	}
+	return toolErrorResult("response_too_large", toolName+" compact response exceeds max_output_bytes", http.StatusRequestEntityTooLarge, map[string]any{
+		"tool":             toolName,
+		"view":             readViewCompact,
+		"measuredBytes":    measurement.JSONRPCEnvelopeBytes,
+		"maxOutputBytes":   mailboxCompactMaxOutputBytes,
+		"contentTextBytes": measurement.ContentTextBytes,
+		"structuredBytes":  measurement.StructuredContentBytes,
+		"guidance":         "reduce limit or use view=standard/full for explicit expansion",
+	})
+}
+
+func sanitizeMailboxRawMessage(m map[string]any) map[string]any {
+	out := make(map[string]any, len(m))
+	for key, value := range m {
+		if isMailboxBodyField(key) {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(key), "content") {
+			if content, ok := value.(map[string]any); ok {
+				out[key] = sanitizeMailboxRawContent(content)
+				continue
+			}
+		}
+		out[key] = value
+	}
+	return out
+}
+
+func sanitizeMailboxRawContent(m map[string]any) map[string]any {
+	out := make(map[string]any, len(m))
+	for key, value := range m {
+		if isMailboxBodyField(key) {
+			continue
+		}
+		out[key] = value
+	}
+	return out
+}
+
+func isMailboxBodyField(key string) bool {
+	switch strings.ToLower(strings.TrimSpace(key)) {
+	case "body", "textbody", "htmlbody", "bodytext", "bodyhtml", "messagebody", "rawbody":
+		return true
+	default:
+		return false
 	}
 }
 


### PR DESCRIPTION
## Milestone
Project 33 P3.1 / #235 — add compact/standard/full mailbox list views with `email_read` as the required acceptance gate.

Closes #235

## Classification
MCP-contract / tool-surface / host-delegation / communication read-tool shaping / test-coverage / docs

## Surfaces affected
- `email_read` input schema now advertises `view=compact|standard|full`.
- Omitted/default and `view=standard` preserve the existing mailbox list shape.
- `view=compact` returns bounded mailbox refs/previews with deterministic `email_get` / `email_get_content` expansion metadata.
- `view=full` and `include_raw=true` remain explicit audit/debug metadata paths, with list bodies sanitized so `email_get_content` remains the only full-body path.
- `docs/mcp.md` documents compact mailbox semantics and budget.

## File summary
- `internal/mcpserver/comm_tools.go`: advertises `email_read.view` enum and descriptions.
- `internal/mcpserver/inbox_tools.go`: parses/validates `email_read` view before lesser-host mailbox calls, routes compact/full projections.
- `internal/mcpserver/mailbox_host_tools.go`: adds compact mailbox projection, response budget enforcement, compact text locator, and body-field sanitization for mailbox metadata/raw payloads.
- `internal/mcpapp/comm_contract_test.go`: asserts schema parity for the new `email_read.view` enum.
- `internal/mcpapp/inbox_tools_test.go`: covers default/standard compatibility, compact shape/budget/omissions/expansion refs, full/include_raw metadata sanitization, invalid view handling before lesser-host, and `email_get_content` as the only full-body path.
- `docs/mcp.md`: updates tool catalog and mailbox read-shaping contract.

## Specialist walks referenced
- Tool surface: additive read-scope `email_read` schema/behavior refinement; no scope/profile loosening; static registration preserved.
- MCP contract: additive optional parameter plus opt-in compact/full projections; default/omitted behavior remains compatible for existing clients.
- Host delegation: existing lesser-host mailbox API is unchanged; no compact API requirement; `LESSER_HOST_INSTANCE_KEY` handling and host rate-limit boundaries unchanged; list paths do not fetch full bodies.
- Lesser integration: not touched.
- Framework: idiomatic AppTheory MCP tool results; no local framework patch.

## Consumer impact
- Existing MCP clients: no change when omitting `view`; `view=standard` preserves current aliases/notes/filter echoes.
- New/updated clients: can request `view=compact` for bounded mailbox context and expand specific messages through `email_get` or `email_get_content`.
- Operators/sibling repos: no Host/Lesser/AppTheory deployment contract change required.

## Tasks
- [x] Advertise `email_read.view=compact|standard|full` in discovery schema.
- [x] Preserve omitted/default mailbox list shape.
- [x] Preserve compatibility aliases and notes in `view=standard` (`messageId`, `messageRef`, `deliveryId`, `hostMessageId`, `channel`/`channelType`, preview-as-`body`, `bodyIsPreview`, `nextCursor`/`nextSince`, and filter echoes).
- [x] Add `view=compact` with canonical `messageRef`, `channelType`, preview, page/cursor state, read/archive/delete state, omission metadata, and expansion refs.
- [x] Ensure compact does not duplicate preview into `body`, include `_raw`, or inline full message content.
- [x] Keep `email_get_content` as the only full-body path; `view=full` / `include_raw=true` expose sanitized metadata only.
- [x] Reject non-string and unsupported `view` values with structured tool errors before lesser-host mailbox list calls.
- [x] Update docs/contracts/tests together.

## Validation
- `gofmt -l .` (empty)
- `git diff --check origin/main...HEAD`
- `git diff --check`
- `go test -count=1 ./...`
- `go vet ./...`
- `bash scripts/build.sh`
- Targeted: `go test -count=1 -v ./internal/mcpapp -run 'TestLBM0_CommunicationToolSchemasMatchSpec|TestLBM3_InboxToolsUseHostMailbox'`
- Targeted: `go test -count=1 ./internal/mcpserver`

## Payload-size evidence
From `TestLBM3_InboxToolsUseHostMailbox` with a 10-message large mailbox fixture:
- default/omitted: `18072` JSON-RPC bytes
- `view=standard`: `18073` JSON-RPC bytes
- `view=compact`: `7504` JSON-RPC bytes under the 8000-byte compact budget
- `view=full`: `54407` JSON-RPC bytes with explicit sanitized `_raw` mailbox metadata
- `include_raw=true`: `54375` JSON-RPC bytes with explicit sanitized `_raw` mailbox metadata

## Compact shape / expansion example
```json
{
  "source": "lesser-host-mailbox",
  "view": "compact",
  "count": 10,
  "hasMore": true,
  "nextCursor": "cursor-2",
  "messages": [
    {
      "messageRef": "comm-delivery-email-00",
      "channelType": "email",
      "subject": "Hi 00",
      "preview": "Hello preview 00",
      "content": {"available": true},
      "state": {"read": false, "archived": false, "deleted": false},
      "expand": {
        "metadata": {"tool": "email_get", "arguments": {"messageId": "comm-delivery-email-00", "include_raw": false}, "resultPath": "structuredContent.message"},
        "content": {"tool": "email_get_content", "arguments": {"messageId": "comm-delivery-email-00"}, "resultPath": "structuredContent"}
      }
    }
  ],
  "omitted": [
    {"path": "messages[].messageId", "reason": "compatibility_alias", "expansion": "call email_read with view=standard"},
    {"path": "messages[].body", "reason": "full_body_not_in_list", "expansion": "messages[].expand.content"},
    {"path": "messages[]._raw", "reason": "debug_payload", "expansion": "call email_read with view=full"}
  ]
}
```

## Compatibility notes
- No compact default flip: omitted `view` preserves the current mailbox list shape.
- `view=standard` preserves compatibility aliases, notes, cursor aliases, and filter echoes.
- Compact responses keep flat top-level `structuredContent` but concise `content[0].text` points to `structuredContent` instead of duplicating all messages.
- Full/include_raw paths sanitize full-body fields from list metadata; `email_get_content` remains the only full-body path.
- Existing `email_search`, `sms_read`, and `voicemail_read` behavior remains compatibility-preserving; they were not expanded beyond existing include_raw coverage.

## Stage rollout plan (handoff to deploy-body)
- [ ] Merged to main
- [ ] Deployed to lab / dev
- [ ] Lab soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
None required for this body-only additive MCP/tool-surface refinement. Host delegation uses the existing lesser-host mailbox list/get/content contract.

## Advisor / assignment authorization
Activated by Arch for Project 33 P3.1 via GitHub issue #235 comment `4472535847`; proceeding under standing user authorization for Arch-assigned milestones.

## Blockers / risks
- Hosted GitHub checks pending after PR creation.
- No deploy performed.