### PR TITLE
docs(security): document verified scope-enforcement model

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -328,18 +328,30 @@ Use a distinct MCP URL per agent so OAuth tokens stay isolated per client cache 
 
 JWT-based callers are authorized by scopes inside the JWT claims:
 
-- `admin`: can call any tool
-- `write`: can call write tools and read tools
-- `read`: can call read tools only
+- `read`: can call read tools and read-scoped MCP methods only
+- `write`: can call write tools plus everything `read` can call
+- `admin`: can call every `write` and `read` surface
+
+The hierarchy is `read` ⊂ `write` ⊂ `admin`: `write` satisfies read requirements, and `admin` satisfies both read and
+write requirements. The authoritative per-tool classification is `internal/mcpserver/tool_scopes.go`
+(`toolScopes`/`RequiredScopesForTool`); this documentation table is a client-facing description of that classifier, not
+the runtime source of truth. A registered tool without an explicit classification fails closed to `admin` rather than
+defaulting to `read`, and exhaustiveness tests fail when the registered tool surface and `toolScopes` drift.
 
 The managed instance key compatibility path currently bypasses scope checks (treat it as `admin`), which is why it is
 being deprecated for inbound MCP traffic. That bypass only remains available when
-`MCP_ALLOW_LEGACY_INSTANCE_KEY=true`.
+`MCP_ALLOW_LEGACY_INSTANCE_KEY=true`; migrate clients through the [OAuth migration guide](oauth-migration.md).
 
 Scoped x402 grant callers are authorized by the Host-issued grant, not JWT scopes. They can invoke only the single
-`tools/call` request bound into the grant. Body rejects wrong actor-resolved agent, wrong capability/tool, wrong resource/request
-hash, expired grants, replay/usage rejection, missing payment evidence, unsupported scoped-invocation authority/status,
-and missing or unsupported policy versions before tool dispatch.
+`tools/call` request bound into the grant. Body also enforces Host consumed-grant `grant.scope` against the requested
+tool's `RequiredScopesForTool` classification using the same `read` ⊂ `write` ⊂ `admin` hierarchy; missing, unknown,
+or insufficient grant scope fails closed as `x402_grant_scope_mismatch`. Body rejects wrong actor-resolved agent, wrong
+capability/tool, wrong resource/request hash, expired grants, replay/usage rejection, missing payment evidence,
+unsupported scoped-invocation authority/status, and missing or unsupported policy versions before tool dispatch.
+
+Body's scope gate runs before AppTheory tool dispatch. For `memory_append` and host-backed communication writes, this
+is the single scope gate before the memory write or lesser-host delegation. For social writes, Body gates first and then
+calls Lesser's REST API with the caller bearer so Lesser can apply its server-side authorization checks as well.
 
 ## Tools
 
@@ -362,6 +374,7 @@ Scope key:
 | `direct_messages_read` | Read | Read bounded recent direct-message previews from a named counterpart via Lesser's one-to-one conversation lookup; defaults to compact and returns explicit `not_found` instead of scanning unrelated surfaces. |
 | `notifications_read` | Read | Read recent notifications; supports opt-in compact notification refs and secondary actor/source filtering. |
 | `notification_get` | Read | Expand a compact notification ref through Lesser's notification read route. |
+| `notification_dismiss` | Write | Dismiss one notification or all notifications by marking them read through Lesser. |
 | `article_draft_create` | Write | Create an unpublished Article draft through Lesser CMS; defaults to a compact draft ref and never auto-publishes. |
 | `article_draft_update` | Write | Update an unpublished Article draft through Lesser CMS; defaults to compact and does not preview or publish. |
 | `article_draft_get` | Read | Read one Article draft by draft id; defaults to a compact ref with bounded preview and `article_draft_get(view=standard)` expansion. |

