### PR TITLE
feat(cms): add Lesser GraphQL client path

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -56,6 +56,14 @@ Notes:
   - `LESSER_API_BASE_URL` or `MCP_ENDPOINT`-derived base URL
   - calls Mastodon-compatible endpoints (for example: `/api/v1/accounts/verify_credentials`)
 
+### CMS / Article client path (internal, calls Lesser API)
+
+- `internal/cmsapi/`
+  - wraps the Lesser API client for `POST /api/graphql`
+  - forwards the caller's OAuth bearer token to Lesser and preserves Lesser HTTP errors through `lesserapi.APIError`
+  - preserves GraphQL `data`, `errors`, and `extensions` without encoding Article-specific operations yet
+  - exists so future Article/Draft MCP tools can use Lesser's CMS contract instead of Mastodon status APIs for long-form authoring
+
 ### Communication tools (delegate to lesser-host)
 
 - `internal/soulapi/`

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -501,6 +501,10 @@ measured byte details rather than silently dropping fields.
 
 Notes:
 
+- Article / CMS authoring tools are not public MCP tools yet. `lesser-body` has an internal CMS GraphQL client boundary
+  for Lesser `POST /api/graphql`, but public Article draft/preview/publish tools remain gated on the Lesser Article
+  contract, renderer, and publish behavior stabilizing. Long-form Article authoring must not be routed through
+  Mastodon-compatible status APIs such as `post_create`.
 - Social tools require an **OAuth JWT** bearer token (not just an instance key) because they call the Lesser API on behalf
   of the authenticated agent.
 - M0 baseline read-tool policy: daily agent read paths should move toward compact, bounded defaults only after

--- a/internal/cmsapi/client.go
+++ b/internal/cmsapi/client.go
@@ -1,0 +1,115 @@
+package cmsapi
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/equaltoai/lesser-body/internal/lesserapi"
+)
+
+const graphQLEndpoint = "/api/graphql"
+
+// Client is the internal CMS/GraphQL path for Lesser Article/Draft work.
+//
+// It deliberately does not register MCP tools or encode Article-specific
+// operations. Public Article tools can layer typed operations on top once the
+// Lesser Article contract is stable.
+type Client struct {
+	lesser *lesserapi.Client
+}
+
+// Default returns a CMS client backed by the configured Lesser API client.
+func Default() (*Client, error) {
+	lesser, err := lesserapi.Default()
+	if err != nil {
+		return nil, err
+	}
+	return New(lesser)
+}
+
+// New wraps an existing Lesser API client.
+func New(lesser *lesserapi.Client) (*Client, error) {
+	if lesser == nil {
+		return nil, fmt.Errorf("lesser cms client requires lesser api client")
+	}
+	return &Client{lesser: lesser}, nil
+}
+
+// Operation is a generic GraphQL operation against Lesser's CMS schema.
+type Operation struct {
+	Query         string         `json:"query"`
+	OperationName string         `json:"operationName,omitempty"`
+	Variables     map[string]any `json:"variables,omitempty"`
+}
+
+// Response is a raw GraphQL response envelope. Data is intentionally left as
+// json.RawMessage so future Article/Draft operations can evolve independently
+// of this transport boundary.
+type Response struct {
+	Data       json.RawMessage `json:"data,omitempty"`
+	Errors     []Error         `json:"errors,omitempty"`
+	Extensions map[string]any  `json:"extensions,omitempty"`
+}
+
+// Error is a single GraphQL error item returned by Lesser.
+type Error struct {
+	Message    string         `json:"message"`
+	Locations  []Location     `json:"locations,omitempty"`
+	Path       []any          `json:"path,omitempty"`
+	Extensions map[string]any `json:"extensions,omitempty"`
+}
+
+// Location identifies a GraphQL source location for an error.
+type Location struct {
+	Line   int `json:"line,omitempty"`
+	Column int `json:"column,omitempty"`
+}
+
+// GraphQLErrors reports GraphQL-level failures from a successful HTTP response.
+type GraphQLErrors struct {
+	Errors []Error
+	Data   json.RawMessage
+}
+
+func (e *GraphQLErrors) Error() string {
+	if e == nil || len(e.Errors) == 0 {
+		return "lesser cms graphql error"
+	}
+	msg := strings.TrimSpace(e.Errors[0].Message)
+	if msg == "" {
+		msg = "unknown graphql error"
+	}
+	if len(e.Errors) == 1 {
+		return "lesser cms graphql error: " + msg
+	}
+	return fmt.Sprintf("lesser cms graphql error: %s (+%d more)", msg, len(e.Errors)-1)
+}
+
+// Execute posts a GraphQL operation to Lesser /api/graphql using the caller's
+// OAuth bearer token. HTTP failures are returned as lesserapi.APIError;
+// GraphQL errors are returned as *GraphQLErrors with the response preserved.
+func (c *Client) Execute(ctx context.Context, bearerToken string, op Operation) (*Response, error) {
+	if c == nil || c.lesser == nil {
+		return nil, fmt.Errorf("lesser cms client not initialized")
+	}
+	op.Query = strings.TrimSpace(op.Query)
+	if op.Query == "" {
+		return nil, fmt.Errorf("graphql query is required")
+	}
+
+	raw, err := c.lesser.DoRawJSON(ctx, "POST", graphQLEndpoint, nil, bearerToken, op)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp Response
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return nil, fmt.Errorf("unmarshal graphql response: %w", err)
+	}
+	if len(resp.Errors) > 0 {
+		return &resp, &GraphQLErrors{Errors: resp.Errors, Data: resp.Data}
+	}
+	return &resp, nil
+}

