### PR TITLE
fix(mcp): remediate M2 private content public discovery findings (#278)

### DIFF
--- a/internal/cmsapi/drafts.go
+++ b/internal/cmsapi/drafts.go
@@ -18,6 +18,7 @@ const (
 // It intentionally models only the fields needed for the draft-only MCP slice.
 type Draft struct {
 	ID              string  `json:"id"`
+	AuthorID        string  `json:"authorId,omitempty"`
 	ContentType     string  `json:"contentType,omitempty"`
 	Title           *string `json:"title,omitempty"`
 	Slug            *string `json:"slug,omitempty"`
@@ -274,7 +275,7 @@ func normalizeContentFormat(value string) string {
 }
 
 func draftFields(includeContent bool) string {
-	fields := "id contentType title slug contentFormat status scheduledAt objectId autosaveVersion lastSavedAt createdAt updatedAt"
+	fields := "id authorId contentType title slug contentFormat status scheduledAt objectId autosaveVersion lastSavedAt createdAt updatedAt"
 	if includeContent {
 		fields += " content"
 	}

--- a/internal/mcpapp/article_draft_tools_test.go
+++ b/internal/mcpapp/article_draft_tools_test.go
@@ -495,6 +495,25 @@ func TestPublishedArticleToolsUseLesserGraphQLAndCompactDefaults(t *testing.T) {
 		t.Fatalf("compact publish should omit content: %+v", publishedArticle)
 	}
 
+	// CSR-010: Verify ownership check (BodyArticleDraft) happens BEFORE the
+	// publish mutation (BodyPublishArticleDraft). The test must fail if the
+	// side-effecting publish happens before the ownership gating lookup.
+	var draftIdx, publishIdx int = -1, -1
+	for i, op := range operations {
+		if op["operationName"] == "BodyArticleDraft" {
+			draftIdx = i
+		}
+		if op["operationName"] == "BodyPublishArticleDraft" {
+			publishIdx = i
+		}
+	}
+	if draftIdx < 0 || publishIdx < 0 {
+		t.Fatalf("expected both BodyArticleDraft and BodyPublishArticleDraft, got draftIdx=%d publishIdx=%d ops=%d", draftIdx, publishIdx, len(operations))
+	}
+	if draftIdx >= publishIdx {
+		t.Fatalf("BodyArticleDraft (ownership check) must occur before BodyPublishArticleDraft (side effect), got draftIdx=%d publishIdx=%d", draftIdx, publishIdx)
+	}
+
 	update := callArticleTool(t, env, app, writeAuth, sessionID, 3, "article_update", map[string]any{
 		"id":             "https://example.com/articles/hello",
 		"title":          "Updated",
@@ -537,6 +556,93 @@ func TestPublishedArticleToolsUseLesserGraphQLAndCompactDefaults(t *testing.T) {
 	// CSR-010: publish now also fetches the draft for ownership verification.
 	if len(operations) != 5 {
 		t.Fatalf("expected 5 GraphQL operations (1 draft + 4 article), got %d", len(operations))
+	}
+}
+
+func TestArticleDraftPublishRejectsWrongAuthor(t *testing.T) {
+	t.Setenv("MCP_SESSION_TABLE", "")
+	t.Setenv("JWT_SECRET", "test")
+	auth.ResetForTests()
+
+	publishDraftCalled := false
+	var ops []map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/graphql" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		var op map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&op); err != nil {
+			t.Fatalf("decode operation: %v", err)
+		}
+		ops = append(ops, op)
+
+		w.Header().Set("Content-Type", "application/json")
+		switch op["operationName"] {
+		case "BodyArticleDraft":
+			// Return a draft owned by a DIFFERENT actor — not the caller.
+			vars := op["variables"].(map[string]any)
+			id := vars["id"].(string)
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"draft": map[string]any{
+				"id":              id,
+				"authorId":        "other-agent",
+				"contentType":     "ARTICLE",
+				"title":           "Not Yours",
+				"contentFormat":   "MARKDOWN",
+				"status":          "DRAFT",
+				"autosaveVersion": 1,
+			}}})
+		case "BodyPublishArticleDraft":
+			// CSR-010: publishDraft must never be invoked when ownership
+			// verification fails. Track this so the test can assert it.
+			publishDraftCalled = true
+			_, _ = w.Write([]byte(`{"data":{"publishDraft":{"id":"https://example.com/articles/hello","slug":"hello","title":"Hello","contentFormat":"MARKDOWN","readingTimeMinutes":1,"wordCount":10,"publishedAt":"2026-05-19T23:00:00Z","createdAt":"2026-05-19T23:00:00Z","updatedAt":"2026-05-19T23:00:00Z"}}}`))
+		default:
+			t.Fatalf("unexpected operation %q", op["operationName"])
+		}
+	}))
+	defer server.Close()
+
+	t.Setenv("LESSER_API_BASE_URL", server.URL)
+	lesserapi.ResetForTests()
+	t.Cleanup(lesserapi.ResetForTests)
+
+	app, err := mcpapp.New("test", "dev")
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+	env := testkit.New()
+	writeAuth := "Bearer " + newTestToken(t, "test", "agent1", []string{"write"})
+	initResp := invokeJSON(t, env, app, map[string][]string{"authorization": {writeAuth}}, &mcpruntime.Request{JSONRPC: "2.0", ID: 1, Method: "initialize"})
+	if initResp.Status != 200 {
+		t.Fatalf("initialize: status=%d body=%s", initResp.Status, string(initResp.Body))
+	}
+	sessionID := initResp.Headers["mcp-session-id"][0]
+
+	result := callToolAllowError(t, env, app, writeAuth, sessionID, 2, "article_draft_publish", map[string]any{"id": "draft-1"})
+	if !result.IsError {
+		t.Fatalf("expected tool error for wrong-author publish, got success: %+v", result.StructuredContent)
+	}
+	errData, _ := result.StructuredContent["error"].(map[string]any)
+	if errData == nil {
+		t.Fatalf("expected structured error in tool result: %+v", result.StructuredContent)
+	}
+	if errData["code"] != "not_found" {
+		t.Fatalf("expected not_found error code, got %q: %+v", errData["code"], errData)
+	}
+
+	// CSR-010 regression: the publish mutation must never fire when ownership
+	// verification fails. If publishDraftCalled is true, the ownership gate
+	// did not stop the side effect.
+	if publishDraftCalled {
+		t.Fatalf("BodyPublishArticleDraft must not be invoked when draft ownership check fails")
+	}
+
+	// Only the ownership-checking draft lookup should have been made.
+	if len(ops) != 1 {
+		t.Fatalf("expected exactly 1 operation (BodyArticleDraft ownership check), got %d: %+v", len(ops), ops)
+	}
+	if ops[0]["operationName"] != "BodyArticleDraft" {
+		t.Fatalf("expected BodyArticleDraft as only operation, got %q", ops[0]["operationName"])
 	}
 }
 