--- a/docs/oauth-migration.md
+++ b/docs/oauth-migration.md
@@ -12,6 +12,10 @@ These legacy inbound patterns are deprecated:
 - Simulacrum runtime credentials issued via `delegateToAgent()`
 - managed instance key as a direct `/mcp/{actor}` bearer token
 
+When `MCP_ALLOW_LEGACY_INSTANCE_KEY=true` enables managed-instance-key inbound compatibility, lesser-body treats that
+caller as `admin` for MCP scope enforcement. Use that path only as an explicit, time-boxed rollback bridge while
+clients move to OAuth; do not treat it as a normal least-privilege client mode.
+
 This guide shows how to migrate without removing the `LESSER_HOST_INSTANCE_KEY` that host-backed communication tools
 and scoped x402 grant consume/verification still need for server-to-server calls into lesser-host.
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -33,19 +33,74 @@ This doc describes the implemented security posture of `lesser-body`.
 JWT callers are authorized by scope on `tools/call`, `resources/read`, `prompts/get`, `completion/complete`, and
 MCP task methods:
 
-- `admin`: all tools and task methods
-- `write`: write tools + read tools + task methods
-- `read`: read tools and task methods only
+- `read`: read tools and read-scoped MCP methods only
+- `write`: write tools plus everything `read` can do
+- `admin`: every `write` and `read` surface
 
-Data-bearing resources, prompts, completions, and task methods require at least `read` scope. Tool-specific write
-operations require `write` scope (or `admin`). `tasks/cancel` remains read-scoped because the Phase 6 task pilot only
-cancels session-scoped execution of the read-only `skill_bundle_get` tool.
+The hierarchy is `read` ⊂ `write` ⊂ `admin`: a `write` token satisfies read requirements, and an `admin` token
+satisfies both read and write requirements. Data-bearing resources, prompts, completions, and task methods require at
+least `read` scope. Tool-specific write operations require `write` scope (or `admin`). `tasks/cancel` remains
+read-scoped because the Phase 6 task pilot only cancels session-scoped execution of the read-only `skill_bundle_get`
+tool.
+
+The authoritative per-tool classification is `internal/mcpserver/tool_scopes.go` (`toolScopes` and
+`RequiredScopesForTool`). Documentation tables are descriptive; the code classifier is the gate. The classifier is
+fail-closed:
+
+- every registered tool must have an explicit classification;
+- a registered tool that has no classification resolves to `admin` (`StrictestToolScope`), not `read`;
+- if the registered tool surface cannot be derived, the classifier also resolves to `admin`; and
+- an unregistered tool name has no handler, carries no scope requirement, and is left to the MCP runtime's normal
+  tool-not-found path.
+
+The M0.1 regression locks are `internal/mcpserver/tool_scopes_test.go` and
+`internal/mcpapp/scope_classification_test.go`. They assert classification exhaustiveness, no stale entries, known
+scope values, annotation consistency where annotations exist, a pinned write-tool set, fail-closed default behavior,
+and read-token rejection for write tools before downstream calls.
 
 Write tools include:
 
 - `post_create`, `post_boost`, `post_favorite`, `follow`, `unfollow`, `profile_update`, `memory_append`
+- `notification_dismiss`
 - `article_draft_create`, `article_draft_update`, `article_draft_publish`, `article_update`
 - `email_send`, `email_reply`, `email_delete`, `email_mark_read`, `email_mark_unread`, `sms_send`
