### PR TITLE
feat(mcp): filter notifications by actor

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -528,8 +528,11 @@ Notes:
   `identifier` where Lesser/host include it). Because Lesser does not yet expose an upstream actor filter, body
   over-fetches a bounded notification page (`min(limit*4, 80)`) and returns
   `structuredContent.data.filter.strategy="mcp_side_overfetch"` with `requestedLimit`, `overFetchLimit`,
-  `upstreamCount`, `matchedCount`, and `returnedCount`. Actor-filtered compact reads still use the normal compact
-  budget and return `response_too_large` rather than silently dropping fields.
+  `upstreamCount`, `matchedCount`, `returnedCount`, and `windowOffset`. If an over-fetched page contains more actor
+  matches than the requested return `limit`, `nextCursor` is an opaque body actor-filter cursor that re-reads the same
+  over-fetch window and returns the remaining matches before advancing to Lesser's upstream cursor. This prevents
+  matched-but-not-returned notifications inside the over-fetch window from becoming unreachable. Actor-filtered compact
+  reads still use the normal compact budget and return `response_too_large` rather than silently dropping fields.
 - `notifications_read` omits full upstream `raw` notification objects by default and accepts optional
   `include_raw=true`, which returns `_raw` on each notification for expensive audit/debug use. Default notifications
   contain compact `actor`, bounded `targetPost`, optional bounded `communication` summaries, normalized read state

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -360,7 +360,7 @@ Scope key:
 | `conversations_read` | Read | Read direct-message conversations; supports opt-in compact conversation refs. |
 | `conversation_get` | Read | Expand one direct-message conversation into bounded recent message previews; defaults to compact and requires explicit standard/full opt-in for message bodies/raw payloads. |
 | `direct_messages_read` | Read | Read bounded recent direct-message previews from a named counterpart via Lesser's one-to-one conversation lookup; defaults to compact and returns explicit `not_found` instead of scanning unrelated surfaces. |
-| `notifications_read` | Read | Read recent notifications; supports opt-in compact notification refs. |
+| `notifications_read` | Read | Read recent notifications; supports opt-in compact notification refs and secondary actor/source filtering. |
 | `notification_get` | Read | Expand a compact notification ref through Lesser's notification read route. |
 | `post_create` | Write | Create a new post. |
 | `post_boost` | Write | Boost/reblog a post. |
@@ -431,6 +431,9 @@ index/ref pages and expand only the items they need:
   follow `targetPostRef.expand` through `post_get` only when that expansion is present. For remote/generated
   notification target snapshots where the target id is not a direct Lesser status lookup key, use the notification ref's
   `notification_get` expansion as the reliable snapshot path.
+- `notifications_read({"actor":"ops","limit":10,"view":"compact"})` is a secondary discovery aid for "things from
+  Ops". It filters the normalized notification actor/source after a bounded Lesser over-fetch and declares the strategy
+  under `structuredContent.data.filter`. Use `direct_messages_read(counterpart=...)` as the primary DM retrieval path.
 - `conversations_read({"limit":10,"view":"compact"})` returns conversation refs with bounded participant and last-post
   metadata. Use `conversation_get({"conversationId":"<conversation-id>","limit":20,"view":"compact"})` to expand one
   conversation into recent message previews. `lastPostRef` can still expand through `post_get` when Lesser supplies a
@@ -519,6 +522,14 @@ Notes:
   read requests cannot amplify one MCP call into an unbounded backend query set. The `communication:inbound` type is
   available only in the `souled` runtime profile; drone-profile callers receive a runtime-boundary tool error for
   explicit communication filters, and untyped drone reads omit communication rows.
+- `notifications_read.actor` is optional and additive. It filters MCP-side on normalized social actor metadata
+  (`actor.id`, `actor.username`, `actor.acct`, `actor.url`, plus target-post author metadata where present) and
+  host-backed communication sender metadata (`communication.from.soulAgentId`, `agentId`, `email`/`address`, and
+  `identifier` where Lesser/host include it). Because Lesser does not yet expose an upstream actor filter, body
+  over-fetches a bounded notification page (`min(limit*4, 80)`) and returns
+  `structuredContent.data.filter.strategy="mcp_side_overfetch"` with `requestedLimit`, `overFetchLimit`,
+  `upstreamCount`, `matchedCount`, and `returnedCount`. Actor-filtered compact reads still use the normal compact
+  budget and return `response_too_large` rather than silently dropping fields.
 - `notifications_read` omits full upstream `raw` notification objects by default and accepts optional
   `include_raw=true`, which returns `_raw` on each notification for expensive audit/debug use. Default notifications
   contain compact `actor`, bounded `targetPost`, optional bounded `communication` summaries, normalized read state

