### PR TITLE
feat(ptah): add account-scoped agent registry store

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -54,6 +54,21 @@ Variables:
   - Do not remove this just because inbound MCP clients migrate to OAuth; host-backed communication tools still use it.
   - The long-term inbound replacement for operator automation is documented in `docs/operator-auth-replacement.md`.
 
+### Instance-plane storage
+
+Ptah/Ba instance-plane state uses body-owned DynamoDB tables provisioned by this repo's CDK stack. These tables
+are separate from Lesser's actor data table (`LESSER_TABLE_NAME`).
+
+- `INSTANCE_CONTENT_TABLE` (string, required for the instance-plane Lambda)
+  - Body-owned table for instance-plane content state.
+- `INSTANCE_REGISTRY_TABLE` (string, required for the instance-plane Lambda)
+  - Body-owned table for Ptah-created account-scoped agent registry records keyed by `(account, agentID)`.
+    Internal stores must use this table rather than `LESSER_TABLE_NAME`.
+- `INSTANCE_GRANT_TABLE` (string, required for the instance-plane Lambda)
+  - Body-owned table for instance-plane grant state.
+- `INSTANCE_SESSION_TABLE` (string, required for the instance-plane Lambda)
+  - Body-owned table for instance-plane session state; CDK configures `expiresAt` as its TTL attribute.
+
 ### MCP session and stream persistence
 
 - `MCP_SESSION_TABLE` (string, optional)

--- a/internal/agentregistry/doc.go
+++ b/internal/agentregistry/doc.go
@@ -1,0 +1,9 @@
+// Package agentregistry stores Ptah-created agent registry entries scoped by
+// account-holder principal.
+//
+// The registry is an internal instance-plane data layer. It uses the
+// body-owned INSTANCE_REGISTRY_TABLE table provisioned for Ptah/Ba instance
+// state, not the Lesser-owned LESSER_TABLE_NAME table. Records are keyed by the
+// account-holder scope and the created agent id so cross-account reads resolve
+// to not-found instead of leaking existence.
+package agentregistry