+
+The Body scope gate runs before AppTheory MCP tool dispatch. For `memory_append` and host-backed communication write
+tools, this is the single scope gate before the local memory write or lesser-host delegation; there is no later Lesser
+server-side scope re-check for those side effects. For social write tools, Body still gates first and then calls
+Lesser's REST API with the caller's bearer token, so Lesser can apply its normal server-side authorization as a second
+check. Body must not bypass Lesser's authorizer for social actions.
+
+Scoped public x402 invocation grants use the same per-tool classifier. `grant.scope` is normalized as `read`, `write`,
+or `admin` and must authorize the requested tool's required scope under the same hierarchy. Missing, unknown, or
+insufficient `grant.scope` fails closed with `x402_grant_scope_mismatch` before MCP tool dispatch. The M0.2 regression
+locks live in `internal/mcpapp/x402_grants_test.go`.
+
+`internal/mcpapp/audit.go` uses AppTheory's MCP JSON-RPC parser for scope authorization before dispatch. Parser
+failures intentionally fall through to the AppTheory runtime and remain safe only because the runtime uses the same
+parser and fails before tool dispatch. The M0.3 regression locks in `internal/mcpapp/parser_equivalence_test.go` assert
+parser-equivalence for single requests, batches, notification-form `tools/call`, malformed payloads, and empty tool
+names. `internal/mcpapp/no_side_effect_403_test.go` asserts read-scoped 403s make zero lesser-host calls for
+communication writes and zero memory writes for `memory_append`.
+
+The managed instance key compatibility path bypasses scope checks (treat as `admin`) only when
+`MCP_ALLOW_LEGACY_INSTANCE_KEY=true`. Keep that path rollback-only and migrate inbound clients to OAuth; see the
+[OAuth migration guide](oauth-migration.md).
+
+### Project 48 M0 scope-enforcement notes
+
+- M0.1: [#368](https://github.com/equaltoai/lesser-body/issues/368) /
+  [PR #389](https://github.com/equaltoai/lesser-body/pull/389) moved tool classification to the exhaustive
+  `toolScopes` map, changed the unclassified registered-tool default from read to `admin`, and recorded that
+  `phone_call` remains unregistered and therefore tool-not-found rather than dispatchable.
+- M0.2: [#369](https://github.com/equaltoai/lesser-body/issues/369) /
+  [PR #390](https://github.com/equaltoai/lesser-body/pull/390) enforced Host consumed-grant `grant.scope` against the
+  same `RequiredScopesForTool` classifier.
+- M0.3: [#370](https://github.com/equaltoai/lesser-body/issues/370) /
+  [PR #391](https://github.com/equaltoai/lesser-body/pull/391) added parser-equivalence and no-side-effect-on-403
+  regression coverage for the authorization gate.
+- M0.4: [#371](https://github.com/equaltoai/lesser-body/issues/371) is this docs truth-up, preserving the verified
+  scope-enforcement model in the operator and MCP documentation.
 
 ## Bound-body operation authorization
 
@@ -70,7 +125,8 @@ private reachability, provider details, payment evidence, tenant data, wallet ma
 security details. Policy denial happens before lesser-host communication endpoints are invoked.
 
 The managed instance key compatibility path bypasses scope checks (treat as `admin`), which is why it should not
-remain the long-term inbound client auth model.
+remain the long-term inbound client auth model; the [OAuth migration guide](oauth-migration.md) treats it as a
+time-boxed rollback bridge only.
 
 ## Secrets handling
 


### PR DESCRIPTION
## Summary

Closes #371.

Documents the verified post-M0.1/M0.2/M0.3 scope-enforcement model for the Lesser Body MCP runtime:

- read/write/admin x402 scope hierarchy and fail-closed defaults
- per-tool scope classification source of truth
- parser-equivalence and no-side-effect-on-403 coverage
- managed-instance-key compatibility caveat while OAuth remains canonical

## Publication note

Factory is publishing the completed steward delegate commit through the GitHub API because the governed small-file commit path is not suitable for this docs payload. No child implementation was authored by Factory during publication; the remote PR tree matches the local `project48-m0.4-security-docs` steward commit content.

Local steward commit: `4ab503066a8a694ce798eb9614ca000849d0af87`
Remote API commit: `412114a44eab88c9b0258253203953b93fd37c72`

## Validation

Reported by body delegate before publication:

- `python3` link/manual check for docs references
- `git diff --check`
- `gofmt -l .`
- `go test ./...`
- `go vet ./...`
- `bash scripts/build.sh`

Factory follow-up will run adversarial review before approval/merge.