--- a/internal/cmsapi/client_test.go
+++ b/internal/cmsapi/client_test.go
@@ -1,0 +1,171 @@
+package cmsapi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/equaltoai/lesser-body/internal/lesserapi"
+)
+
+func TestExecutePropagatesAuthAndDecodesSuccess(t *testing.T) {
+	var gotAuth string
+	var gotOperation Operation
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/api/graphql" {
+			t.Fatalf("path = %s, want /api/graphql", r.URL.Path)
+		}
+		if got := r.Header.Get("Accept"); got != "application/json" {
+			t.Fatalf("Accept = %q, want application/json", got)
+		}
+		if got := r.Header.Get("Content-Type"); !strings.HasPrefix(got, "application/json") {
+			t.Fatalf("Content-Type = %q, want application/json", got)
+		}
+		gotAuth = r.Header.Get("Authorization")
+		if err := json.NewDecoder(r.Body).Decode(&gotOperation); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"articleDraft":{"id":"draft-123","title":"Hello"}},"extensions":{"cost":1}}`))
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server.URL)
+	resp, err := client.Execute(context.Background(), " token-abc ", Operation{
+		Query:         " query Draft($id: ID!) { articleDraft(id: $id) { id title } } ",
+		OperationName: "Draft",
+		Variables:     map[string]any{"id": "draft-123"},
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if gotAuth != "Bearer token-abc" {
+		t.Fatalf("Authorization = %q, want Bearer token-abc", gotAuth)
+	}
+	if gotOperation.Query != "query Draft($id: ID!) { articleDraft(id: $id) { id title } }" {
+		t.Fatalf("query = %q", gotOperation.Query)
+	}
+	if gotOperation.OperationName != "Draft" {
+		t.Fatalf("operationName = %q", gotOperation.OperationName)
+	}
+	if gotOperation.Variables["id"] != "draft-123" {
+		t.Fatalf("variables = %#v", gotOperation.Variables)
+	}
+
+	var data struct {
+		ArticleDraft struct {
+			ID    string `json:"id"`
+			Title string `json:"title"`
+		} `json:"articleDraft"`
+	}
+	if err := json.Unmarshal(resp.Data, &data); err != nil {
+		t.Fatalf("unmarshal data: %v", err)
+	}
+	if data.ArticleDraft.ID != "draft-123" || data.ArticleDraft.Title != "Hello" {
+		t.Fatalf("decoded data = %#v", data.ArticleDraft)
+	}
+	if resp.Extensions["cost"].(float64) != 1 {
+		t.Fatalf("extensions = %#v", resp.Extensions)
+	}
+}
+
+func TestExecuteReturnsGraphQLErrorsWithResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"articleDraft":null},"errors":[{"message":"draft not found","path":["articleDraft"],"extensions":{"code":"NOT_FOUND"}}]}`))
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server.URL)
+	resp, err := client.Execute(context.Background(), "token", Operation{Query: "query { articleDraft(id: \"missing\") { id } }"})
+	if err == nil {
+		t.Fatalf("expected GraphQLErrors")
+	}
+	var gqlErr *GraphQLErrors
+	if !errors.As(err, &gqlErr) {
+		t.Fatalf("expected *GraphQLErrors, got %T: %v", err, err)
+	}
+	if !strings.Contains(err.Error(), "draft not found") {
+		t.Fatalf("error string = %q", err.Error())
+	}
+	if resp == nil || len(resp.Errors) != 1 {
+		t.Fatalf("response/errors = %#v", resp)
+	}
+	if string(gqlErr.Data) != `{"articleDraft":null}` {
+		t.Fatalf("error data = %s", string(gqlErr.Data))
+	}
+}
+
+func TestExecuteReturnsHTTPAPIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"error":"unavailable"}`, http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server.URL)
+	_, err := client.Execute(context.Background(), "token", Operation{Query: "query { viewer { id } }"})
+	if err == nil {
+		t.Fatalf("expected HTTP error")
+	}
+	var apiErr *lesserapi.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected *lesserapi.APIError, got %T: %v", err, err)
+	}
+	if apiErr.Status != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d", apiErr.Status)
+	}
+}
+
+func TestExecuteValidatesQueryBeforeRequest(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server.URL)
+	_, err := client.Execute(context.Background(), "token", Operation{Query: " \t\n "})
+	if err == nil || !strings.Contains(err.Error(), "graphql query is required") {
+		t.Fatalf("expected query validation error, got %v", err)
+	}
+	if requests != 0 {
+		t.Fatalf("requests = %d, want 0", requests)
+	}
+}
+
+func TestExecuteRejectsMalformedGraphQLResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`not-json`))
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server.URL)
+	_, err := client.Execute(context.Background(), "token", Operation{Query: "query { viewer { id } }"})
+	if err == nil || !strings.Contains(err.Error(), "unmarshal graphql response") {
+		t.Fatalf("expected response unmarshal error, got %v", err)
+	}
+}
+
+func newTestClient(t *testing.T, baseURL string) *Client {
+	t.Helper()
+	t.Setenv("LESSER_API_BASE_URL", baseURL)
+	lesserapi.ResetForTests()
+	t.Cleanup(lesserapi.ResetForTests)
+
+	client, err := Default()
+	if err != nil {
+		t.Fatalf("Default: %v", err)
+	}
+	return client
+}

--- a/internal/lesserapi/client.go
+++ b/internal/lesserapi/client.go
@@ -85,6 +85,28 @@ func (c *Client) DoJSON(ctx context.Context, method string, path string, query u
 }
 
 func (c *Client) DoJSONWithHeaders(ctx context.Context, method string, path string, query url.Values, bearerToken string, body any) (any, http.Header, error) {
+	respBody, headers, err := c.DoRawJSONWithHeaders(ctx, method, path, query, bearerToken, body)
+	if err != nil {
+		return nil, headers, err
+	}
+
+	if len(respBody) == 0 {
+		return map[string]any{}, headers, nil
+	}
+
+	var out any
+	if err := json.Unmarshal(respBody, &out); err != nil {
+		return nil, nil, fmt.Errorf("unmarshal response: %w", err)
+	}
+	return out, headers, nil
+}
+
+func (c *Client) DoRawJSON(ctx context.Context, method string, path string, query url.Values, bearerToken string, body any) ([]byte, error) {
+	out, _, err := c.DoRawJSONWithHeaders(ctx, method, path, query, bearerToken, body)
+	return out, err
+}
+
+func (c *Client) DoRawJSONWithHeaders(ctx context.Context, method string, path string, query url.Values, bearerToken string, body any) ([]byte, http.Header, error) {
 	if c == nil || c.baseURL == nil || c.http == nil {
 		return nil, nil, fmt.Errorf("lesser api client not initialized")
 	}
@@ -137,16 +159,7 @@ func (c *Client) DoJSONWithHeaders(ctx context.Context, method string, path stri
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return nil, headers, &APIError{Status: resp.StatusCode, Body: respBody}
 	}
-
-	if len(respBody) == 0 {
-		return map[string]any{}, headers, nil
-	}
-
-	var out any
-	if err := json.Unmarshal(respBody, &out); err != nil {
-		return nil, nil, fmt.Errorf("unmarshal response: %w", err)
-	}
-	return out, headers, nil
+	return respBody, headers, nil
 }
 
 func resolveBaseURL() (*url.URL, error) {


### PR DESCRIPTION
## Milestone
Project 36 M5.1 — Add Lesser CMS/GraphQL client path

## Classification
lesser-integration / internal client path / docs / test-coverage

## Surfaces affected
- Adds `internal/cmsapi/` as the internal CMS GraphQL client boundary.
- Extends `internal/lesserapi.Client` with raw JSON helpers so GraphQL clients can preserve `data`, `errors`, and `extensions` without lossy `any` decoding.
- Updates docs to state that public Article tools are not registered yet and are gated on the Lesser Article contract/renderer/publish behavior.

## Specialist walks referenced
- Advisor brief: Arch assignment email `delivery-073751e3cc0c76da`, under Aron's standing authorization in the active objective.
- Lesser integration: consumes existing Lesser `POST /api/graphql` through `LESSER_API_BASE_URL`/`MCP_ENDPOINT` resolution; forwards caller OAuth bearer; no JWT validation, DynamoDB, SSM export, `soulEnabled`, or deploy-order changes.
- Tool surface: no public Article MCP tools registered; no scope/profile/tool-list change.
- MCP contract: no `.well-known/mcp.json`, OAuth metadata, or JSON-RPC shape change.
- Host delegation: not touched.
- Framework: no AppTheory/TableTheory patch.

## Consumer impact
No public MCP contract change. This creates the internal path future Article/Draft tools can use once Lesser's Article contract stabilizes, instead of routing long-form authoring through Mastodon status APIs.

## Tasks
- [x] #263 — Add Lesser CMS/GraphQL client path.

## Validation
- `gofmt -l .` — empty
- `go test ./internal/cmsapi ./internal/lesserapi` — pass
- `go test ./...` — pass
- `go vet ./...` — pass
- `scripts/build.sh` — pass
- `git diff --check HEAD` — pass

## Stage rollout plan (handoff to deploy-body)
- [ ] Merged to main
- [ ] Deployed to lab / dev
- [ ] Lab soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
No Lesser code change is required in this PR. Body consumes the existing `/api/graphql` endpoint generically and intentionally avoids encoding Article-specific schema assumptions until the Lesser M0/M1/M3 contract work stabilizes.

## Scope guard
This PR closes only #263. It does not implement #264-#268, does not register public Article MCP tools, and does not use Mastodon-compatible status APIs for long-form Article authoring.

Closes #263.
