### PR TITLE
docs(mcp): teach compact expansion probes

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -203,7 +203,8 @@ Expected headers include:
 MCP calls require auth. See `docs/mcp.md` for examples and auth expectations.
 
 For host-backed communication validation in lab, run the mailbox canary with an actor-scoped OAuth token. The script
-redacts credentials and prints hashes/lengths instead of message bodies:
+checks default/standard mailbox compatibility plus explicit `email_read(view=compact)` expansion refs. It redacts
+credentials and prints hashes/lengths instead of message bodies:
 
 ```bash
 MCP_ENDPOINT="https://api.<stageDomain>/mcp/<actor>" \

--- a/docs/development.md
+++ b/docs/development.md
@@ -83,7 +83,8 @@ MCP_BEARER_TOKEN="<oauth-access-token>" \
 scripts/canary_host_mailbox_mcp.py
 ```
 
-The canary checks `tools/list`, `email_read`, `email_get`, `email_get_content`, `email_search`,
-`email_mark_read`, `email_mark_unread`, `sms_read`, `voicemail_read`, and a not-found error path. It never prints
-full message bodies, full recipient addresses, bearer tokens, or raw upstream error payloads; error logs keep only
-stable codes/status plus hashed payload summaries where details are needed.
+The canary checks `tools/list`, default/standard `email_read`, explicit `email_read(view=compact)` expansion refs,
+`email_get`, `email_get_content`, `email_search`, `email_mark_read`, `email_mark_unread`, `sms_read`,
+`voicemail_read`, and a not-found error path. It never prints full message bodies, full recipient addresses, bearer
+tokens, or raw upstream error payloads; error logs keep only stable codes/status plus hashed payload summaries where
+details are needed.