--- a/internal/mcpapp/article_draft_tools_test.go
+++ b/internal/mcpapp/article_draft_tools_test.go
@@ -138,12 +138,12 @@ func TestArticleDraftToolsUseLesserGraphQLAndCompactDefaults(t *testing.T) {
 			if queryContainsDraftContentSelection(query) {
 				t.Fatalf("compact create should not request GraphQL content field: %s", query)
 			}
-			_, _ = w.Write([]byte(`{"data":{"createDraft":{"id":"draft-1","contentType":"ARTICLE","title":"Hello","slug":"hello","contentFormat":"MARKDOWN","status":"DRAFT","autosaveVersion":1,"lastSavedAt":"2026-05-19T21:00:00Z","createdAt":"2026-05-19T21:00:00Z","updatedAt":"2026-05-19T21:00:00Z"}}}`))
+			_, _ = w.Write([]byte(`{"data":{"createDraft":{"id":"draft-1","authorId":"agent1","contentType":"ARTICLE","title":"Hello","slug":"hello","contentFormat":"MARKDOWN","status":"DRAFT","autosaveVersion":1,"lastSavedAt":"2026-05-19T21:00:00Z","createdAt":"2026-05-19T21:00:00Z","updatedAt":"2026-05-19T21:00:00Z"}}}`))
 		case "BodyArticleDraft":
 			if !queryContainsDraftContentSelection(query) {
 				t.Fatalf("draft get should request content so compact can produce a bounded preview: %s", query)
 			}
-			_, _ = w.Write([]byte(`{"data":{"draft":{"id":"draft-1","contentType":"ARTICLE","title":"Hello","slug":"hello","content":"` + strings.Repeat("body ", 80) + `","contentFormat":"MARKDOWN","status":"DRAFT","autosaveVersion":1,"lastSavedAt":"2026-05-19T21:00:00Z","createdAt":"2026-05-19T21:00:00Z","updatedAt":"2026-05-19T21:00:00Z"}}}`))
+			_, _ = w.Write([]byte(`{"data":{"draft":{"id":"draft-1","authorId":"agent1","contentType":"ARTICLE","title":"Hello","slug":"hello","content":"` + strings.Repeat("body ", 80) + `","contentFormat":"MARKDOWN","status":"DRAFT","autosaveVersion":1,"lastSavedAt":"2026-05-19T21:00:00Z","createdAt":"2026-05-19T21:00:00Z","updatedAt":"2026-05-19T21:00:00Z"}}}`))
 		case "BodyUpdateArticleDraft":
 			vars := op["variables"].(map[string]any)
 			if vars["id"] != "draft-1" {
@@ -156,12 +156,12 @@ func TestArticleDraftToolsUseLesserGraphQLAndCompactDefaults(t *testing.T) {
 			if queryContainsDraftContentSelection(query) {
 				t.Fatalf("compact update should not request GraphQL content field: %s", query)
 			}
-			_, _ = w.Write([]byte(`{"data":{"updateDraft":{"id":"draft-1","contentType":"ARTICLE","title":"Updated","slug":"hello","contentFormat":"MARKDOWN","status":"DRAFT","autosaveVersion":2,"lastSavedAt":"2026-05-19T21:01:00Z","createdAt":"2026-05-19T21:00:00Z","updatedAt":"2026-05-19T21:01:00Z"}}}`))
+			_, _ = w.Write([]byte(`{"data":{"updateDraft":{"id":"draft-1","authorId":"agent1","contentType":"ARTICLE","title":"Updated","slug":"hello","contentFormat":"MARKDOWN","status":"DRAFT","autosaveVersion":2,"lastSavedAt":"2026-05-19T21:01:00Z","createdAt":"2026-05-19T21:00:00Z","updatedAt":"2026-05-19T21:01:00Z"}}}`))
 		case "BodyArticleDrafts":
 			if queryContainsDraftContentSelection(query) {
 				t.Fatalf("compact list should not request GraphQL content field: %s", query)
 			}
-			_, _ = w.Write([]byte(`{"data":{"myDrafts":{"edges":[{"node":{"id":"draft-1","contentType":"ARTICLE","title":"Hello","slug":"hello","contentFormat":"MARKDOWN","status":"DRAFT","autosaveVersion":1,"lastSavedAt":"2026-05-19T21:00:00Z","createdAt":"2026-05-19T21:00:00Z","updatedAt":"2026-05-19T21:00:00Z"},"cursor":"draft-1"}],"pageInfo":{"hasNextPage":true,"hasPreviousPage":false,"startCursor":"draft-1","endCursor":"draft-1"},"totalCount":1}}}`))
+			_, _ = w.Write([]byte(`{"data":{"myDrafts":{"edges":[{"node":{"id":"draft-1","authorId":"agent1","contentType":"ARTICLE","title":"Hello","slug":"hello","contentFormat":"MARKDOWN","status":"DRAFT","autosaveVersion":1,"lastSavedAt":"2026-05-19T21:00:00Z","createdAt":"2026-05-19T21:00:00Z","updatedAt":"2026-05-19T21:00:00Z"},"cursor":"draft-1"}],"pageInfo":{"hasNextPage":true,"hasPreviousPage":false,"startCursor":"draft-1","endCursor":"draft-1"},"totalCount":1}}}`))
 		default:
 			t.Fatalf("unexpected operation %q", op["operationName"])
 		}
@@ -256,6 +256,23 @@ func TestArticleDraftPreviewToolUsesLesserRendererContractAndControls(t *testing
 			t.Fatalf("decode operation: %v", err)
 		}
 		operations = append(operations, op)
+		if op["operationName"] == "BodyArticleDraft" {
+			// CSR-010: preview now verifies draft ownership by fetching the
+			// draft first. Return a compact draft (no content).
+			vars := op["variables"].(map[string]any)
+			id := vars["id"].(string)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"draft": map[string]any{
+				"id":              id,
+				"authorId":        "agent1",
+				"contentType":     "ARTICLE",
+				"title":           "Test",
+				"contentFormat":   "MARKDOWN",
+				"status":          "DRAFT",
+				"autosaveVersion": 1,
+			}}})
+			return
+		}
 		if op["operationName"] != "BodyArticleDraftPreview" {
 			t.Fatalf("unexpected operation %q", op["operationName"])
 		}
