### PR TITLE
[codex][M0.3] fix(x402): send paymentEvidenceHash in grant consume request (CSR-011)

### DIFF
--- a/internal/mcpapp/x402_grants.go
+++ b/internal/mcpapp/x402_grants.go
@@ -35,6 +35,12 @@ const (
 	x402MaxEvidenceHeaderLength = 64 << 10
 )
 
+// x402GrantConsumeRequest is the request body dispatched to lesser-host's
+// x402 grant consume endpoint. The PaymentEvidenceHash field is sent to host
+// so host can verify the caller's payment evidence matches the grant's
+// recorded evidence BEFORE consuming (decrementing) the grant's usage count.
+// This prevents burning a grant use on a mismatched payment evidence hash.
+// Depends on lesser-host#361 for verified-host-side pre-consume verification.
 type x402GrantConsumeRequest struct {
 	GrantID             string `json:"-"`
 	GrantToken          string `json:"grantToken"`
@@ -45,7 +51,7 @@ type x402GrantConsumeRequest struct {
 	Resource            string `json:"resource"`
 	RequestHash         string `json:"requestHash"`
 	IdempotencyKey      string `json:"idempotencyKey"`
-	PaymentEvidenceHash string `json:"-"`
+	PaymentEvidenceHash string `json:"paymentEvidenceHash"`
 }
 
 type x402GrantConsumeResponse struct {

--- a/internal/mcpapp/x402_grants_test.go
+++ b/internal/mcpapp/x402_grants_test.go
@@ -66,12 +66,12 @@ func TestX402Grant_AllowsScopedToolCallWithoutOAuthSession(t *testing.T) {
 		t.Fatalf("marshal consume request: %v", err)
 	}
 	wire := string(wireReq)
-	for _, forbidden := range []string{"grantId", "actor", "paymentEvidenceHash"} {
+	for _, forbidden := range []string{"grantId", "actor"} {
 		if strings.Contains(wire, forbidden) {
 			t.Fatalf("consume request body should match accepted Host shape and omit %s: %s", forbidden, wire)
 		}
 	}
-	for _, required := range []string{"grantToken", "agentId", "capability", "tool", "resource", "requestHash", "idempotencyKey"} {
+	for _, required := range []string{"grantToken", "agentId", "capability", "tool", "resource", "requestHash", "idempotencyKey", "paymentEvidenceHash"} {
 		if !strings.Contains(wire, required) {
 			t.Fatalf("consume request body missing accepted Host field %s: %s", required, wire)
 		}
@@ -99,7 +99,7 @@ func TestX402Grant_DefaultConsumerCallsAcceptedHostConsumeContract(t *testing.T)
 		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
 			t.Fatalf("decode consume request: %v", err)
 		}
-		forbidden := []string{"grantId", "actor", "paymentEvidenceHash"}
+		forbidden := []string{"grantId", "actor"}
 		for _, key := range forbidden {
 			if _, ok := gotBody[key]; ok {
 				t.Fatalf("consume request body must omit %s: %+v", key, gotBody)
@@ -148,7 +148,7 @@ func TestX402Grant_DefaultConsumerCallsAcceptedHostConsumeContract(t *testing.T)
 	if gotAuth != "Bearer instance-key-123" {
 		t.Fatalf("expected instance-key bearer auth, got %q", gotAuth)
 	}
-	for _, required := range []string{"grantToken", "agentId", "capability", "tool", "resource", "requestHash", "idempotencyKey"} {
+	for _, required := range []string{"grantToken", "agentId", "capability", "tool", "resource", "requestHash", "idempotencyKey", "paymentEvidenceHash"} {
 		value, _ := gotBody[required].(string)
 		if strings.TrimSpace(value) == "" {
 			t.Fatalf("consume request body missing %s: %+v", required, gotBody)
@@ -156,6 +156,12 @@ func TestX402Grant_DefaultConsumerCallsAcceptedHostConsumeContract(t *testing.T)
 	}
 	if gotBody["grantToken"] != "grant-token" || gotBody["capability"] != "tools.invoke" || gotBody["tool"] != "echo" {
 		t.Fatalf("unexpected consume request body: %+v", gotBody)
+	}
+	// CSR-011: paymentEvidenceHash must be present in the wire body (hashed, not raw)
+	// so host can verify it against the grant's recorded evidence BEFORE consuming.
+	peh, _ := gotBody["paymentEvidenceHash"].(string)
+	if peh == "" || peh == "payment-signature-value" || strings.Contains(peh, "payment-signature-value") {
+		t.Fatalf("paymentEvidenceHash must be present and hashed in wire body, got %q", peh)
 	}
 }
 
@@ -344,6 +350,25 @@ func TestX402Grant_RejectsRequestResourceBindingMismatch(t *testing.T) {
 			assertX402FailureReason(t, resp, 403, scenario.reason)
 		})
 	}
+}
+
+// TestX402Grant_RejectsPaymentEvidenceMismatch is a targeted regression test for CSR-011.
+// It proves that when the host response carries a payment evidence hash that differs from
+// what body computed from the caller payment-signature header, body rejects the grant.
+// This is body second-line verification; the first line (sending paymentEvidenceHash in
+// the wire request) enables host to verify BEFORE consuming the grant (see lesser-host#361).
+func TestX402Grant_RejectsPaymentEvidenceMismatch(t *testing.T) {
+	restore := setupX402GrantTest(t, func(req mcpapp.X402GrantConsumeRequestForTests) mcpapp.X402GrantConsumeResponseForTests {
+		resp := validX402GrantConsumeResponse(req, time.Now().UTC().Add(time.Hour))
+		// Simulate host returning a grant whose recorded payment evidence hash differs
+		// from the caller evidence -- the host should have caught this pre-consume.
+		resp.Grant.Payment.EvidenceHash = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+		return resp
+	})
+	defer restore()
+
+	resp := invokeX402Tool(t, mustNewTestApp(t), "agent1", "grant-token", "payment-signature-value", "echo", map[string]any{"message": "hi"})
+	assertX402FailureReason(t, resp, 403, "x402_payment_evidence_mismatch")
 }
 
 func setupX402GrantTest(t *testing.T, response func(mcpapp.X402GrantConsumeRequestForTests) mcpapp.X402GrantConsumeResponseForTests) func() {


### PR DESCRIPTION
## Summary

- **CSR-011** (`equaltoai/lesser-body` — x402 grants consumed before payment hash verification): **FIXED** — body now sends `paymentEvidenceHash` in the wire consume request so host can verify before consuming.
- **CSR-035** (`equaltoai/greater-components` — Public x402 grants accept unverified payment hashes): **Not in body scope** — belongs to greater-components. This PR only addresses the body-side change; CSR-035 needs a separate PR in greater-components.

## CSR-011: Root cause and fix

### Before
`x402GrantConsumeRequest.PaymentEvidenceHash` was tagged `json:"-"`, meaning body computed the hash from the caller's `payment-signature` header but **never sent it to host**. Host consumed the grant (potentially decrementing usage) without being able to verify the payment evidence hash matched what was on the grant. Body's post-consume check (`x402_payment_evidence_mismatch`) could then reject a call after host had already burned a use.

### After
`PaymentEvidenceHash` is now tagged `json:"paymentEvidenceHash"` and included in the HTTP body dispatched to `POST /api/v1/soul/x402/grants/{grantId}/consume`. This gives host the data it needs to **verify payment evidence before consuming** the grant. Body retains its own post-consume mismatch check as a second line of verification.

### Contract change
- **Wire format**: adding `paymentEvidenceHash` field to the x402 grant consume request body: `{"grantToken": "...", "agentId": "...", ..., "paymentEvidenceHash": "sha256:..."}`
- **Host dependency**: lesser-host#361 must verify `paymentEvidenceHash` against the grant's recorded evidence before consuming. Without the host-side change, this is still an improvement (body won't silently omit the hash) but the full fix requires host verification.

## Changes

| File | Change |
|------|--------|
| `internal/mcpapp/x402_grants.go` | Changed `PaymentEvidenceHash string json:"-"` to `json:"paymentEvidenceHash"`; added security-rationale doc comment referencing CSR-011 and lesser-host#361 |
| `internal/mcpapp/x402_grants_test.go` | Removed `paymentEvidenceHash` from forbidden-wire-body lists; added to required-wire-body lists; added value-level hash check (not raw); added targeted regression test `TestX402Grant_RejectsPaymentEvidenceMismatch` |

## Validation

```
go test ./internal/mcpapp/ -run "X402" -v -count=1  — all 11 tests PASS including new CSR-011 regression
go test ./...        — all packages pass
go vet ./...          — clean
bash scripts/build.sh — OK: dist/lesser-body.zip
git diff --check      — clean
```

## Per-CSR evidence checklist

- [x] **CSR-011** — x402 grants consumed before payment hash verification
  - Disposition: `fix`
  - Evidence PR: this PR (commit `031f87b` on `project-38/m0.3-277`)
  - Regression test: `TestX402Grant_RejectsPaymentEvidenceMismatch` + wire-format assertions updated to require `paymentEvidenceHash` in consume request body
- [ ] **CSR-035** — Public x402 grants accept unverified payment hashes
  - Disposition: `cross-repo` — belongs to greater-components, not body's scope
  - Evidence: needs separate PR in greater-components

## x402 dependency chain

Per the Arch review in #277: "Closure depends on the Host contract and runtime behavior in equaltoai/lesser-host#361."

This PR delivers the body-side contract change (sending `paymentEvidenceHash`). The host-side change (lesser-host#361) to verify the hash before consuming is required for full closure. The PR is safe to merge independently — host that ignores the new field won't break, and host that checks it gets the full fix.

---
Provenance: body steward, equaltoai/lesser-body Project 38 M0.3

## Issue linkage

Closes #277
