### PR TITLE
docs(mcp): keep compact defaults opt-in for P4.1

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -409,6 +409,12 @@ Structured-first result shaping is additive. Existing tools that use `content[0]
 `structuredContent.data`. If diagnostics are requested, concise text should point to `structuredContent.diagnostics`
 rather than duplicating timing/size payloads.
 
+Project 33 P4.1 compatibility decision: compact defaults remain opt-in for now. `timeline_read`, `post_search`,
+`soul_read`, and `email_read` keep their omitted/default behavior equivalent to `view=standard`; callers must request
+`view=compact` or `view=summary` explicitly for the bounded agent-context shape. A later default flip requires P4.2
+docs/probe guidance plus Ops live evidence against compact-default behavior. See
+`docs/project33-p4.1-compatibility-decision.md`.
+
 Social compact references use deterministic expansion metadata. `AccountRef` values include only source-backed stable
 fields (`id`, `acct`, `displayName`, and `url`) and report `missingFields` rather than guessing absent data. `StatusRef`
 values include `id`, `url`, `authorRef`, `createdAt`, `visibility`, `contentPreview`, and a `contentTruncated` marker.
@@ -429,10 +435,12 @@ Notes:
 
 - Social tools require an **OAuth JWT** bearer token (not just an instance key) because they call the Lesser API on behalf
   of the authenticated agent.
-- M0 baseline read-tool policy: daily agent read paths must have compact, bounded defaults. List/read tools should return
-  operational metadata (ids, timestamps, actor/from/to, subject/type, preview/status/state, and cursor metadata) rather
-  than full upstream product payloads. Raw/debug payloads are opt-in only via `include_raw=true` where currently
-  supported, and full content remains on explicit get/content tools rather than default list responses.
+- M0 baseline read-tool policy: daily agent read paths should move toward compact, bounded defaults only after
+  compatibility review, docs/probe guidance, and live evidence. In P4.1, `timeline_read`, `post_search`, `soul_read`,
+  and `email_read` explicitly keep compact/summary views opt-in. List/read tools should return operational metadata
+  (ids, timestamps, actor/from/to, subject/type, preview/status/state, and cursor metadata) rather than full upstream
+  product payloads when compact mode is selected. Raw/debug payloads are opt-in only via `include_raw=true` where
+  currently supported, and full content remains on explicit get/content tools rather than default list responses.
 - `notifications_read.since` is a temporal RFC3339/RFC3339Nano lower bound (`createdAt > since`). Use the optional
   `cursor` argument for pagination/backfill; `nextCursor` is returned when Lesser supplies an opaque pagination cursor.
   Cursor pagination is strongest for untyped reads or reads with a single `types` value; multi-type reads fan out to

--- a/docs/project33-p4.1-compatibility-decision.md
+++ b/docs/project33-p4.1-compatibility-decision.md
@@ -1,0 +1,61 @@
+# Project 33 P4.1 compatibility decision
+
+Date: 2026-05-17
+
+## Decision
+
+Compact defaults remain **opt-in** for P4.1. lesser-body does not flip omitted/default read behavior globally in this
+milestone.
+
+The compatibility-preserving behavior remains:
+
+- `timeline_read` omitted `view` stays upstream-shaped; `view=standard` is the same back-compat escape hatch.
+- `post_search` omitted `view` stays upstream-shaped; `view=standard` is the same back-compat escape hatch.
+- `soul_read` omitted `view` stays the existing public soul bundle shape; `view=standard` is the same back-compat
+  escape hatch.
+- `email_read` omitted `view` stays the existing mailbox list metadata/preview shape; `view=standard` is the same
+  back-compat escape hatch.
+
+Opt-in compact/summary views remain available for agent-context slimming:
+
+- `timeline_read(view=compact)` and `post_search(view=compact)` return bounded `StatusRef` lists with `post_get`
+  expansion metadata and omission records.
+- `soul_read(view=summary)` returns bounded public soul essentials with `soul_read(..., view=standard|full)`
+  expansion metadata and omission records.
+- `email_read(view=compact)` returns bounded mailbox refs with `email_get` / `email_get_content` expansion metadata
+  and omission records.
+
+Explicit audit/debug expansion remains explicit: `view=full` and `include_raw=true` continue to be opt-in only where
+already supported. `email_read(view=full)` and `email_read(include_raw=true)` do not fetch or inline full message bodies;
+`email_get_content` remains the full email body path.
+
+## Rationale
+
+The compact views added through P1-P3 are useful and measured, but existing clients and probes still issue some calls
+without `view` and parse standard/upstream-shaped fields from `content[0].text` or `structuredContent`. Flipping the
+global omitted/default shape before P4.2 docs/probe guidance and Ops live compact-default evidence would make a
+context-size improvement by changing a compatibility contract that clients have not yet been taught to rely on safely.
+
+The safe P4.1 outcome is therefore a recorded decision plus compatibility coverage: keep compact views opt-in, preserve
+`view=standard` / `view=full` escape and expansion routes, and defer any global/profile/runtime default flip until after
+P4.2 and explicit Ops live evidence.
+
+## Rollback and escape path
+
+Because P4.1 does not change runtime defaults, rollback is documentation/test-only. If a later milestone enables compact
+defaults by global, profile, or runtime configuration, every compact-capable read surface must keep explicit
+`view=standard` as the caller-visible compatibility escape hatch and `view=full` / explicit raw-debug behavior where
+already supported.
+
+## Validation scope
+
+P4.1 compatibility tests assert that omitted/default calls still match `view=standard` for:
+
+- `timeline_read`
+- `post_search`
+- `soul_read`
+- `email_read`
+
+The same tests keep opt-in compact/summary paths covered for payload budgets, deterministic expansion refs, and omission
+metadata. No Lesser, lesser-host, AppTheory, runtime, CDK, scope/profile, or static-registration changes are part of
+this decision.

--- a/internal/mcpapp/identity_surfaces_test.go
+++ b/internal/mcpapp/identity_surfaces_test.go
@@ -1921,6 +1921,10 @@ func TestP21_SoulReadSummaryStandardFullViews(t *testing.T) {
 	if len(standardCapabilities) != 2 || standardCapabilities[0].(map[string]any)["constraints"] != capabilityConstraint {
 		t.Fatalf("view=standard should preserve existing capability bodies, got %+v", standardCapabilities)
 	}
+	if !reflect.DeepEqual(defaultOut.StructuredContent, standardOut.StructuredContent) ||
+		defaultOut.Content[0].Text != standardOut.Content[0].Text {
+		t.Fatalf("soul_read omitted view must remain equivalent to view=standard")
+	}
 
 	summaryOut, summaryBody := call(4, map[string]any{"self": true, "view": "summary"})
 	if summaryOut.IsError {

--- a/internal/mcpapp/inbox_tools_test.go
+++ b/internal/mcpapp/inbox_tools_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -187,6 +188,9 @@ func TestLBM3_InboxToolsUseHostMailbox(t *testing.T) {
 	}
 	if emailReadStandard["nextCursor"] != "cursor-2" || emailReadStandard["nextSince"] != "cursor-2" || emailReadStandard["unreadOnly"] != true {
 		t.Fatalf("view=standard should preserve cursor/filter echo fields, got %+v", emailReadStandard)
+	}
+	if !reflect.DeepEqual(emailRead, emailReadStandard) {
+		t.Fatalf("email_read omitted view must remain equivalent to view=standard: default=%+v standard=%+v", emailRead, emailReadStandard)
 	}
 
 	emailReadCompact := callTool(25, "email_read", map[string]any{"folder": "inbox", "limit": 10, "view": "compact"})

--- a/internal/mcpapp/social_tools_test.go
+++ b/internal/mcpapp/social_tools_test.go
@@ -894,6 +894,10 @@ func TestM5_TimelineReadCompactUsesStatusRefsAndPayloadBudget(t *testing.T) {
 	if _, ok := defaultResult.Result.StructuredContent["data"].([]any); !ok {
 		t.Fatalf("default timeline response must remain upstream array-shaped, got %+v", defaultResult.Result.StructuredContent["data"])
 	}
+	if !reflect.DeepEqual(defaultResult.Result.StructuredContent, standard.Result.StructuredContent) ||
+		defaultResult.Result.Content[0].Text != standard.Result.Content[0].Text {
+		t.Fatalf("timeline_read omitted view must remain equivalent to view=standard")
+	}
 }
 
 func TestM5_PostSearchCompactUsesStatusRefsAndPayloadBudget(t *testing.T) {
@@ -997,6 +1001,21 @@ func TestM5_PostSearchCompactUsesStatusRefsAndPayloadBudget(t *testing.T) {
 	)
 	if !strings.Contains(string(standard.ResponseBody), contentTail) || !strings.Contains(string(standard.ResponseBody), accountNote) {
 		t.Fatalf("standard search response should preserve upstream payload")
+	}
+
+	defaultResult := callSocialTool(t, env, app, authHeader, sessionID, 4, "post_search", map[string]any{
+		"query": "mcp",
+		"limit": 10,
+	})
+	if gotQueries[2] != "limit=10&q=mcp&type=statuses" {
+		t.Fatalf("expected default search query, got %q", gotQueries[2])
+	}
+	if !strings.Contains(string(defaultResult.ResponseBody), contentTail) || !strings.Contains(string(defaultResult.ResponseBody), accountNote) {
+		t.Fatalf("default search response should preserve upstream payload")
+	}
+	if !reflect.DeepEqual(defaultResult.Result.StructuredContent, standard.Result.StructuredContent) ||
+		defaultResult.Result.Content[0].Text != standard.Result.Content[0].Text {
+		t.Fatalf("post_search omitted view must remain equivalent to view=standard")
 	}
 }
 


### PR DESCRIPTION
## Milestone
Project 33 P4.1 — compatibility decision for compact defaults (#236)

Closes #236.

## Classification
MCP-contract / tool-surface compatibility documentation and tests.

## Surfaces affected
- `docs/project33-p4.1-compatibility-decision.md` records the decision that compact defaults remain opt-in for now.
- `docs/mcp.md` now points agents/operators at the P4.1 decision and clarifies that compact-default migration remains staged.
- Targeted tests now assert omitted/default behavior remains equivalent to `view=standard` for `timeline_read`, `post_search`, `soul_read`, and `email_read`.

## Specialist walks referenced
- MCP contract: no discovery/OAuth/JSON-RPC runtime shape change; this PR explicitly preserves omitted/default behavior for the gated read tools.
- Tool surface: no scope/profile/registration changes; compact/summary/full views remain opt-in exactly where already advertised.
- Host delegation: no lesser-host API change; `email_read` remains host-delegated and `email_get_content` remains the full-body path.
- Lesser/AppTheory/CDK: no changes.

## Decision outcome
Compact remains opt-in in P4.1. No global/profile/runtime default flip is implemented.

## Compatibility evidence
- `timeline_read` omitted `view` remains upstream-shaped and is asserted equivalent to `view=standard`.
- `post_search` omitted `view` remains upstream-shaped and is asserted equivalent to `view=standard`.
- `soul_read` omitted `view` remains the existing public soul bundle shape and is asserted equivalent to `view=standard`.
- `email_read` omitted `view` remains the existing mailbox list metadata/preview shape and is asserted equivalent to `view=standard`.

## What remains opt-in
- `timeline_read(view=compact)` / `post_search(view=compact)` bounded `StatusRef` views.
- `soul_read(view=summary)` bounded soul summary view.
- `email_read(view=compact)` bounded mailbox-ref view.
- Existing explicit `view=full` / `include_raw=true` audit-debug behavior where supported.

## Rollback / escape path
There is no runtime default change to roll back. Future compact-default work must keep explicit `view=standard` as the compatibility escape hatch and `view=full` / explicit raw-debug expansion where already supported.

## Tasks
- [x] Record P4.1 compatibility decision locally.
- [x] Preserve omitted/default behavior for `timeline_read`, `post_search`, `soul_read`, and `email_read`.
- [x] Preserve standard/full escape and existing compact opt-in payload/expansion coverage.
- [x] Avoid runtime/profile/config switch and avoid Lesser/Host/AppTheory/CDK redesign.

## Validation
- [x] Baseline on `main` before branch: `gofmt -l .`, `go test -count=1 ./...`, `go vet ./...`, `bash scripts/build.sh`
- [x] `git diff --check origin/main...HEAD`
- [x] `git diff --check`
- [x] `gofmt -l .` (empty)
- [x] Targeted: `go test -count=1 -v ./internal/mcpapp -run 'TestM5_TimelineReadCompactUsesStatusRefsAndPayloadBudget|TestM5_PostSearchCompactUsesStatusRefsAndPayloadBudget|TestP21_SoulReadSummaryStandardFullViews|TestLBM3_InboxToolsUseHostMailbox'`
- [x] `go test -count=1 ./...`
- [x] `go vet ./...`
- [x] `bash scripts/build.sh`
- [x] Hosted checks

## Stage rollout plan (handoff to deploy-body)
- [ ] Merged to main
- [ ] Deployed to lab / dev
- [ ] Lab soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

No deploy performed.

## Cross-repo coordination
None required for P4.1: no Lesser, Host, AppTheory, TableTheory, CDK, SSM, or OAuth metadata changes.

## Advisor-brief authorization
Arch assigned P4.1 via GitHub issue comment 4472587942 and advisor email `delivery-66e96636c65f885c`; provenance verified (`arch@lessersoul.ai`, target lesser-body/#236, AI-agent footer), under Aron's standing authorization for Arch-assigned milestones.