--- a/internal/mcpapp/social_tools_test.go
+++ b/internal/mcpapp/social_tools_test.go
@@ -121,6 +121,9 @@ func TestM5_ToolsListContainsCoreTools(t *testing.T) {
 	if propType, _ := notificationSchema.Properties["include_diagnostics"]["type"].(string); propType != "boolean" {
 		t.Fatalf("notifications_read include_diagnostics should be boolean, got %+v", notificationSchema.Properties["include_diagnostics"])
 	}
+	if propType, _ := notificationSchema.Properties["actor"]["type"].(string); propType != "string" {
+		t.Fatalf("notifications_read actor should be string, got %+v", notificationSchema.Properties["actor"])
+	}
 	typesProp := notificationSchema.Properties["types"]
 	items, _ := typesProp["items"].(map[string]any)
 	enum, _ := items["enum"].([]any)
@@ -1892,6 +1895,161 @@ func TestM5_NotificationsReadReturnsStructuredNotifications(t *testing.T) {
 	favourite, _ := notifications[0].(map[string]any)
 	if favourite["type"] != "favourite" {
 		t.Fatalf("expected favourite notification type, got %+v", favourite)
+	}
+}
+
+func TestM5_NotificationsReadActorFilterOverfetchesAndMatchesSources(t *testing.T) {
+	t.Setenv("MCP_SESSION_TABLE", "")
+	t.Setenv("JWT_SECRET", "test")
+	installSoulBindingLookup(t, "agent1", "0x1111111111111111111111111111111111111111111111111111111111111111")
+	auth.ResetForTests()
+
+	const contentTail = "NOTIFICATION_ACTOR_FILTER_FULL_CONTENT_SHOULD_NOT_APPEAR"
+	var gotQueries []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/api/v1/notifications" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		if r.URL.Query().Get("actor") != "" {
+			t.Fatalf("actor filter should be MCP-side, not forwarded upstream: %q", r.URL.RawQuery)
+		}
+		gotQueries = append(gotQueries, r.URL.RawQuery)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[
+			{
+				"id":"n-ops",
+				"type":"mention",
+				"created_at":"2026-05-18T12:00:00Z",
+				"account":{"id":"acct-ops","username":"ops","acct":"ops@example.com","display_name":"Ops","url":"https://example.com/@ops"},
+				"status":{"id":"post-ops","content":"` + strings.Repeat("ops notification content ", 20) + contentTail + `","visibility":"public"}
+			},
+			{
+				"id":"n-sentinel",
+				"type":"reply",
+				"created_at":"2026-05-18T11:00:00Z",
+				"account":{"id":"acct-sentinel","username":"sentinel","acct":"sentinel@remote.example","display_name":"Sentinel","url":"https://remote.example/users/sentinel"},
+				"status":{"id":"post-sentinel","content":"sentinel reply","visibility":"public"}
+			},
+			{
+				"id":"n-medic-email",
+				"type":"communication:inbound",
+				"created_at":"2026-05-18T10:00:00Z",
+				"channel":"email",
+				"messageId":"comm-medic",
+				"from":{"name":"Medic","address":"medic@lessersoul.ai","email":"medic@lessersoul.ai","soulAgentId":"agent://medic","identifier":"medic"},
+				"subject":"Medic check-in",
+				"body":"` + strings.Repeat("medic body ", 40) + contentTail + `"
+			},
+			{
+				"id":"n-other",
+				"type":"mention",
+				"created_at":"2026-05-18T09:00:00Z",
+				"account":{"id":"acct-other","username":"other","acct":"other@example.com","url":"https://example.com/@other"},
+				"status":{"id":"post-other","content":"other notification","visibility":"public"}
+			}
+		]`))
+	}))
+	defer server.Close()
+
+	t.Setenv("LESSER_API_BASE_URL", server.URL)
+	lesserapi.ResetForTests()
+
+	app, env, sessionID, authHeader := newSocialToolTestSession(t)
+
+	ops := callSocialTool(t, env, app, authHeader, sessionID, 2, "notifications_read", map[string]any{
+		"actor":            "ops",
+		"limit":            2,
+		"view":             "compact",
+		"preview_chars":    24,
+		"max_output_bytes": 8000,
+	})
+	if ops.Result.IsError {
+		t.Fatalf("notifications_read actor=ops returned tool error: %+v body=%s", ops.Result.StructuredContent, string(ops.ResponseBody))
+	}
+	if gotQueries[0] != "limit=8" {
+		t.Fatalf("expected actor filter to over-fetch bounded Lesser page with limit=8, got %q", gotQueries[0])
+	}
+	if strings.Contains(string(ops.ResponseBody), contentTail) {
+		t.Fatalf("compact actor-filtered notifications leaked full content: %s", string(ops.ResponseBody))
+	}
+	assertMCPPayloadBudget(t, "notifications_read actor compact", len(ops.ResponseBody), 8000)
+	opsData, _ := ops.Result.StructuredContent["data"].(map[string]any)
+	if opsData["count"] != float64(1) {
+		t.Fatalf("expected one Ops notification, got %+v", opsData)
+	}
+	filter, _ := opsData["filter"].(map[string]any)
+	if filter["actor"] != "ops" || filter["strategy"] != "mcp_side_overfetch" || filter["requestedLimit"] != float64(2) || filter["overFetchLimit"] != float64(8) || filter["upstreamCount"] != float64(4) || filter["matchedCount"] != float64(1) || filter["returnedCount"] != float64(1) {
+		t.Fatalf("unexpected actor filter metadata: %+v", filter)
+	}
+	notifications, _ := opsData["notifications"].([]any)
+	first, _ := notifications[0].(map[string]any)
+	actorRef, _ := first["actorRef"].(map[string]any)
+	if first["id"] != "n-ops" || actorRef["acct"] != "ops@example.com" {
+		t.Fatalf("expected Ops compact notification ref, got %+v", first)
+	}
+
+	actorURL := callSocialTool(t, env, app, authHeader, sessionID, 3, "notifications_read", map[string]any{
+		"actor": "https://remote.example/users/sentinel",
+		"limit": 2,
+		"view":  "compact",
+	})
+	if actorURL.Result.IsError {
+		t.Fatalf("notifications_read actor URL returned tool error: %+v", actorURL.Result.StructuredContent)
+	}
+	actorURLData, _ := actorURL.Result.StructuredContent["data"].(map[string]any)
+	actorURLNotifications, _ := actorURLData["notifications"].([]any)
+	actorURLFirst, _ := actorURLNotifications[0].(map[string]any)
+	if actorURLData["count"] != float64(1) || actorURLFirst["id"] != "n-sentinel" {
+		t.Fatalf("expected actor URL to match sentinel notification, got %+v", actorURLData)
+	}
+
+	comm := callSocialTool(t, env, app, authHeader, sessionID, 4, "notifications_read", map[string]any{
+		"actor": "medic@lessersoul.ai",
+		"limit": 2,
+		"view":  "compact",
+	})
+	if comm.Result.IsError {
+		t.Fatalf("notifications_read actor=medic email returned tool error: %+v", comm.Result.StructuredContent)
+	}
+	commData, _ := comm.Result.StructuredContent["data"].(map[string]any)
+	commNotifications, _ := commData["notifications"].([]any)
+	commFirst, _ := commNotifications[0].(map[string]any)
+	communication, _ := commFirst["communication"].(map[string]any)
+	from, _ := communication["from"].(map[string]any)
+	if commData["count"] != float64(1) || commFirst["id"] != "n-medic-email" || from["soulAgentId"] != "agent://medic" {
+		t.Fatalf("expected communication sender metadata match, got data=%+v first=%+v", commData, commFirst)
+	}
+
+	missing := callSocialTool(t, env, app, authHeader, sessionID, 5, "notifications_read", map[string]any{
+		"actor": "not-a-sender",
+		"limit": 2,
+		"view":  "compact",
+	})
+	if missing.Result.IsError {
+		t.Fatalf("notifications_read actor=no-match returned tool error: %+v", missing.Result.StructuredContent)
+	}
+	missingData, _ := missing.Result.StructuredContent["data"].(map[string]any)
+	missingFilter, _ := missingData["filter"].(map[string]any)
+	if missingData["count"] != float64(0) || missingFilter["matchedCount"] != float64(0) {
+		t.Fatalf("expected no-match actor filter metadata, got %+v", missingData)
+	}
+
+	tooLarge := callSocialTool(t, env, app, authHeader, sessionID, 6, "notifications_read", map[string]any{
+		"actor":            "ops",
+		"limit":            2,
+		"view":             "compact",
+		"max_output_bytes": 300,
+	})
+	if !tooLarge.Result.IsError {
+		t.Fatalf("expected actor-filtered compact response_too_large tool error, got %+v", tooLarge.Result)
+	}
+	errorPayload, _ := tooLarge.Result.StructuredContent["error"].(map[string]any)
+	if errorPayload["code"] != "response_too_large" || errorPayload["status"] != float64(413) {
+		t.Fatalf("unexpected too-large error payload: %+v", errorPayload)
+	}
+	details, _ := errorPayload["details"].(map[string]any)
+	if details["tool"] != "notifications_read" || details["maxOutputBytes"] != float64(300) {
+		t.Fatalf("unexpected too-large details: %+v", details)
 	}
 }
 

--- a/internal/mcpapp/social_tools_test.go
+++ b/internal/mcpapp/social_tools_test.go
@@ -1915,6 +1915,7 @@ func TestM5_NotificationsReadActorFilterOverfetchesAndMatchesSources(t *testing.
 		}
 		gotQueries = append(gotQueries, r.URL.RawQuery)
 		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Link", `<https://example.com/api/v1/notifications?max_id=cursor-after-window>; rel="next"`)
 		_, _ = w.Write([]byte(`[
 			{
 				"id":"n-ops",
@@ -1922,6 +1923,20 @@ func TestM5_NotificationsReadActorFilterOverfetchesAndMatchesSources(t *testing.
 				"created_at":"2026-05-18T12:00:00Z",
 				"account":{"id":"acct-ops","username":"ops","acct":"ops@example.com","display_name":"Ops","url":"https://example.com/@ops"},
 				"status":{"id":"post-ops","content":"` + strings.Repeat("ops notification content ", 20) + contentTail + `","visibility":"public"}
+			},
+			{
+				"id":"n-ops-2",
+				"type":"reply",
+				"created_at":"2026-05-18T11:30:00Z",
+				"account":{"id":"acct-ops","username":"ops","acct":"ops@example.com","display_name":"Ops","url":"https://example.com/@ops"},
+				"status":{"id":"post-ops-2","content":"ops reply","visibility":"public"}
+			},
+			{
+				"id":"n-ops-3",
+				"type":"favourite",
+				"created_at":"2026-05-18T11:15:00Z",
+				"account":{"id":"acct-ops","username":"ops","acct":"ops@example.com","display_name":"Ops","url":"https://example.com/@ops"},
+				"status":{"id":"post-ops-3","content":"ops favourite","visibility":"public"}
 			},
 			{
 				"id":"n-sentinel",
@@ -1974,11 +1989,11 @@ func TestM5_NotificationsReadActorFilterOverfetchesAndMatchesSources(t *testing.
 	}
 	assertMCPPayloadBudget(t, "notifications_read actor compact", len(ops.ResponseBody), 8000)
 	opsData, _ := ops.Result.StructuredContent["data"].(map[string]any)
-	if opsData["count"] != float64(1) {
-		t.Fatalf("expected one Ops notification, got %+v", opsData)
+	if opsData["count"] != float64(2) {
+		t.Fatalf("expected two Ops notifications, got %+v", opsData)
 	}
 	filter, _ := opsData["filter"].(map[string]any)
-	if filter["actor"] != "ops" || filter["strategy"] != "mcp_side_overfetch" || filter["requestedLimit"] != float64(2) || filter["overFetchLimit"] != float64(8) || filter["upstreamCount"] != float64(4) || filter["matchedCount"] != float64(1) || filter["returnedCount"] != float64(1) {
+	if filter["actor"] != "ops" || filter["strategy"] != "mcp_side_overfetch" || filter["requestedLimit"] != float64(2) || filter["overFetchLimit"] != float64(8) || filter["upstreamCount"] != float64(6) || filter["matchedCount"] != float64(3) || filter["returnedCount"] != float64(2) || filter["continuation"] != "same_overfetch_window" || filter["sameWindowRemainder"] != float64(1) {
 		t.Fatalf("unexpected actor filter metadata: %+v", filter)
 	}
 	notifications, _ := opsData["notifications"].([]any)
@@ -1986,6 +2001,33 @@ func TestM5_NotificationsReadActorFilterOverfetchesAndMatchesSources(t *testing.
 	actorRef, _ := first["actorRef"].(map[string]any)
 	if first["id"] != "n-ops" || actorRef["acct"] != "ops@example.com" {
 		t.Fatalf("expected Ops compact notification ref, got %+v", first)
+	}
+	sameWindowCursor, _ := opsData["nextCursor"].(string)
+	if !strings.HasPrefix(sameWindowCursor, "actor-filter:v1:") {
+		t.Fatalf("expected generated same-window actor cursor, got %+v", opsData)
+	}
+
+	opsContinuation := callSocialTool(t, env, app, authHeader, sessionID, 7, "notifications_read", map[string]any{
+		"actor":  "ops",
+		"limit":  2,
+		"view":   "compact",
+		"cursor": sameWindowCursor,
+	})
+	if opsContinuation.Result.IsError {
+		t.Fatalf("notifications_read actor continuation returned tool error: %+v", opsContinuation.Result.StructuredContent)
+	}
+	if gotQueries[len(gotQueries)-1] != "limit=8" {
+		t.Fatalf("same-window actor cursor should re-read the same over-fetch window before advancing, got %q", gotQueries[len(gotQueries)-1])
+	}
+	continuationData, _ := opsContinuation.Result.StructuredContent["data"].(map[string]any)
+	continuationFilter, _ := continuationData["filter"].(map[string]any)
+	if continuationData["count"] != float64(1) || continuationFilter["windowOffset"] != float64(2) || continuationFilter["continuation"] != "upstream_cursor" || continuationData["nextCursor"] != "cursor-after-window" {
+		t.Fatalf("expected continuation to return remaining Ops match before upstream cursor, got %+v filter=%+v", continuationData, continuationFilter)
+	}
+	continuationNotifications, _ := continuationData["notifications"].([]any)
+	continuationFirst, _ := continuationNotifications[0].(map[string]any)
+	if continuationFirst["id"] != "n-ops-3" {
+		t.Fatalf("expected remaining same-window Ops match, got %+v", continuationFirst)
 	}
 
 	actorURL := callSocialTool(t, env, app, authHeader, sessionID, 3, "notifications_read", map[string]any{

--- a/internal/mcpserver/social_tools.go
+++ b/internal/mcpserver/social_tools.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -27,6 +28,7 @@ const (
 	notificationCursorMemoryPrefix       = "notification_cursor:"
 	notificationCursorMemoryTag          = "notification_cursor"
 	notificationCommunicationInbound     = "communication:inbound"
+	notificationActorFilterCursorPrefix  = "actor-filter:v1:"
 	notificationReadDefaultLimit         = 30
 	notificationReadMaxLimit             = 80
 	notificationReadMaxTypes             = 8
@@ -1455,6 +1457,15 @@ func handleNotificationsRead(ctx context.Context, args json.RawMessage) (*mcprun
 	if explicitSince && requestedSince != "" && !hasTemporalSince && effectiveCursor == "" {
 		effectiveCursor = requestedSince
 	}
+	actorCursorOffset := 0
+	if actorFilter.Active {
+		parsedCursor, parsedOffset, err := parseNotificationActorFilterCursor(effectiveCursor, actorFilter)
+		if err != nil {
+			return nil, invalidParams(err.Error())
+		}
+		effectiveCursor = parsedCursor
+		actorCursorOffset = parsedOffset
+	}
 
 	token, err := requireOAuthBearer(ctx)
 	if err != nil {
@@ -1485,12 +1496,25 @@ func handleNotificationsRead(ctx context.Context, args json.RawMessage) (*mcprun
 		notifications = filterSocialNotificationsByType(notifications, requestedTypes)
 	}
 	actorMatchedCount := 0
+	actorSameWindowCursor := ""
 	if actorFilter.Active {
 		notifications = filterSocialNotificationsByActor(notifications, actorFilter)
 		actorMatchedCount = len(notifications)
 	}
 	sortSocialNotificationsNewestFirst(notifications)
-	if len(notifications) > limit {
+	if actorFilter.Active {
+		if actorCursorOffset > len(notifications) {
+			notifications = nil
+		} else {
+			notifications = notifications[actorCursorOffset:]
+		}
+		if len(notifications) > limit {
+			if cursor := notificationActorFilterCursor(actorFilter, effectiveCursor, actorCursorOffset+limit); cursor != "" {
+				actorSameWindowCursor = cursor
+			}
+			notifications = notifications[:limit]
+		}
+	} else if len(notifications) > limit {
 		notifications = notifications[:limit]
 	}
 
@@ -1524,7 +1548,10 @@ func handleNotificationsRead(ctx context.Context, args json.RawMessage) (*mcprun
 		"includeRaw":    includeRaw,
 	}
 	if actorFilter.Active {
-		payload["filter"] = notificationActorFilterMetadata(actorFilter, fetchLimit, limit, len(list), actorMatchedCount, len(notifications))
+		if actorSameWindowCursor != "" {
+			payload["nextCursor"] = actorSameWindowCursor
+		}
+		payload["filter"] = notificationActorFilterMetadata(actorFilter, fetchLimit, limit, len(list), actorMatchedCount, len(notifications), actorCursorOffset, actorSameWindowCursor != "")
 	}
 	if in.IncludeDiagnostics {
 		attachNotificationReadDiagnostics(payload, notificationReadDiagnostics{
@@ -2818,6 +2845,13 @@ type notificationActorFilter struct {
 	Candidates map[string]struct{}
 }
 
+type notificationActorFilterCursorPayload struct {
+	Version        int    `json:"v"`
+	Actor          string `json:"actor"`
+	UpstreamCursor string `json:"upstreamCursor,omitempty"`
+	Offset         int    `json:"offset,omitempty"`
+}
+
 func newNotificationActorFilter(raw string) notificationActorFilter {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
@@ -2840,6 +2874,58 @@ func notificationActorFilterFetchLimit(limit int) int {
 	return boundedNotificationReadLimit(overFetch)
 }
 
+func parseNotificationActorFilterCursor(cursor string, filter notificationActorFilter) (string, int, error) {
+	cursor = strings.TrimSpace(cursor)
+	if cursor == "" || !strings.HasPrefix(cursor, notificationActorFilterCursorPrefix) {
+		return cursor, 0, nil
+	}
+	encoded := strings.TrimPrefix(cursor, notificationActorFilterCursorPrefix)
+	decoded, err := base64.RawURLEncoding.DecodeString(encoded)
+	if err != nil {
+		return "", 0, fmt.Errorf("invalid actor filter cursor")
+	}
+	var payload notificationActorFilterCursorPayload
+	if err := json.Unmarshal(decoded, &payload); err != nil {
+		return "", 0, fmt.Errorf("invalid actor filter cursor")
+	}
+	if payload.Version != 1 || payload.Offset < 0 {
+		return "", 0, fmt.Errorf("invalid actor filter cursor")
+	}
+	if !notificationActorFilterSameActor(payload.Actor, filter) {
+		return "", 0, fmt.Errorf("actor filter cursor does not match actor")
+	}
+	return strings.TrimSpace(payload.UpstreamCursor), payload.Offset, nil
+}
+
+func notificationActorFilterCursor(filter notificationActorFilter, upstreamCursor string, offset int) string {
+	if !filter.Active || offset <= 0 {
+		return ""
+	}
+	payload := notificationActorFilterCursorPayload{
+		Version:        1,
+		Actor:          filter.Raw,
+		UpstreamCursor: strings.TrimSpace(upstreamCursor),
+		Offset:         offset,
+	}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return ""
+	}
+	return notificationActorFilterCursorPrefix + base64.RawURLEncoding.EncodeToString(b)
+}
+
+func notificationActorFilterSameActor(actor string, filter notificationActorFilter) bool {
+	if !filter.Active {
+		return false
+	}
+	for candidate := range notificationActorFilterCandidates(actor) {
+		if _, ok := filter.Candidates[candidate]; ok {
+			return true
+		}
+	}
+	return false
+}
+
 func filterSocialNotificationsByActor(items []any, filter notificationActorFilter) []any {
 	if !filter.Active || len(items) == 0 {
 		return items
@@ -2854,8 +2940,12 @@ func filterSocialNotificationsByActor(items []any, filter notificationActorFilte
 	return out
 }
 
-func notificationActorFilterMetadata(filter notificationActorFilter, overFetchLimit int, requestedLimit int, upstreamCount int, matchedCount int, returnedCount int) map[string]any {
-	return map[string]any{
+func notificationActorFilterMetadata(filter notificationActorFilter, overFetchLimit int, requestedLimit int, upstreamCount int, matchedCount int, returnedCount int, windowOffset int, sameWindowContinuation bool) map[string]any {
+	continuation := "upstream_cursor"
+	if sameWindowContinuation {
+		continuation = "same_overfetch_window"
+	}
+	out := map[string]any{
 		"actor":          filter.Raw,
 		"strategy":       "mcp_side_overfetch",
 		"requestedLimit": requestedLimit,
@@ -2863,6 +2953,8 @@ func notificationActorFilterMetadata(filter notificationActorFilter, overFetchLi
 		"upstreamCount":  upstreamCount,
 		"matchedCount":   matchedCount,
 		"returnedCount":  returnedCount,
+		"windowOffset":   windowOffset,
+		"continuation":   continuation,
 		"matchFields": []any{
 			"actor.id",
 			"actor.username",
@@ -2876,6 +2968,10 @@ func notificationActorFilterMetadata(filter notificationActorFilter, overFetchLi
 			"communication.from.identifier",
 		},
 	}
+	if sameWindowContinuation {
+		out["sameWindowRemainder"] = matchedCount - (windowOffset + returnedCount)
+	}
+	return out
 }
 
 func notificationActorMatches(notification map[string]any, filter notificationActorFilter) bool {

--- a/internal/mcpserver/social_tools.go
+++ b/internal/mcpserver/social_tools.go
@@ -1417,6 +1417,7 @@ func handleNotificationsRead(ctx context.Context, args json.RawMessage) (*mcprun
 
 	var in struct {
 		Types              []string `json:"types,omitempty"`
+		Actor              string   `json:"actor,omitempty"`
 		Since              *string  `json:"since"`
 		Cursor             string   `json:"cursor,omitempty"`
 		Limit              int      `json:"limit,omitempty"`
@@ -1440,6 +1441,11 @@ func handleNotificationsRead(ctx context.Context, args json.RawMessage) (*mcprun
 		})
 	}
 	limit := boundedNotificationReadLimit(in.Limit)
+	actorFilter := newNotificationActorFilter(in.Actor)
+	fetchLimit := limit
+	if actorFilter.Active {
+		fetchLimit = notificationActorFilterFetchLimit(limit)
+	}
 	explicitSince := in.Since != nil
 	requestedSince := trimDeref(in.Since)
 	effectiveSince := requestedSince
@@ -1460,7 +1466,7 @@ func handleNotificationsRead(ctx context.Context, args json.RawMessage) (*mcprun
 	}
 
 	apiStartedAt := time.Now()
-	list, nextCursor, err := readSocialNotifications(ctx, client, token, upstreamTypes, limit, effectiveCursor)
+	list, nextCursor, err := readSocialNotifications(ctx, client, token, upstreamTypes, fetchLimit, effectiveCursor)
 	apiDuration := time.Since(apiStartedAt)
 	if err != nil {
 		return authToolResultFromError(err)
@@ -1477,6 +1483,11 @@ func handleNotificationsRead(ctx context.Context, args json.RawMessage) (*mcprun
 	}
 	if len(requestedTypes) > 0 {
 		notifications = filterSocialNotificationsByType(notifications, requestedTypes)
+	}
+	actorMatchedCount := 0
+	if actorFilter.Active {
+		notifications = filterSocialNotificationsByActor(notifications, actorFilter)
+		actorMatchedCount = len(notifications)
 	}
 	sortSocialNotificationsNewestFirst(notifications)
 	if len(notifications) > limit {
@@ -1511,6 +1522,9 @@ func handleNotificationsRead(ctx context.Context, args json.RawMessage) (*mcprun
 		"types":         requestedTypes,
 		"notifications": notifications,
 		"includeRaw":    includeRaw,
+	}
+	if actorFilter.Active {
+		payload["filter"] = notificationActorFilterMetadata(actorFilter, fetchLimit, limit, len(list), actorMatchedCount, len(notifications))
 	}
 	if in.IncludeDiagnostics {
 		attachNotificationReadDiagnostics(payload, notificationReadDiagnostics{
@@ -1639,6 +1653,9 @@ func socialCompactNotificationsResult(standardPayload map[string]any, notificati
 			"contentPreviewRunes": previewRunes,
 			"enforcement":         "response_too_large",
 		},
+	}
+	if filter, ok := standardPayload["filter"].(map[string]any); ok {
+		payload["filter"] = filter
 	}
 
 	diagnostics := map[string]any(nil)
@@ -2196,11 +2213,12 @@ func followingListDef() mcpruntime.ToolDef {
 func notificationsReadDef() mcpruntime.ToolDef {
 	return mcpruntime.ToolDef{
 		Name:        "notifications_read",
-		Description: "Read recent social notifications with normalized actor and target post data.",
+		Description: "Read recent social notifications with normalized actor/source and target post data. Optional actor filtering is MCP-side and bounded; use direct_messages_read as the primary DM retrieval path.",
 		InputSchema: json.RawMessage(`{
 			"type":"object",
 			"properties":{
 				"types":{"type":"array","maxItems":8,"description":"Optional normalized notification types to return. Supported values include communication:inbound for host-backed inbound email/SMS/voice notifications; favorite is accepted as an alias for favourite. At most 8 values may be supplied; duplicates still count against the request budget.","items":{"type":"string","enum":["mention","reply","favourite","favorite","reblog","follow","follow_request","poll","status","update","admin.sign_up","admin.report","communication:inbound"]}},
+				"actor":{"type":"string","description":"Optional MCP-side actor/source filter. Matches normalized social actor id, username/local id, acct, or actor URL; communication notifications match available sender soul agent id, agent id, email/address, or identifier metadata. Body over-fetches bounded notification pages from Lesser and declares the strategy in the response."},
 				"since":{"type":"string"},
 				"cursor":{"type":"string"},
 				"limit":{"type":"integer","minimum":1,"maximum":80},
@@ -2794,6 +2812,171 @@ func filterSocialNotificationsByType(items []any, want []string) []any {
 	return out
 }
 
+type notificationActorFilter struct {
+	Raw        string
+	Active     bool
+	Candidates map[string]struct{}
+}
+
+func newNotificationActorFilter(raw string) notificationActorFilter {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return notificationActorFilter{}
+	}
+	candidates := notificationActorFilterCandidates(raw)
+	return notificationActorFilter{
+		Raw:        raw,
+		Active:     len(candidates) > 0,
+		Candidates: candidates,
+	}
+}
+
+func notificationActorFilterFetchLimit(limit int) int {
+	limit = boundedNotificationReadLimit(limit)
+	overFetch := limit * 4
+	if overFetch < limit {
+		overFetch = limit
+	}
+	return boundedNotificationReadLimit(overFetch)
+}
+
+func filterSocialNotificationsByActor(items []any, filter notificationActorFilter) []any {
+	if !filter.Active || len(items) == 0 {
+		return items
+	}
+	out := make([]any, 0, len(items))
+	for _, item := range items {
+		notification, _ := item.(map[string]any)
+		if notificationActorMatches(notification, filter) {
+			out = append(out, notification)
+		}
+	}
+	return out
+}
+
+func notificationActorFilterMetadata(filter notificationActorFilter, overFetchLimit int, requestedLimit int, upstreamCount int, matchedCount int, returnedCount int) map[string]any {
+	return map[string]any{
+		"actor":          filter.Raw,
+		"strategy":       "mcp_side_overfetch",
+		"requestedLimit": requestedLimit,
+		"overFetchLimit": overFetchLimit,
+		"upstreamCount":  upstreamCount,
+		"matchedCount":   matchedCount,
+		"returnedCount":  returnedCount,
+		"matchFields": []any{
+			"actor.id",
+			"actor.username",
+			"actor.acct",
+			"actor.url",
+			"targetPost.author.*",
+			"communication.from.soulAgentId",
+			"communication.from.agentId",
+			"communication.from.email",
+			"communication.from.address",
+			"communication.from.identifier",
+		},
+	}
+}
+
+func notificationActorMatches(notification map[string]any, filter notificationActorFilter) bool {
+	if notification == nil || !filter.Active {
+		return false
+	}
+	for _, actor := range []map[string]any{
+		firstMap(notification, "actor", "account"),
+		firstMap(firstMap(notification, "targetPost", "status", "post"), "author", "account", "actor"),
+		firstMap(firstMap(notification, "communication"), "from"),
+	} {
+		if notificationActorMapMatches(actor, filter.Candidates) {
+			return true
+		}
+	}
+	return false
+}
+
+func notificationActorMapMatches(raw map[string]any, candidates map[string]struct{}) bool {
+	if raw == nil || len(candidates) == 0 {
+		return false
+	}
+	for _, key := range []string{
+		"id",
+		"username",
+		"acct",
+		"url",
+		"uri",
+		"actorUrl",
+		"actorURL",
+		"actor_url",
+		"soulAgentId",
+		"soul_agent_id",
+		"agentId",
+		"agentID",
+		"agent_id",
+		"email",
+		"address",
+		"identifier",
+		"name",
+	} {
+		if notificationActorValueMatches(firstNonEmptyStringMap(raw, key), candidates) {
+			return true
+		}
+	}
+	return false
+}
+
+func notificationActorValueMatches(value string, candidates map[string]struct{}) bool {
+	for candidate := range notificationActorFilterCandidates(value) {
+		if _, ok := candidates[candidate]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func notificationActorFilterCandidates(value string) map[string]struct{} {
+	out := map[string]struct{}{}
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return out
+	}
+	add := func(candidate string) {
+		candidate = normalizeNotificationActorCandidate(candidate)
+		if candidate != "" {
+			out[candidate] = struct{}{}
+		}
+	}
+
+	add(value)
+	add(strings.TrimPrefix(value, "@"))
+
+	withoutAt := strings.TrimPrefix(strings.TrimSpace(value), "@")
+	if at := strings.Index(withoutAt, "@"); at > 0 {
+		add(withoutAt[:at])
+		add(withoutAt)
+	}
+
+	if parsed, err := url.Parse(value); err == nil && parsed.Scheme != "" && parsed.Host != "" {
+		add(parsed.String())
+		add(parsed.Host + parsed.EscapedPath())
+		parts := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+		if len(parts) > 0 {
+			add(strings.TrimPrefix(parts[len(parts)-1], "@"))
+		}
+	}
+
+	return out
+}
+
+func normalizeNotificationActorCandidate(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	value = strings.TrimPrefix(value, "@")
+	value = strings.TrimRight(value, "/")
+	return strings.ToLower(value)
+}
+
 func filterSocialNotificationsAfter(items []any, since time.Time) []any {
 	if since.IsZero() {
 		return items
@@ -2963,7 +3146,7 @@ func normalizeSocialNotificationActor(raw map[string]any) map[string]any {
 	putIfNotEmpty(out, "username", firstNonEmptyStringMap(raw, "username"))
 	putIfNotEmpty(out, "acct", firstNonEmptyStringMap(raw, "acct"))
 	putIfNotEmpty(out, "displayName", firstNonEmptyStringMap(raw, "display_name", "displayName"))
-	putIfNotEmpty(out, "url", firstNonEmptyStringMap(raw, "url"))
+	putIfNotEmpty(out, "url", firstNonEmptyStringMap(raw, "url", "uri", "actorUrl", "actorURL", "actor_url"))
 	putIfNotEmpty(out, "avatar", firstNonEmptyStringMap(raw, "avatar", "avatar_static", "avatarStatic"))
 	if len(out) == 0 {
 		return nil


### PR DESCRIPTION
## Milestone
Project 35 M3 — `notifications_read` actor/source filtering as a secondary discovery aid.

## Classification
MCP-contract / tool-surface / lesser-integration / docs / test-coverage.

## Surfaces affected
- `notifications_read` input schema and behavior.
- `docs/mcp.md` notification workflow and tool catalog notes.
- Lesser REST API consumption stays on existing `GET /api/v1/notifications`; actor filtering is MCP-side bounded over-fetch.

## Specialist walks referenced
- Tool surface: modifies existing read-scoped social tool only; no scope/profile change, no side effects.
- MCP contract: additive optional `actor` input and additive `structuredContent.data.filter` response metadata when used.
- Lesser integration: no new Lesser endpoint required; body over-fetches bounded notification pages (`min(limit*4, 80)`) from the existing notifications route.
- Host delegation: no delivery/delegation change; host-backed communication notifications are only matched via normalized sender metadata already present in notification payloads.

## Consumer impact
- Existing clients unaffected unless they opt into `notifications_read.actor`.
- Actor-filtered reads declare `strategy=mcp_side_overfetch`, `requestedLimit`, `overFetchLimit`, `upstreamCount`, `matchedCount`, and `returnedCount`.
- This remains secondary discovery; `direct_messages_read(counterpart=...)` is documented as the primary DM retrieval path.

## Tasks
- [x] #258 — Add actor filter to `notifications_read`.

## Validation
- `gofmt -l .`
- `go test ./internal/mcpserver ./internal/mcpapp`
- `go test ./...`
- `go vet ./...`
- `scripts/build.sh`
- `git diff --check`

## Stage rollout plan (handoff to deploy-body)
- [ ] Merged to main
- [ ] Deployed to lab / dev
- [ ] Lab soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
No Lesser code change is required for this body milestone. If Lesser later adds an upstream actor filter, body can switch from MCP-side over-fetch to upstream query with a follow-up compatibility note.

## Issues
Closes #257.
Closes #258.