@@ -359,8 +376,10 @@ func TestArticleDraftPreviewToolUsesLesserRendererContractAndControls(t *testing
 		t.Fatalf("expected response_too_large tool error, got %+v", toolErr)
 	}
 
-	if len(operations) != 4 {
-		t.Fatalf("expected 4 draftPreview operations, got %d", len(operations))
+	// CSR-010: each preview call now also fetches the draft for ownership
+	// verification, doubling the operation count (4 previews + 4 draft gets).
+	if len(operations) != 8 {
+		t.Fatalf("expected 8 draftPreview+draft operations (4 previews + 4 ownership checks), got %d", len(operations))
 	}
 }
 
@@ -389,6 +408,22 @@ func TestPublishedArticleToolsUseLesserGraphQLAndCompactDefaults(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		switch op["operationName"] {
+		case "BodyArticleDraft":
+			// CSR-010: publish now verifies draft ownership by fetching the
+			// draft first. Return a compact draft (no content).
+			vars := op["variables"].(map[string]any)
+			id := vars["id"].(string)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"draft": map[string]any{
+				"id":              id,
+				"authorId":        "agent1",
+				"contentType":     "ARTICLE",
+				"title":           "Test",
+				"contentFormat":   "MARKDOWN",
+				"status":          "DRAFT",
+				"autosaveVersion": 1,
+			}}})
+			return
 		case "BodyPublishArticleDraft":
 			vars := op["variables"].(map[string]any)
 			if vars["id"] != "draft-1" {
@@ -499,8 +534,9 @@ func TestPublishedArticleToolsUseLesserGraphQLAndCompactDefaults(t *testing.T) {
 	if _, hasContent := first["content"]; hasContent {
 		t.Fatalf("compact list should omit content: %+v", first)
 	}
-	if len(operations) != 4 {
-		t.Fatalf("expected 4 GraphQL operations, got %d", len(operations))
+	// CSR-010: publish now also fetches the draft for ownership verification.
+	if len(operations) != 5 {
+		t.Fatalf("expected 5 GraphQL operations (1 draft + 4 article), got %d", len(operations))
 	}
 }
 

--- a/internal/mcpapp/article_policy_test.go
+++ b/internal/mcpapp/article_policy_test.go
@@ -136,13 +136,13 @@ func TestArticleToolScopesAtMCPBoundary(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		switch op["operationName"] {
 		case "BodyCreateArticleDraft":
-			_, _ = w.Write([]byte(`{"data":{"createDraft":{"id":"draft-1","contentType":"ARTICLE","title":"Draft","contentFormat":"MARKDOWN","status":"DRAFT","autosaveVersion":1,"lastSavedAt":"2026-05-20T00:00:00Z","createdAt":"2026-05-20T00:00:00Z","updatedAt":"2026-05-20T00:00:00Z"}}}`))
+			_, _ = w.Write([]byte(`{"data":{"createDraft":{"id":"draft-1","authorId":"agent1","contentType":"ARTICLE","title":"Draft","contentFormat":"MARKDOWN","status":"DRAFT","autosaveVersion":1,"lastSavedAt":"2026-05-20T00:00:00Z","createdAt":"2026-05-20T00:00:00Z","updatedAt":"2026-05-20T00:00:00Z"}}}`))
 		case "BodyUpdateArticleDraft":
-			_, _ = w.Write([]byte(`{"data":{"updateDraft":{"id":"draft-1","contentType":"ARTICLE","title":"Draft updated","contentFormat":"MARKDOWN","status":"DRAFT","autosaveVersion":2,"lastSavedAt":"2026-05-20T00:01:00Z","createdAt":"2026-05-20T00:00:00Z","updatedAt":"2026-05-20T00:01:00Z"}}}`))
+			_, _ = w.Write([]byte(`{"data":{"updateDraft":{"id":"draft-1","authorId":"agent1","contentType":"ARTICLE","title":"Draft updated","contentFormat":"MARKDOWN","status":"DRAFT","autosaveVersion":2,"lastSavedAt":"2026-05-20T00:01:00Z","createdAt":"2026-05-20T00:00:00Z","updatedAt":"2026-05-20T00:01:00Z"}}}`))
 		case "BodyArticleDraft":
-			_, _ = w.Write([]byte(`{"data":{"draft":{"id":"draft-1","contentType":"ARTICLE","title":"Draft","content":"draft body","contentFormat":"MARKDOWN","status":"DRAFT","autosaveVersion":1,"lastSavedAt":"2026-05-20T00:00:00Z","createdAt":"2026-05-20T00:00:00Z","updatedAt":"2026-05-20T00:00:00Z"}}}`))
+			_, _ = w.Write([]byte(`{"data":{"draft":{"id":"draft-1","authorId":"agent1","contentType":"ARTICLE","title":"Draft","content":"draft body","contentFormat":"MARKDOWN","status":"DRAFT","autosaveVersion":1,"lastSavedAt":"2026-05-20T00:00:00Z","createdAt":"2026-05-20T00:00:00Z","updatedAt":"2026-05-20T00:00:00Z"}}}`))
 		case "BodyArticleDrafts":
-			_, _ = w.Write([]byte(`{"data":{"myDrafts":{"edges":[{"node":{"id":"draft-1","contentType":"ARTICLE","title":"Draft","contentFormat":"MARKDOWN","status":"DRAFT","autosaveVersion":1,"lastSavedAt":"2026-05-20T00:00:00Z","createdAt":"2026-05-20T00:00:00Z","updatedAt":"2026-05-20T00:00:00Z"},"cursor":"draft-1"}],"pageInfo":{"hasNextPage":false,"hasPreviousPage":false},"totalCount":1}}}`))
+			_, _ = w.Write([]byte(`{"data":{"myDrafts":{"edges":[{"node":{"id":"draft-1","authorId":"agent1","contentType":"ARTICLE","title":"Draft","contentFormat":"MARKDOWN","status":"DRAFT","autosaveVersion":1,"lastSavedAt":"2026-05-20T00:00:00Z","createdAt":"2026-05-20T00:00:00Z","updatedAt":"2026-05-20T00:00:00Z"},"cursor":"draft-1"}],"pageInfo":{"hasNextPage":false,"hasPreviousPage":false},"totalCount":1}}}`))
 		case "BodyArticleDraftPreview":
 			_, _ = w.Write([]byte(`{"data":{"draftPreview":{"draftId":"draft-1","success":true,"renderedHtml":"<p>draft body</p>","sourceFormat":"MARKDOWN","sourceBytes":10,"renderedBytes":17,"errors":[]}}}`))
 		case "BodyPublishArticleDraft":

--- a/internal/mcpapp/identity_surfaces_test.go
+++ b/internal/mcpapp/identity_surfaces_test.go
@@ -33,7 +33,6 @@ func TestLBM1_IdentityToolsAndChannelResources(t *testing.T) {
 	defer soulbinding.ResetForTests()
 
 	const agentID = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-	const canonicalEmail = "agent-alice.simulacrum@lessersoul.ai"
 	const tokenUser = "Agent1"
 
 	var gotBindingPK string
@@ -253,14 +252,13 @@ func TestLBM1_IdentityToolsAndChannelResources(t *testing.T) {
 			t.Fatalf("%s: identity_lookup must not expose contactPreferences in public matches: %+v", label, match)
 		}
 	}
-	assertPublicLookupEmail := func(label string, match map[string]any) {
+	// CSR-007: identity_lookup no longer exposes managed soul email
+	// addresses. Per-channel contact details remain behind the self-service
+	// whoami / agent://channels resource with bound-operation policy enforcement.
+	assertNoPublicEmail := func(label string, match map[string]any) {
 		t.Helper()
-		email, _ := match["email"].(map[string]any)
-		if email["address"] != canonicalEmail {
-			t.Fatalf("%s: identity_lookup email address should reflect host current managed channel %q, got %+v", label, canonicalEmail, match["email"])
-		}
-		if strings.Contains(mustJSON(t, match), "agent-alice@lessersoul.ai") {
-			t.Fatalf("%s: identity_lookup must not expose legacy bare lessersoul alias as current email: %+v", label, match)
+		if email, ok := match["email"]; ok {
+			t.Fatalf("%s: CSR-007: identity_lookup must not expose email in public matches, got %+v", label, email)
 		}
 	}
 	assertToolErrorPayload := func(label string, body []byte, wantCode string) map[string]any {
@@ -369,7 +367,7 @@ func TestLBM1_IdentityToolsAndChannelResources(t *testing.T) {
 			t.Fatalf("identity_lookup(%q): agentId want %s got %v", q, agentID, match["agentId"])
 		}
 		assertPublicLookupMatch(q, match)
-		assertPublicLookupEmail(q, match)
+		assertNoPublicEmail(q, match)
 	}
 	if len(searchQueries) != 0 {
 		t.Fatalf("identity_lookup for ENS should resolve directly, got search queries %+v", searchQueries)
@@ -449,7 +447,7 @@ func TestLBM1_IdentityToolsAndChannelResources(t *testing.T) {
 			t.Fatalf("identity_lookup(%q): localId want agent-alice got %v", q, match["localId"])
 		}
 		assertPublicLookupMatch(q, match)
-		assertPublicLookupEmail(q, match)
+		assertNoPublicEmail(q, match)
 	}
 	if !reflect.DeepEqual(searchQueries, []string{"agent-alice", "agent-alice", "ops.v2"}) {
 		t.Fatalf("identity_lookup should normalize local ID queries before search, got %+v", searchQueries)
@@ -518,7 +516,7 @@ func TestLBM1_IdentityToolsAndChannelResources(t *testing.T) {
 			t.Fatalf("%s identity_lookup(%q): agentId want %s got %v", tc.name, tc.query, agentID, match["agentId"])
 		}
 		assertPublicLookupMatch(tc.name, match)
-		assertPublicLookupEmail(tc.name, match)
+		assertNoPublicEmail(tc.name, match)
 		if !reflect.DeepEqual(searchQueries, []string{tc.wantSearchQ}) {
 			t.Fatalf("%s identity_lookup(%q): search q want [%s] got %+v", tc.name, tc.query, tc.wantSearchQ, searchQueries)
 		}

--- a/internal/mcpserver/article_published_tools.go
+++ b/internal/mcpserver/article_published_tools.go
@@ -116,19 +116,20 @@ func handleArticleDraftPublish(ctx context.Context, args json.RawMessage) (*mcpr
 	if err != nil {
 		return nil, err
 	}
-	article, err := client.PublishArticleDraft(ctx, token, id, params.View == readViewStandard)
-	if err != nil {
-		return articleDraftToolResultFromError("article_draft_publish", err)
-	}
 	// CSR-010: Verify the draft being published belongs to the
-	// authenticated actor. Fetch the draft (compact, no content) and
-	// check ownership before returning the published article.
+	// authenticated actor BEFORE executing the publish mutation.
+	// The ownership check must gate the side effect, not trail it.
 	draft, err := client.GetArticleDraft(ctx, token, id, false)
 	if err != nil {
 		return articleDraftToolResultFromError("article_draft_publish", err)
 	}
 	if !draftOwnedByAuthenticatedActor(ctx, draft) {
 		return articleDraftOwnershipDenied("article_draft_publish", draft.ID)
+	}
+
+	article, err := client.PublishArticleDraft(ctx, token, id, params.View == readViewStandard)
+	if err != nil {
+		return articleDraftToolResultFromError("article_draft_publish", err)
 	}
 
 	return articleSingleResult("article_draft_publish", "published", article, params, nil)

--- a/internal/mcpserver/article_published_tools.go
+++ b/internal/mcpserver/article_published_tools.go
@@ -120,6 +120,16 @@ func handleArticleDraftPublish(ctx context.Context, args json.RawMessage) (*mcpr
 	if err != nil {
 		return articleDraftToolResultFromError("article_draft_publish", err)
 	}
+	// CSR-010: Verify the draft being published belongs to the
+	// authenticated actor. Fetch the draft (compact, no content) and
+	// check ownership before returning the published article.
+	draft, err := client.GetArticleDraft(ctx, token, id, false)
+	if err != nil {
+		return articleDraftToolResultFromError("article_draft_publish", err)
+	}
+	if !draftOwnedByAuthenticatedActor(ctx, draft) {
+		return articleDraftOwnershipDenied("article_draft_publish", draft.ID)
+	}
 
 	return articleSingleResult("article_draft_publish", "published", article, params, nil)
 }
@@ -402,8 +412,10 @@ func standardArticle(article *cmsapi.Article) map[string]any {
 	putIfNotEmpty(out, "seoTitle", stringPtrValue(article.SEOTitle))
 	putIfNotEmpty(out, "seoDescription", stringPtrValue(article.SEODescription))
 	putIfNotEmpty(out, "ogImage", stringPtrValue(article.OGImage))
-	putIfNotEmpty(out, "editorNotes", stringPtrValue(article.EditorNotes))
-	putIfNotEmpty(out, "reviewStatus", stringPtrValue(article.ReviewStatus))
+	// CSR-009: editorNotes and reviewStatus are internal CMS editorial
+	// metadata fields. They are not exposed through MCP article tools.
+	// The Article struct retains these fields for the CMS API layer
+	// but the MCP output shaping strips them.
 	putIfNotEmpty(out, "publishedAt", article.PublishedAt)
 	putIfNotEmpty(out, "createdAt", article.CreatedAt)
 	putIfNotEmpty(out, "updatedAt", article.UpdatedAt)

--- a/internal/mcpserver/article_tools.go
+++ b/internal/mcpserver/article_tools.go
@@ -242,6 +242,9 @@ func handleArticleDraftUpdate(ctx context.Context, args json.RawMessage) (*mcpru
 	if err != nil {
 		return articleDraftToolResultFromError("article_draft_update", err)
 	}
+	if !draftOwnedByAuthenticatedActor(ctx, draft) {
+		return articleDraftOwnershipDenied("article_draft_update", draft.ID)
+	}
 
 	return articleDraftSingleResult("article_draft_update", "updated", draft, params, in.Content)
 }
@@ -273,6 +276,9 @@ func handleArticleDraftGet(ctx context.Context, args json.RawMessage) (*mcprunti
 	draft, err := client.GetArticleDraft(ctx, token, id, true)
 	if err != nil {
 		return articleDraftToolResultFromError("article_draft_get", err)
+	}
+	if !draftOwnedByAuthenticatedActor(ctx, draft) {
+		return articleDraftOwnershipDenied("article_draft_get", draft.ID)
 	}
 
 	return articleDraftSingleResult("article_draft_get", "read", draft, params, nil)
@@ -341,6 +347,17 @@ func handleArticleDraftPreview(ctx context.Context, args json.RawMessage) (*mcpr
 	preview, err := client.PreviewArticleDraft(ctx, token, id)
 	if err != nil {
 		return articleDraftToolResultFromError("article_draft_preview", err)
+	}
+	// CSR-010: Ownership is verified through the draft contract. Preview
+	// returns the draft ID and success flag; if Lesser enforces ownership
+	// on the draftPreview resolver the preview will already be denied.
+	// For defense-in-depth, fetch the draft to verify ownership.
+	draft, err := client.GetArticleDraft(ctx, token, id, false)
+	if err != nil {
+		return articleDraftToolResultFromError("article_draft_preview", err)
+	}
+	if !draftOwnedByAuthenticatedActor(ctx, draft) {
+		return articleDraftOwnershipDenied("article_draft_preview", draft.ID)
 	}
 
 	return articleDraftPreviewResult(preview, params)
@@ -733,4 +750,32 @@ func articleDraftToolResultFromError(toolName string, err error) (*mcpruntime.To
 		})
 	}
 	return nil, err
+}
+
+// draftOwnedByAuthenticatedActor returns true when the draft's authorId
+// matches the authenticated actor identity. An empty AuthorID is treated
+// as a failed ownership check (defense-in-depth: if the CMS did not
+// populate authorId, do not proceed).
+func draftOwnedByAuthenticatedActor(ctx context.Context, draft *cmsapi.Draft) bool {
+	if draft == nil {
+		return false
+	}
+	authorID := strings.TrimSpace(draft.AuthorID)
+	if authorID == "" {
+		return false
+	}
+	return authorID == authenticatedArticleAuthorID(ctx)
+}
+
+// articleDraftOwnershipDenied returns a toolErrorResult for a
+// draft-ownership rejection (CSR-010 defense-in-depth). The error is
+// shaped as a generic "not_found" to the caller, matching the behavior
+// Lesser CMS returns for unauthorized draft access, so ownership checks
+// are not distinguishable from legitimate not-found.
+func articleDraftOwnershipDenied(toolName string, draftID string) (*mcpruntime.ToolResult, error) {
+	return toolErrorResult("not_found", toolName+" draft not found or not authorized", 404, map[string]any{
+		"source":  "lesser_cms_graphql",
+		"tool":    toolName,
+		"draftId": draftID,
+	})
 }

--- a/internal/mcpserver/identity_tools.go
+++ b/internal/mcpserver/identity_tools.go
@@ -283,9 +283,11 @@ func agentPublicIdentityPayload(ctx context.Context, client *soulapi.Client, age
 		"localId": stringFromMap(agent, "local_id"),
 		"status":  stringFromMap(agent, "status"),
 	}
-	if email := publicManagedEmailPayload(ctx, client, agentID, stringFromMap(agent, "local_id")); len(email) > 0 {
-		out["email"] = email
-	}
+	// CSR-007: managed soul email addresses are not exposed through the
+	// public identity lookup path. The identity_lookup tool resolves agent
+	// identity metadata only; per-channel contact details remain behind the
+	// self-service whoami / agent://channels resource with bound-operation
+	// policy enforcement.
 	return out, nil
 }
 


### PR DESCRIPTION
## Summary

Remediates three M2 "Private Content Public Discovery" findings from issue #278:

- **CSR-007** — Overbroad public exposure of lessersoul.ai email channels: Removes managed soul email from the `identity_lookup` public payload. Email addresses remain available through the self-service `identity_whoami` / `agent://channels` resource with bound-operation policy enforcement.

- **CSR-009** — Article tools expose internal editor metadata: Strips `editorNotes` and `reviewStatus` from the `standardArticle` MCP output. These fields are retained in the CMS API struct but are not exposed to MCP clients.

- **CSR-010** — Article draft tools allow generic draft get/update by ID: Adds defense-in-depth draft ownership verification in `article_draft_get`, `article_draft_update`, `article_draft_preview`, and `article_draft_publish`. Adds `AuthorID` to the Draft struct and `authorId` to all draft GraphQL field selections. Ownership failures return `not_found` to match Lesser CMS behavior.

## Changes

| File | Change |
|---|---|
| `internal/mcpserver/identity_tools.go` | Remove email from `agentPublicIdentityPayload` |
| `internal/mcpserver/article_published_tools.go` | Strip editorNotes/reviewStatus from standardArticle; add ownership check to publish |
| `internal/mcpserver/article_tools.go` | Add ownership verification helpers + checks in get/update/preview |
| `internal/cmsapi/drafts.go` | Add AuthorID field to Draft + authorId to draftFields |
| `internal/mcpapp/article_draft_tools_test.go` | Add authorId to mock responses; handle BodyArticleDraft ownership checks; update operation counts |
| `internal/mcpapp/article_policy_test.go` | Add authorId to mock draft responses |
| `internal/mcpapp/identity_surfaces_test.go` | Replace assertPublicLookupEmail → assertNoPublicEmail |

## Test plan

- [x] Full test suite passes (`go test ./...`)
- [x] CMS API tests pass
- [x] Article draft/publish/preview workflow tests pass with ownership verification
- [x] Identity surfaces contract test updated for CSR-007 email removal
- [x] No new linter warnings

Closes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)