--- a/docs/m0-baseline-probe.md
+++ b/docs/m0-baseline-probe.md
@@ -45,16 +45,38 @@ export PROBE_NOTIFICATION_WORKFLOW_UNREAD_ONLY_VIEW=false
 export PROBE_WRONG_USER_BEARER_TOKEN='<OAuth token for a different actor>'
 ```
 
+Optional compact/summary projection probe input:
+
+```bash
+# Used only for the explicit post_search(view=compact) probe. Defaults to "mcp".
+export PROBE_POST_SEARCH_QUERY='mcp'
+```
+
 ## Command
 
 ```bash
 scripts/m0_baseline_mcp_probe.py | tee m0-baseline-probe.jsonl
 ```
 
-The script prints one line per probe with pass/fail/skip, elapsed time, HTTP response size, and compact metadata. It
-prints a final `SUMMARY` JSON object suitable for attaching to the Project 21 issue or deploy notes. The summary includes
-`mode`, `closureRequired`, `closureReady`, and `closureProbeNames` so smoke/read-surface passes cannot be mistaken for
-full M0 closure evidence.
+The script prints one line per probe with pass/fail/skip, elapsed time, HTTP response size, compact/summary omission
+counts, and expansion tool names. It prints a final `SUMMARY` JSON object suitable for attaching to the Project 21 issue
+or deploy notes. The summary includes `mode`, `closureRequired`, `closureReady`, and `closureProbeNames` so
+smoke/read-surface passes cannot be mistaken for full M0 closure evidence.
+
+P4.2 compact/summary probes are explicit opt-ins. They do not imply compact defaults:
+
+- `notifications_read(view=compact)` records payload bytes, omitted metadata count, and expansion tools.
+- `email_read(view=compact)` verifies canonical `messageRef`, no `body`/`raw`/`_raw` list fields, and
+  `email_get` / `email_get_content` expansion refs.
+- `conversations_read(view=compact)` verifies compact expansion metadata and fails if a `conversation_get` route is
+  advertised.
+- `soul_read(view=summary)` verifies summary omission/expansion metadata without private blocks or raw payloads.
+- `timeline_read(view=compact)` and `post_search(view=compact)` verify `post_get` expansion metadata when list entries
+  are present.
+
+The probe output remains sanitized: bearer tokens, message bodies, full tool JSON, raw upstream payloads, private
+reachability details, and full recipient addresses are not printed. Message/content checks emit counts, booleans,
+opaque refs only where needed for expansion validation, byte sizes, and SHA-256 digests.
 
 The probe treats semantic failure payloads as failures, not successful MCP transport:
 
@@ -76,7 +98,10 @@ The report must include:
 - elapsed time per probe;
 - approximate payload size for large read paths;
 - `notifications_read.diagnostics` timing/size fields when probes request `include_diagnostics=true`;
+- compact/summary opt-in payload sizes, omitted metadata counts, and expansion tool names;
 - whether default notification output omitted raw/debug payloads;
+- whether explicit compact mailbox output avoided `body`, `raw`, and `_raw`, kept canonical `messageRef`, and advertised
+  `email_get` / `email_get_content`;
 - whether the run is smoke-only or closure-mode (`SUMMARY.mode` and `SUMMARY.closureReady`);
 - for closure-mode runs, notification workflow details: selected notification type/id (redacted), direct Lesser
   single-get status, MCP dismiss result, follow-up `notifications_read` `read` state, direct follow-up read-state
@@ -106,6 +131,11 @@ For the Project 21 post-M0 cleanup issues, Ops can verify these narrow contract 
 - `notifications_read({"types":["communication:inbound"],"limit":5})` must be accepted. Returned rows, if any, must have
   `type:"communication:inbound"` and preserve the compact `communication` summary; the call must not expose `raw` /
   `_raw` unless `include_raw=true`.
+- `notifications_read({"limit":10,"view":"compact"})`, `conversations_read({"limit":10,"view":"compact"})`,
+  `soul_read({"self":true,"view":"summary"})`, `timeline_read({"timeline":"home","limit":5,"view":"compact"})`,
+  `post_search({"query":"mcp","limit":10,"view":"compact"})`, and
+  `email_read({"folder":"inbox","limit":10,"view":"compact"})` must be treated as explicit opt-ins and should report
+  concise payload/omission/expansion evidence without changing omitted/default behavior.
 - A normal `email_send` without reply fields must still queue through lesser-host.
 - `email_send` with legacy `messageId` or `inReplyTo` arguments must fail locally as a structured `invalid_request`
   tool error that directs callers to `email_reply`; the failure must occur before lesser-host returns a conversation

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -415,6 +415,33 @@ Project 33 P4.1 compatibility decision: compact defaults remain opt-in for now. 
 docs/probe guidance plus Ops live evidence against compact-default behavior. See
 `docs/project33-p4.1-compatibility-decision.md`.
 
+### Agent-facing compact expansion workflows
+
+Compact/summary responses are explicit requests, not new defaults. Agents should treat compact list responses as
+index/ref pages and expand only the items they need:
+
+- `timeline_read({"timeline":"home","limit":5,"view":"compact"})` and
+  `post_search({"query":"mcp","limit":10,"view":"compact"})` return `StatusRef` entries. Use each ref's `expand`
+  metadata, or call `post_get({"id":"<status-id>","view":"standard"})` for normalized content and
+  `post_get({"id":"<status-id>","view":"full"})` for explicit audit/debug expansion.
+- `notifications_read({"limit":10,"view":"compact"})` returns notification refs. Use
+  `notification_get({"id":"<notification-id>","view":"standard"})` or `view:"full"` for a single notification, and
+  follow any `targetPostRef.expand` route through `post_get` for post content.
+- `conversations_read({"limit":10,"view":"compact"})` returns conversation refs with bounded participant and last-post
+  metadata. There is no `conversation_get` tool; expand only the `lastPostRef` through `post_get` when Lesser supplies a
+  stable post id.
+- `soul_read({"self":true,"view":"summary"})` returns bounded public identity essentials. Use the summary `expand`
+  metadata, or call `soul_read(..., "view":"standard")` for the compatibility bundle and `view:"full"` for explicit
+  sanitized audit/debug raw public payloads.
+- `email_read({"folder":"inbox","limit":10,"view":"compact"})` returns mailbox refs with canonical `messageRef`. Use
+  `email_get({"messageId":"<messageRef>"})` for mailbox metadata and
+  `email_get_content({"messageId":"<messageRef>"})` for the full body when `content.available=true`.
+
+Omitted/default calls remain compatibility-oriented until a later, evidence-backed default migration. Do not infer
+private reachability from compact omissions: private email/phone reachability still fails closed with
+`private_reachability_unavailable`, explicit source/contract/status/reason metadata remains significant, and private
+mint-conversation blocks require explicit self-scope expansion outside summary mode.
+
 Social compact references use deterministic expansion metadata. `AccountRef` values include only source-backed stable
 fields (`id`, `acct`, `displayName`, and `url`) and report `missingFields` rather than guessing absent data. `StatusRef`
 values include `id`, `url`, `authorRef`, `createdAt`, `visibility`, `contentPreview`, and a `contentTruncated` marker.

--- a/scripts/canary_host_mailbox_mcp.py
+++ b/scripts/canary_host_mailbox_mcp.py
@@ -10,7 +10,8 @@ Optional environment:
                      first email_read message is used.
   MAILBOX_QUERY      Bounded metadata/preview query for email_search (default: subject/from preview from message, else "canary")
 
-The script intentionally redacts bearer tokens and never prints message bodies or full recipient addresses.
+The script intentionally redacts bearer tokens and never prints message bodies, raw upstream payloads, or full recipient
+addresses. Compact-view checks print only payload sizes, opaque message refs, state booleans, and content hashes.
 """
 
 from __future__ import annotations
@@ -54,6 +55,7 @@ if not AUTHORIZATION:
 
 session_id = ""
 next_id = 1
+last_response_bytes = 0
 
 
 def log(message: str) -> None:
@@ -153,7 +155,7 @@ def decode_rpc_response(method: str, request_id: int, raw: bytes, content_type: 
 
 
 def post_rpc(method: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
-    global next_id, session_id
+    global next_id, session_id, last_response_bytes
     request_id = next_id
     payload: dict[str, Any] = {"jsonrpc": "2.0", "id": request_id, "method": method}
     next_id += 1
@@ -177,6 +179,7 @@ def post_rpc(method: str, params: dict[str, Any] | None = None) -> dict[str, Any
     try:
         with authenticated_open(req, timeout=30) as resp:
             raw = resp.read()
+            last_response_bytes = len(raw)
             content_type = resp.headers.get("Content-Type", "")
             if not session_id:
                 session_id = resp.headers.get("mcp-session-id", "").strip()
@@ -210,9 +213,39 @@ def tool_call(name: str, arguments: dict[str, Any], *, expect_error: bool = Fals
         error_payload = structured.get("error") or result
         raise CanaryError(f"{name} tool error: {json.dumps(sanitized_error_payload(error_payload), sort_keys=True)}")
     data = structured.get("data")
-    if not isinstance(data, dict):
-        raise CanaryError(f"{name} missing structuredContent.data")
-    return data
+    if isinstance(data, dict):
+        return data
+    if isinstance(structured, dict):
+        return structured
+    raise CanaryError(f"{name} missing structuredContent")
+
+
+def expansion_tool_names(value: Any) -> set[str]:
+    names: set[str] = set()
+    if isinstance(value, dict):
+        tool_name = value.get("tool")
+        if isinstance(tool_name, str) and tool_name:
+            names.add(tool_name)
+        for nested in value.values():
+            names.update(expansion_tool_names(nested))
+    elif isinstance(value, list):
+        for nested in value:
+            names.update(expansion_tool_names(nested))
+    return names
+
+
+def omitted_count(value: Any) -> int:
+    total = 0
+    if isinstance(value, dict):
+        omitted = value.get("omitted")
+        if isinstance(omitted, list):
+            total += len(omitted)
+        for nested in value.values():
+            total += omitted_count(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            total += omitted_count(nested)
+    return total
 
 
 def summarize_message(message: dict[str, Any]) -> str:
@@ -235,6 +268,49 @@ def first_message(data: dict[str, Any]) -> dict[str, Any] | None:
         return None
     first = messages[0]
     return first if isinstance(first, dict) else None
+
+
+def require_standard_message_shape(message: dict[str, Any], context: str) -> None:
+    if not message:
+        return
+    if not str(message.get("messageId") or message.get("messageRef") or "").strip():
+        raise CanaryError(f"{context} missing messageId/messageRef compatibility alias")
+    if not str(message.get("channel") or message.get("channelType") or "").strip():
+        raise CanaryError(f"{context} missing channel/channelType compatibility alias")
+    if "_raw" in message or "raw" in message:
+        raise CanaryError(f"{context} exposed raw payload without include_raw")
+    if "body" not in message and "preview" not in message:
+        raise CanaryError(f"{context} missing preview/body compatibility field")
+
+
+def compact_message_ref(message: dict[str, Any]) -> str:
+    return str(message.get("messageRef") or "").strip()
+
+
+def require_compact_email_shape(data: dict[str, Any]) -> str:
+    messages = data.get("messages") if isinstance(data.get("messages"), list) else []
+    dict_messages = [item for item in messages if isinstance(item, dict)]
+    if not dict_messages:
+        return ""
+    for index, item in enumerate(dict_messages):
+        for forbidden in ("body", "_raw", "raw"):
+            if forbidden in item:
+                raise CanaryError(f"email_read compact message {index} exposed forbidden {forbidden}")
+    message = dict_messages[0]
+    message_ref = compact_message_ref(message)
+    if not message_ref:
+        raise CanaryError("email_read compact first message missing canonical messageRef")
+    tools = expansion_tool_names(message)
+    missing = {"email_get", "email_get_content"} - tools
+    if missing:
+        raise CanaryError(f"email_read compact missing expansion tools: {sorted(missing)}")
+    expand = message.get("expand") if isinstance(message.get("expand"), dict) else {}
+    for label, tool_name in (("metadata", "email_get"), ("content", "email_get_content")):
+        ref = expand.get(label) if isinstance(expand.get(label), dict) else {}
+        args = ref.get("arguments") if isinstance(ref.get("arguments"), dict) else {}
+        if ref.get("tool") != tool_name or args.get("messageId") != message_ref:
+            raise CanaryError(f"email_read compact {label} expansion does not target {tool_name} with messageRef")
+    return message_ref
 
 
 def main() -> int:
@@ -264,13 +340,56 @@ def main() -> int:
     log("ok tools/list host mailbox tools present")
 
     email_list = tool_call("email_read", {"folder": "inbox", "limit": 5, "includeArchived": False})
+    default_payload_bytes = last_response_bytes
     messages = email_list.get("messages") if isinstance(email_list.get("messages"), list) else []
-    log(f"ok email_read count={len(messages)} hasMore={email_list.get('hasMore')} nextCursor_present={bool(email_list.get('nextCursor'))}")
+    default_message = first_message(email_list)
+    require_standard_message_shape(default_message or {}, "email_read default")
+    log(
+        "ok email_read default "
+        f"count={len(messages)} hasMore={email_list.get('hasMore')} "
+        f"nextCursor_present={bool(email_list.get('nextCursor'))} payloadB={default_payload_bytes}"
+    )
+
+    standard_list = tool_call("email_read", {"folder": "inbox", "limit": 5, "view": "standard", "includeArchived": False})
+    standard_payload_bytes = last_response_bytes
+    standard_messages = standard_list.get("messages") if isinstance(standard_list.get("messages"), list) else []
+    require_standard_message_shape(first_message(standard_list) or {}, "email_read standard")
+    log(
+        "ok email_read standard "
+        f"count={len(standard_messages)} hasMore={standard_list.get('hasMore')} "
+        f"payloadB={standard_payload_bytes}"
+    )
+
+    compact_list = tool_call("email_read", {"folder": "inbox", "limit": 5, "view": "compact", "includeArchived": False})
+    compact_payload_bytes = last_response_bytes
+    compact_messages = compact_list.get("messages") if isinstance(compact_list.get("messages"), list) else []
+    compact_ref = require_compact_email_shape(compact_list)
+    log(
+        "ok email_read compact "
+        f"count={len(compact_messages)} messageRef_present={bool(compact_ref)} "
+        f"omitted={omitted_count(compact_list)} expansionTools={sorted(expansion_tool_names(compact_list))} "
+        f"payloadB={compact_payload_bytes}"
+    )
 
     message_ref = os.environ.get("MAILBOX_MESSAGE_ID", "").strip()
-    message = first_message(email_list)
+    message = default_message
     if not message_ref and message:
         message_ref = str(message.get("messageId") or message.get("messageRef") or "").strip()
+    if compact_ref:
+        compact_get_data = tool_call("email_get", {"messageId": compact_ref})
+        compact_got_message = compact_get_data.get("message") if isinstance(compact_get_data.get("message"), dict) else {}
+        log(f"ok compact expansion email_get {summarize_message(compact_got_message)}")
+        compact_content = compact_got_message.get("content") if isinstance(compact_got_message.get("content"), dict) else {}
+        if compact_content.get("available") is not False:
+            compact_content_data = tool_call("email_get_content", {"messageId": compact_ref})
+            compact_body = str(compact_content_data.get("body") or "")
+            log(
+                "ok compact expansion email_get_content "
+                f"bytes={compact_content_data.get('bytes', len(compact_body.encode('utf-8')))} "
+                f"body_len={len(compact_body)} body_sha256_12={hashlib.sha256(compact_body.encode('utf-8')).hexdigest()[:12]}"
+            )
+        else:
+            log("skip compact expansion email_get_content content.available=false")
     if not message_ref:
         raise CanaryError("no mailbox message found; set MAILBOX_MESSAGE_ID to validate get/content/state paths")
     log(f"using mailbox message {summarize_message(message or {'messageId': message_ref})}")

--- a/scripts/m0_baseline_mcp_probe.py
+++ b/scripts/m0_baseline_mcp_probe.py
@@ -19,11 +19,13 @@ Recommended probe inputs:
   PROBE_NOTIFICATION_WORKFLOW_ID Optional specific list-returned notification ID to exercise
   PROBE_NOTIFICATION_WORKFLOW_TYPES Optional comma-separated notification types to exercise separately
   PROBE_WRONG_USER_BEARER_TOKEN Optional wrong-user token for negative notification controls
+  PROBE_POST_SEARCH_QUERY      Query for the compact post_search probe (default: mcp)
   PROBE_SAFE_SEND_EMAIL       Set true to run self-email send/search/readback
   PROBE_SELF_EMAIL_TO         Recipient for the safe self-email send
 
-The script prints only probe status, timing, sizes, and compact metadata. It never prints bearer tokens,
-message bodies, full tool JSON, or full recipient lists.
+The script prints only probe status, timing, sizes, compact/summary omission counts, and expansion tool names. It never
+prints bearer tokens, message bodies, full tool JSON, raw upstream payloads, private reachability details, or full
+recipient lists.
 """
 
 from __future__ import annotations
@@ -389,6 +391,116 @@ def assert_mailbox_page_sane(data: dict[str, Any], context: str) -> None:
         raise ProbeError(f"{context} returned hasMore=true without nextCursor")
 
 
+def list_of_dicts(data: dict[str, Any], key: str) -> list[dict[str, Any]]:
+    values = data.get(key)
+    if not isinstance(values, list):
+        return []
+    return [item for item in values if isinstance(item, dict)]
+
+
+def expansion_tool_names(value: Any) -> set[str]:
+    names: set[str] = set()
+    if isinstance(value, dict):
+        tool_name = value.get("tool")
+        if isinstance(tool_name, str) and tool_name:
+            names.add(tool_name)
+        for nested in value.values():
+            names.update(expansion_tool_names(nested))
+    elif isinstance(value, list):
+        for nested in value:
+            names.update(expansion_tool_names(nested))
+    return names
+
+
+def omitted_count(value: Any) -> int:
+    total = 0
+    if isinstance(value, dict):
+        omitted = value.get("omitted")
+        if isinstance(omitted, list):
+            total += len(omitted)
+        for nested in value.values():
+            total += omitted_count(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            total += omitted_count(nested)
+    return total
+
+
+def assert_forbidden_keys_absent(value: Any, keys: set[str], context: str) -> None:
+    if isinstance(value, dict):
+        for key in keys:
+            if key in value:
+                raise ProbeError(f"{context} exposed forbidden key {key}")
+        for nested in value.values():
+            assert_forbidden_keys_absent(nested, keys, context)
+    elif isinstance(value, list):
+        for nested in value:
+            assert_forbidden_keys_absent(nested, keys, context)
+
+
+def probe_compact_projection(
+    name: str,
+    tool_name: str,
+    args: dict[str, Any],
+    item_key: str,
+    *,
+    expected_tools: set[str] | None = None,
+    forbidden_tools: set[str] | None = None,
+    forbidden_keys: set[str] | None = None,
+) -> None:
+    result, data, elapsed, size = tool(tool_name, args)
+    assert_tool_ok(result)
+    items = list_of_dicts(data, item_key)
+    tools = expansion_tool_names(data)
+    if forbidden_tools:
+        present_forbidden = sorted(tools & forbidden_tools)
+        if present_forbidden:
+            raise ProbeError(f"{name} exposed forbidden expansion tools: {', '.join(present_forbidden)}")
+    if forbidden_keys:
+        assert_forbidden_keys_absent(items, forbidden_keys, name)
+    missing_tools = sorted((expected_tools or set()) - tools) if items else []
+    if missing_tools:
+        raise ProbeError(f"{name} missing expansion tools: {', '.join(missing_tools)}")
+    record(
+        name,
+        "pass",
+        elapsed,
+        size,
+        view=data.get("view"),
+        count=len(items),
+        omitted=omitted_count(data),
+        expansionTools=sorted(tools),
+    )
+
+
+def probe_email_compact_projection() -> None:
+    result, data, elapsed, size = tool("email_read", {"folder": "inbox", "limit": 10, "view": "compact"})
+    assert_tool_ok(result)
+    assert_mailbox_page_sane(data, "email_read compact")
+    messages = list_of_dicts(data, "messages")
+    tools = expansion_tool_names(data)
+    assert_forbidden_keys_absent(messages, {"body", "_raw", "raw"}, "email_read compact")
+    has_ref = False
+    if messages:
+        first = messages[0]
+        has_ref = bool(str(first.get("messageRef", "")).strip())
+        missing = {"email_get", "email_get_content"} - tools
+        if not has_ref:
+            raise ProbeError("email_read compact first message missing canonical messageRef")
+        if missing:
+            raise ProbeError(f"email_read compact missing expansion tools: {', '.join(sorted(missing))}")
+    record(
+        "email_read compact expansion",
+        "pass",
+        elapsed,
+        size,
+        count=len(messages),
+        messageRef=has_ref,
+        omitted=omitted_count(data),
+        expansionTools=sorted(tools),
+    )
+
+
 def notifications_list(data: dict[str, Any]) -> list[dict[str, Any]]:
     values = data.get("notifications")
     if not isinstance(values, list):
@@ -744,6 +856,17 @@ def main() -> int:
 
     run_probe("notifications_read limit=20", lambda: probe_notifications_read("notifications_read limit=20", {"limit": 20, "include_diagnostics": True}))
     run_probe(
+        "notifications_read compact expansion",
+        lambda: probe_compact_projection(
+            "notifications_read compact expansion",
+            "notifications_read",
+            {"limit": 10, "view": "compact"},
+            "notifications",
+            expected_tools={"notification_get"},
+            forbidden_keys={"raw", "_raw"},
+        ),
+    )
+    run_probe(
         "notifications_read since empty limit=30",
         lambda: probe_notifications_read("notifications_read since empty limit=30", {"since": "", "limit": 30, "include_diagnostics": True}),
     )
@@ -790,6 +913,8 @@ def main() -> int:
     else:
         skip("email_get_content listed message", "email_read inbox returned no messageId")
 
+    run_probe("email_read compact expansion", probe_email_compact_projection)
+
     if env("PROBE_SAFE_SEND_EMAIL").lower() == "true":
         to = require_input("self-email send/search/readback", "PROBE_SELF_EMAIL_TO")
         if to:
@@ -808,7 +933,52 @@ def main() -> int:
     probe_tool_success("memory_query", "memory_query", {"query": "M0 baseline probe", "limit": 5}, "events")
 
     probe_tool_success("conversations_read", "conversations_read", {"limit": 20}, "conversations")
+    run_probe(
+        "conversations_read compact expansion",
+        lambda: probe_compact_projection(
+            "conversations_read compact expansion",
+            "conversations_read",
+            {"limit": 10, "view": "compact"},
+            "conversations",
+            expected_tools=set(),
+            forbidden_tools={"conversation_get"},
+            forbidden_keys={"raw", "_raw"},
+        ),
+    )
+    run_probe(
+        "soul_read summary expansion",
+        lambda: probe_compact_projection(
+            "soul_read summary expansion",
+            "soul_read",
+            {"self": True, "view": "summary"},
+            "souls",
+            expected_tools={"soul_read"},
+            forbidden_keys={"private", "_raw"},
+        ),
+    )
     probe_tool_success("timeline_read home", "timeline_read", {"timeline": "home", "limit": 20})
+    run_probe(
+        "timeline_read compact expansion",
+        lambda: probe_compact_projection(
+            "timeline_read compact expansion",
+            "timeline_read",
+            {"timeline": "home", "limit": 5, "view": "compact"},
+            "statuses",
+            expected_tools={"post_get"},
+            forbidden_keys={"raw", "_raw"},
+        ),
+    )
+    run_probe(
+        "post_search compact expansion",
+        lambda: probe_compact_projection(
+            "post_search compact expansion",
+            "post_search",
+            {"query": env("PROBE_POST_SEARCH_QUERY", "mcp"), "limit": 10, "view": "compact"},
+            "statuses",
+            expected_tools={"post_get"},
+            forbidden_keys={"raw", "_raw"},
+        ),
+    )
 
     failed = sum(1 for r in results if r.status == "fail")
     skipped = sum(1 for r in results if r.status == "skip")


### PR DESCRIPTION
## Milestone
Project 33 P4.2 — docs/probes for compact opt-ins and explicit expansion (#237)

Closes #237.

## Classification
MCP-contract documentation / operational probe coverage. No runtime behavior change.

## Surfaces affected
- `docs/mcp.md` adds agent-facing compact-list -> expansion workflows.
- `docs/m0-baseline-probe.md` documents explicit compact/summary probe evidence and sanitized output handling.
- `docs/deployment.md` and `docs/development.md` describe the mailbox canary's compact email checks.
- `scripts/m0_baseline_mcp_probe.py` now exercises compact/summary opt-ins and records payload/omission/expansion metrics.
- `scripts/canary_host_mailbox_mcp.py` now exercises default, standard, and compact `email_read` plus compact `email_get` / `email_get_content` follow-ups.

## Specialist walks referenced
- MCP contract: docs/probes only; compact/summary views remain explicit opt-ins and omitted/default behavior is not flipped.
- Tool surface: no schema, scope, profile, registration, or handler changes.
- Host delegation: no lesser-host API change; canary still validates through existing host-delegated MCP tools and keeps full body retrieval on `email_get_content`.
- Lesser/AppTheory/CDK/runtime: no changes.

## Compact/summary workflow coverage
Docs/examples now teach:
- `timeline_read(view=compact)` / `post_search(view=compact)` -> `post_get(id, view=standard|full)`.
- `notifications_read(view=compact)` -> `notification_get(id, view=standard|full)` and `post_get` for `targetPostRef`.
- `conversations_read(view=compact)` -> `post_get` for `lastPostRef` only; no `conversation_get` is invented.
- `soul_read(view=summary)` -> `soul_read(..., view=standard|full)`.
- `email_read(view=compact)` -> `email_get` / `email_get_content`.

## Probe coverage and sanitized output evidence
- M0 probe records compact/summary `response_bytes`, `omitted` counts, and `expansionTools` only.
- M0 probe adds explicit opt-in probes for notifications, email, conversations, soul summary, timeline, and post search.
- Mailbox canary records default/standard payload sizes and compact payload size/omissions/expansion tool names.
- Mailbox canary verifies compact `messageRef`, absence of `body`/`raw`/`_raw`, and `email_get` / `email_get_content` expansion refs/follow-ups.
- Output remains sanitized: no bearer tokens, full tool JSON, raw upstream payloads, full message bodies, private reachability details, or full recipient addresses are printed.
- Private reachability fail-closed docs remain explicit (`private_reachability_unavailable`, source/contract/status/reason semantics, private mint-conversation boundaries).

## What did not change
- No runtime default flip.
- No runtime/profile/config switch.
- No Lesser/Host/AppTheory/CDK/runtime redesign.
- No lesser-host compact API requirement.
- No hot-context/AGENTS.md slimming.
- No standard-mode alias removal.

## Tasks
- [x] Reflect the P4.1 decision in docs: compact/summary remain opt-in.
- [x] Add agent-facing compact-list -> expansion examples.
- [x] Extend M0 baseline probe compact/summary opt-in coverage.
- [x] Extend mailbox canary compact email coverage while preserving default/standard compatibility checks.
- [x] Preserve private reachability fail-closed semantics and sanitized output handling.

## Validation
- [x] Baseline on `main` before branch: `gofmt -l .`, `go test -count=1 ./...`, `go vet ./...`, `bash scripts/build.sh`, `python3 -m py_compile scripts/m0_baseline_mcp_probe.py scripts/canary_host_mailbox_mcp.py`
- [x] `git diff --check origin/main...HEAD`
- [x] `git diff --check`
- [x] `gofmt -l .` (empty)
- [x] `python3 -m py_compile scripts/m0_baseline_mcp_probe.py scripts/canary_host_mailbox_mcp.py`
- [x] `go test -count=1 ./...`
- [x] `go vet ./...`
- [x] `bash scripts/build.sh`
- [x] Hosted checks

## Stage rollout plan (handoff to deploy-body)
- [ ] Merged to main
- [ ] Deployed to lab / dev
- [ ] Lab soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

No deploy performed.

## Cross-repo coordination
None required: no Lesser, Host, AppTheory, TableTheory, CDK, SSM, OAuth metadata, or runtime tool-surface changes.

## Advisor-brief authorization
Arch assigned P4.2 via GitHub issue comment 4472607993 and advisor email `delivery-2dc4cd674a829909`; provenance verified (`arch@lessersoul.ai`, target lesser-body/#237, AI-agent footer), under Aron's standing authorization for Arch-assigned milestones.