--- a/internal/agentregistry/store.go
+++ b/internal/agentregistry/store.go
@@ -1,0 +1,224 @@
+package agentregistry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/theory-cloud/tabletheory/v2"
+	tablecore "github.com/theory-cloud/tabletheory/v2/pkg/core"
+	tableerrors "github.com/theory-cloud/tabletheory/v2/pkg/errors"
+	"github.com/theory-cloud/tabletheory/v2/pkg/session"
+)
+
+const (
+	// EnvInstanceRegistryTable is the body-owned instance-plane registry table.
+	// It is provisioned by this repo's CDK stack as INSTANCE_REGISTRY_TABLE and
+	// must not be confused with Lesser's LESSER_TABLE_NAME actor data table.
+	EnvInstanceRegistryTable = "INSTANCE_REGISTRY_TABLE"
+
+	envAWSRegion = "AWS_REGION"
+
+	accountPKPrefix = "ACCOUNT#"
+	agentSKPrefix   = "AGENT#"
+)
+
+var (
+	// ErrAgentAlreadyExists is returned when a create attempts to write an
+	// existing (account, agentID) registry key.
+	ErrAgentAlreadyExists = errors.New("agent already exists")
+
+	// ErrAgentNotFound is returned when a registry entry is absent for the
+	// supplied account scope and agent id. Cross-account reads intentionally map
+	// here rather than disclosing that the agent id exists under another account.
+	ErrAgentNotFound = errors.New("agent not found")
+)
+
+// Agent is the account-scoped registry projection for a Ptah-created agent.
+type Agent struct {
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+	Account   string    `json:"account"`
+	AgentID   string    `json:"agent_id"`
+}
+
+// CreateInput describes a new Ptah-created agent registry entry.
+type CreateInput struct {
+	Account string
+	AgentID string
+}
+
+// Store persists Ptah-created agent registry entries in a body-owned table.
+type Store struct {
+	db        tablecore.DB
+	tableName string
+}
+
+// NewStore constructs a Store over an injected TableTheory DB. tableName should
+// be the configured INSTANCE_REGISTRY_TABLE value.
+func NewStore(db tablecore.DB, tableName string) (*Store, error) {
+	if db == nil {
+		return nil, fmt.Errorf("agent registry db is required")
+	}
+	tableName = strings.TrimSpace(tableName)
+	if tableName == "" {
+		return nil, fmt.Errorf("%s is required", EnvInstanceRegistryTable)
+	}
+	return &Store{db: db, tableName: tableName}, nil
+}
+
+// Default creates the production TableTheory-backed registry store from
+// process configuration.
+func Default() (*Store, error) {
+	tableName := strings.TrimSpace(os.Getenv(EnvInstanceRegistryTable))
+	if tableName == "" {
+		return nil, fmt.Errorf("%s is required", EnvInstanceRegistryTable)
+	}
+
+	db, err := tabletheory.NewBasic(session.Config{Region: os.Getenv(envAWSRegion)})
+	if err != nil {
+		return nil, fmt.Errorf("create tabletheory client: %w", err)
+	}
+	return NewStore(db, tableName)
+}
+
+// Create inserts a new registry record guarded by TableTheory's conditional
+// create semantics. A duplicate account/agent key is mapped to
+// ErrAgentAlreadyExists.
+func (s *Store) Create(ctx context.Context, in CreateInput) (*Agent, error) {
+	if s == nil {
+		return nil, fmt.Errorf("agent registry store is nil")
+	}
+	account := normalizeAccount(in.Account)
+	if account == "" {
+		return nil, fmt.Errorf("account is required")
+	}
+	agentID := normalizeAgentID(in.AgentID)
+	if agentID == "" {
+		return nil, fmt.Errorf("agent id is required")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	now := time.Now().UTC()
+	record := s.recordFor(account, agentID)
+	record.RegistryCreatedAt = now
+	record.RegistryUpdatedAt = now
+
+	err := s.db.Model(record).WithContext(ctx).IfNotExists().Create()
+	switch {
+	case err == nil:
+		return record.toAgent(), nil
+	case tableerrors.IsConditionFailed(err):
+		return nil, fmt.Errorf("%w: account %q agent %q", ErrAgentAlreadyExists, account, agentID)
+	default:
+		return nil, fmt.Errorf("create agent registry record: %w", err)
+	}
+}
+
+// Get returns the registry record for account and agentID. Looking up an agent
+// id under the wrong account returns ErrAgentNotFound.
+func (s *Store) Get(ctx context.Context, account string, agentID string) (*Agent, error) {
+	if s == nil {
+		return nil, fmt.Errorf("agent registry store is nil")
+	}
+	account = normalizeAccount(account)
+	if account == "" {
+		return nil, fmt.Errorf("account is required")
+	}
+	agentID = normalizeAgentID(agentID)
+	if agentID == "" {
+		return nil, fmt.Errorf("agent id is required")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	record := s.emptyRecord()
+	err := s.db.Model(s.emptyRecord()).
+		WithContext(ctx).
+		Where("PK", "=", accountPartitionKey(account)).
+		Where("SK", "=", agentSortKey(agentID)).
+		First(record)
+	switch {
+	case err == nil:
+		return record.toAgent(), nil
+	case tableerrors.IsNotFound(err):
+		return nil, fmt.Errorf("%w: account %q agent %q", ErrAgentNotFound, account, agentID)
+	default:
+		return nil, fmt.Errorf("get agent registry record: %w", err)
+	}
+}
+
+func (s *Store) emptyRecord() *agentRecord {
+	return &agentRecord{tableName: s.tableName}
+}
+
+func (s *Store) recordFor(account string, agentID string) *agentRecord {
+	return &agentRecord{
+		tableName: s.tableName,
+		PK:        accountPartitionKey(account),
+		SK:        agentSortKey(agentID),
+		Account:   account,
+		AgentID:   agentID,
+	}
+}
+
+type agentRecord struct {
+	tableName string
+
+	PK string `theorydb:"pk,attr:pk" json:"pk"`
+	SK string `theorydb:"sk,attr:sk" json:"sk"`
+
+	Account           string    `theorydb:"attr:account" json:"account"`
+	AgentID           string    `theorydb:"attr:agentId" json:"agent_id"`
+	RegistryCreatedAt time.Time `theorydb:"attr:createdAt" json:"created_at"`
+	RegistryUpdatedAt time.Time `theorydb:"attr:updatedAt" json:"updated_at"`
+}
+
+func (r agentRecord) TableName() string {
+	if tableName := strings.TrimSpace(r.tableName); tableName != "" {
+		return tableName
+	}
+	return strings.TrimSpace(os.Getenv(EnvInstanceRegistryTable))
+}
+
+func (r *agentRecord) toAgent() *Agent {
+	if r == nil {
+		return nil
+	}
+	return &Agent{
+		Account:   normalizeAccount(r.Account),
+		AgentID:   normalizeAgentID(r.AgentID),
+		CreatedAt: r.RegistryCreatedAt.UTC(),
+		UpdatedAt: r.RegistryUpdatedAt.UTC(),
+	}
+}
+
+func accountPartitionKey(account string) string {
+	account = normalizeAccount(account)
+	if account == "" {
+		return ""
+	}
+	return accountPKPrefix + account
+}
+
+func agentSortKey(agentID string) string {
+	agentID = normalizeAgentID(agentID)
+	if agentID == "" {
+		return ""
+	}
+	return agentSKPrefix + agentID
+}
+
+func normalizeAccount(account string) string {
+	return strings.ToLower(strings.TrimSpace(account))
+}
+
+func normalizeAgentID(agentID string) string {
+	return strings.TrimSpace(agentID)
+}

--- a/internal/agentregistry/store_test.go
+++ b/internal/agentregistry/store_test.go
@@ -1,0 +1,104 @@
+package agentregistry
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/theory-cloud/tabletheory/v2"
+	"github.com/theory-cloud/tabletheory/v2/pkg/session"
+	"github.com/theory-cloud/tabletheory/v2/pkg/testing/fakedb"
+)
+
+func TestCreateAndGet(t *testing.T) {
+	store, _ := newTestStore(t)
+	created, err := store.Create(context.Background(), CreateInput{
+		Account: " Account-A ",
+		AgentID: "agent-123",
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if created.Account != "account-a" || created.AgentID != "agent-123" {
+		t.Fatalf("created = %+v, want normalized account and agent", created)
+	}
+	if created.CreatedAt.IsZero() || created.UpdatedAt.IsZero() {
+		t.Fatalf("created timestamps are zero: %+v", created)
+	}
+
+	got, err := store.Get(context.Background(), "account-a", "agent-123")
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if got.Account != created.Account || got.AgentID != created.AgentID {
+		t.Fatalf("Get() = %+v, want %+v", got, created)
+	}
+	if !got.CreatedAt.Equal(created.CreatedAt) || !got.UpdatedAt.Equal(created.UpdatedAt) {
+		t.Fatalf("got timestamps = %s/%s, want %s/%s", got.CreatedAt, got.UpdatedAt, created.CreatedAt, created.UpdatedAt)
+	}
+}
+
+func TestDuplicateCreateMapsAlreadyExists(t *testing.T) {
+	store, _ := newTestStore(t)
+	in := CreateInput{Account: "account-a", AgentID: "agent-123"}
+	if _, err := store.Create(context.Background(), in); err != nil {
+		t.Fatalf("first Create() error = %v", err)
+	}
+
+	_, err := store.Create(context.Background(), in)
+	if !errors.Is(err, ErrAgentAlreadyExists) {
+		t.Fatalf("second Create() error = %v, want ErrAgentAlreadyExists", err)
+	}
+}
+
+func TestCrossAccountGetReturnsNotFound(t *testing.T) {
+	store, _ := newTestStore(t)
+	if _, err := store.Create(context.Background(), CreateInput{Account: "account-a", AgentID: "agent-123"}); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	got, err := store.Get(context.Background(), "account-b", "agent-123")
+	if got != nil {
+		t.Fatalf("cross-account Get() returned %+v, want nil", got)
+	}
+	if !errors.Is(err, ErrAgentNotFound) {
+		t.Fatalf("cross-account Get() error = %v, want ErrAgentNotFound", err)
+	}
+}
+
+func TestCreateUsesInstanceRegistryTableNotLesserTable(t *testing.T) {
+	store, fake := newTestStore(t)
+	if _, err := store.Create(context.Background(), CreateInput{Account: "account-a", AgentID: "agent-123"}); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	registryItems := fake.Items(os.Getenv(EnvInstanceRegistryTable))
+	if len(registryItems) != 1 {
+		t.Fatalf("registry table items = %d, want 1", len(registryItems))
+	}
+	lesserItems := fake.Items(os.Getenv("LESSER_TABLE_NAME"))
+	if len(lesserItems) != 0 {
+		t.Fatalf("LESSER_TABLE_NAME items = %d, want 0", len(lesserItems))
+	}
+}
+
+func newTestStore(t *testing.T) (*Store, *fakedb.Fake) {
+	t.Helper()
+	t.Setenv(EnvInstanceRegistryTable, "body-instance-registry-test")
+	t.Setenv("LESSER_TABLE_NAME", "lesser-stage-table-test")
+
+	fake := fakedb.New()
+	db, err := tabletheory.NewWithClient(session.Config{Region: "us-east-1"}, fake)
+	if err != nil {
+		t.Fatalf("NewWithClient() error = %v", err)
+	}
+	store, err := NewStore(db, os.Getenv(EnvInstanceRegistryTable))
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	if err := db.CreateTable(store.emptyRecord()); err != nil {
+		t.Fatalf("CreateTable() error = %v", err)
+	}
+	return store, fake
+}


### PR DESCRIPTION
## Milestone
Project 48 M4/B5 — account-scoped Ptah agent registry store

## Classification
internal data layer / framework-idiomatic TableTheory use / Ptah instance-plane support

## Surfaces affected
- `internal/agentregistry/**` new internal package
- `docs/configuration.md` documents the existing instance-plane table env convention

## Specialist walks referenced
- Tool surface: no public Ptah/Ka tool registration in this slice; #347 owns `agent_create`
- MCP contract: not affected
- Lesser integration: not affected; package intentionally uses body-owned `INSTANCE_REGISTRY_TABLE`, not `LESSER_TABLE_NAME`
- Host delegation: not affected
- Framework: idiomatic TableTheory v2.0.3 conditional create via `db.Model(record).WithContext(ctx).IfNotExists().Create()`

## Parent
Part of #344. This PR closes the child issue only.

## Tasks
- [x] Add account-scoped model keyed by `(account, agentID)` with explicit TableTheory pk/sk tags
- [x] Map duplicate `IfNotExists().Create()` conditional failures to body-owned `ErrAgentAlreadyExists`
- [x] Return `ErrAgentNotFound` for cross-account reads without leaking existence
- [x] Prove normal create/get, duplicate create, cross-account read, and no `LESSER_TABLE_NAME` writes in tests
- [x] Document `INSTANCE_REGISTRY_TABLE` as the registry store env convention

## Validation
- [x] `gofmt -l .` (empty)
- [x] `go test ./internal/agentregistry -v`
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `scripts/build.sh` attempted directly; existing file mode is non-executable (`permission denied`, status 126)
- [x] `bash scripts/build.sh` succeeded and verified `dist/checksums.txt`

## Consumer impact
Internal only. No MCP discovery, JSON-RPC, OAuth metadata, or public tool surface changes.

## Cross-repo coordination
None required for this slice. Follow-ups remain in #346/#347/#348.

Closes #345
