### PR TITLE
feat(ptah): register agent_create tool

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -430,6 +430,37 @@ surface or Ba's `/instance/ba/mcp` surface. Clients discover them with an authen
 | Tool | Scope | Description |
 |------|-------|-------------|
 | `agent_bind_soul` | Write | Orchestrate Lesser's hosted soul/body binding ceremony for the authenticated account-holder actor. |
+| `agent_create` | Write | Delegate runtime credentials for an existing Lesser local agent account and create a Body/Ptah account-scoped registry entry. |
+
+`agent_create` input:
+
+- Required: `agent_username`, `scopes`.
+- Derived: `actor_username` is taken from the authenticated account-holder OAuth principal. If supplied explicitly, it
+  must match that principal after normalization or the tool fails closed.
+- Optional Lesser delegation fields: `display_name`, `bio`, `expires_in`, `device_label`, and `agent_info`.
+
+Current producer constraint: Lesser's source-backed `POST /api/v1/agents/delegate` endpoint delegates to an existing
+local agent account and mints a fresh runtime token/session. It does **not** create a new Lesser account today. Body/Ptah
+therefore does not fabricate account creation; `agent_create` calls `internal/lesserapi.DelegateAgent` with the caller's
+OAuth bearer token and only creates the Body-owned `INSTANCE_REGISTRY_TABLE` entry after Lesser returns the existing
+agent account.
+
+`agent_create` requires an account-holder OAuth principal with `write` scope. Agent-delegated principals, read-only
+principals, missing bearer tokens, and `actor_username` mismatches are rejected before Body calls Lesser or the registry.
+The tool never uses `LESSER_SOUL_BINDING_INTEGRATION_BEARER`; that dedicated server-to-server bearer is only for
+`agent_bind_soul`.
+
+Successful output includes safe account and registry summaries plus the delegated Lesser token response in
+`structuredContent.data.token`. Those token fields (`access_token` and `refresh_token`) are credentials: Body does not
+include them in log events or text content. Callers that persist the MCP result must handle that structured token block as
+secret material.
+
+Partial-failure reconciliation: Lesser delegation is non-idempotent and Body performs no automatic retry because each
+successful Lesser call mints credentials. If Lesser succeeds but the Body registry create later fails or detects a
+duplicate, Body cannot roll back the minted Lesser token/session in this milestone. Duplicate registry conflicts return
+tool error code `agent_already_exists` without cross-account registry details; other registry failures return
+`agent_registry_error` with partial-failure metadata so operators can reconcile or revoke any unneeded Lesser runtime
+session through Lesser-owned session management.
 
 `agent_bind_soul` input:
 

--- a/internal/instanceapp/app_test.go
+++ b/internal/instanceapp/app_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/equaltoai/lesser-body/internal/agentregistry"
 	"github.com/equaltoai/lesser-body/internal/auth"
 	"github.com/equaltoai/lesser-body/internal/instanceapp"
 	"github.com/equaltoai/lesser-body/internal/lesserapi"
@@ -21,7 +22,10 @@ import (
 	apptheory "github.com/theory-cloud/apptheory/runtime"
 	mcpruntime "github.com/theory-cloud/apptheory/runtime/mcp"
 	"github.com/theory-cloud/apptheory/testkit"
+	"github.com/theory-cloud/tabletheory/v2"
 	tablecore "github.com/theory-cloud/tabletheory/v2/pkg/core"
+	"github.com/theory-cloud/tabletheory/v2/pkg/session"
+	"github.com/theory-cloud/tabletheory/v2/pkg/testing/fakedb"
 )
 
 func TestInstancePlaneMCP_InitializeAndToolsList(t *testing.T) {
@@ -40,7 +44,7 @@ func TestInstancePlaneMCP_InitializeAndToolsList(t *testing.T) {
 		serverName string
 		wantTools  []string
 	}{
-		{name: "ptah", path: "/instance/ptah/mcp", serverName: "lesser-body-instance-ptah", wantTools: []string{"agent_bind_soul"}},
+		{name: "ptah", path: "/instance/ptah/mcp", serverName: "lesser-body-instance-ptah", wantTools: []string{"agent_bind_soul", "agent_create"}},
 		{name: "ba", path: "/instance/ba/mcp", serverName: "lesser-body-instance-ba", wantTools: []string{}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -105,6 +109,10 @@ func TestInstancePlaneMCP_InitializeAndToolsList(t *testing.T) {
 				def := listBody.Result.Tools[0]
 				if def.Annotations == nil || def.Annotations.ReadOnlyHint == nil || *def.Annotations.ReadOnlyHint {
 					t.Fatalf("agent_bind_soul annotations not write/additive: %+v", def.Annotations)
+				}
+				createDef := listBody.Result.Tools[1]
+				if createDef.Name != "agent_create" || createDef.Annotations == nil || createDef.Annotations.ReadOnlyHint == nil || *createDef.Annotations.ReadOnlyHint || createDef.Annotations.DestructiveHint == nil || *createDef.Annotations.DestructiveHint {
+					t.Fatalf("agent_create annotations not write/additive: %+v", createDef)
 				}
 			}
 		})
@@ -239,6 +247,101 @@ func TestInstancePlaneMCP_AgentBindSoulRequiresWriteScope(t *testing.T) {
 	}
 	if requests != 0 {
 		t.Fatalf("Lesser requests = %d, want 0", requests)
+	}
+}
+
+func TestInstancePlaneMCP_AgentCreateDelegatesWithCallerBearerAndRegistry(t *testing.T) {
+	requests := 0
+	var capturedAuth string
+	var capturedBody lesserapi.AgentDelegationRequest
+	lesser := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/api/v1/agents/delegate" {
+			t.Fatalf("path = %s, want /api/v1/agents/delegate", r.URL.Path)
+		}
+		if got := r.Header.Get("Idempotency-Key"); got != "" {
+			t.Fatalf("Idempotency-Key = %q, want none for non-idempotent Lesser delegation", got)
+		}
+		capturedAuth = r.Header.Get("Authorization")
+		if err := json.NewDecoder(r.Body).Decode(&capturedBody); err != nil {
+			t.Fatalf("decode Lesser request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(instanceAgentDelegationResponse()))
+	}))
+	defer lesser.Close()
+
+	registryStore := newInstanceAgentRegistryStore(t)
+	resetRegistry := ptahserver.SetAgentRegistryFactoryForTests(func() (ptahserver.AgentRegistry, error) {
+		return registryStore, nil
+	})
+	t.Cleanup(resetRegistry)
+
+	t.Setenv("JWT_SECRET", "test-secret")
+	t.Setenv("LESSER_API_BASE_URL", lesser.URL)
+	auth.ResetForTests()
+	lesserapi.ResetForTests()
+
+	app, err := instanceapp.New("lesser-body-instance", "dev")
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+	env := testkit.New()
+	userToken := newTestTokenWithAudience(t, "test-secret", "agent1", []string{"write"}, audienceForPath("/instance/ptah/mcp"))
+	headers := initializedMCPHeaders(t, env, app, "/instance/ptah/mcp", userToken)
+
+	out := callMCPTool(t, env, app, "/instance/ptah/mcp", headers, "agent_create", map[string]any{
+		"agent_username": "ptah_agent",
+		"actor_username": "agent1",
+		"display_name":   "Ptah Agent",
+		"bio":            "delegated runtime",
+		"scopes":         []string{"read", "write:statuses"},
+		"expires_in":     3600,
+		"device_label":   "ptah-instance-plane",
+		"agent_info": map[string]any{
+			"version": "1",
+		},
+	})
+	if out.Result == nil || out.Result.IsError {
+		t.Fatalf("agent_create result = %+v error = %+v", out.Result, out.Error)
+	}
+	if requests != 1 {
+		t.Fatalf("Lesser requests = %d, want exactly 1", requests)
+	}
+	if capturedAuth != "Bearer "+userToken {
+		t.Fatalf("Authorization = %q, want caller bearer", capturedAuth)
+	}
+	if strings.Contains(capturedAuth, "integration-secret") {
+		t.Fatalf("agent_create used soul-binding integration bearer")
+	}
+	if capturedBody.AgentUsername != "ptah_agent" || capturedBody.DisplayName != "Ptah Agent" || capturedBody.Bio != "delegated runtime" {
+		t.Fatalf("captured body identity fields = %+v", capturedBody)
+	}
+	if got := strings.Join(capturedBody.Scopes, ","); got != "read,write:statuses" {
+		t.Fatalf("captured scopes = %q", got)
+	}
+	if capturedBody.ExpiresIn != 3600 || capturedBody.DeviceLabel != "ptah-instance-plane" {
+		t.Fatalf("captured token options = %+v", capturedBody)
+	}
+
+	registered, err := registryStore.Get(context.Background(), "agent1", "https://lesser.example/users/ptah_agent")
+	if err != nil {
+		t.Fatalf("registry Get: %v", err)
+	}
+	if registered.Account != "agent1" || registered.AgentID != "https://lesser.example/users/ptah_agent" {
+		t.Fatalf("registry entry = %+v", registered)
+	}
+
+	data := toolResultData(t, out.Result)
+	token, _ := data["token"].(map[string]any)
+	if token["access_token"] != "mock-access-token" || token["refresh_token"] != "mock-refresh-token" {
+		t.Fatalf("structured token = %+v", token)
+	}
+	if len(out.Result.Content) == 0 || strings.Contains(out.Result.Content[0].Text, "mock-access-token") || strings.Contains(out.Result.Content[0].Text, "mock-refresh-token") {
+		t.Fatalf("text content leaked delegated credentials: %+v", out.Result.Content)
 	}
 }
 
@@ -642,6 +745,39 @@ func toolResultError(t testing.TB, result *mcpruntime.ToolResult) map[string]any
 	return payload
 }
 
+func newInstanceAgentRegistryStore(t testing.TB) *agentregistry.Store {
+	t.Helper()
+	t.Setenv(agentregistry.EnvInstanceRegistryTable, "body-instance-registry-test")
+
+	fake := fakedb.New()
+	db, err := tabletheory.NewWithClient(session.Config{Region: "us-east-1"}, fake)
+	if err != nil {
+		t.Fatalf("NewWithClient() error = %v", err)
+	}
+	store, err := agentregistry.NewStore(db, "body-instance-registry-test")
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	if err := db.CreateTable(instanceAgentRegistryRecord{}); err != nil {
+		t.Fatalf("CreateTable() error = %v", err)
+	}
+	return store
+}
+
+type instanceAgentRegistryRecord struct {
+	PK string `theorydb:"pk,attr:pk" json:"pk"`
+	SK string `theorydb:"sk,attr:sk" json:"sk"`
+
+	Account           string    `theorydb:"attr:account" json:"account"`
+	AgentID           string    `theorydb:"attr:agentId" json:"agent_id"`
+	RegistryCreatedAt time.Time `theorydb:"attr:createdAt" json:"created_at"`
+	RegistryUpdatedAt time.Time `theorydb:"attr:updatedAt" json:"updated_at"`
+}
+
+func (instanceAgentRegistryRecord) TableName() string {
+	return "body-instance-registry-test"
+}
+
 func instanceSoulBindingResponse(replayed bool) string {
 	return fmt.Sprintf(`{
 		"version":"1",
@@ -670,6 +806,42 @@ func instanceSoulBindingResponse(replayed bool) string {
 		},
 		"links":{"status":"/api/v1/souls/bindings/agent-0xabc"}
 	}`, lesserapi.SoulAuthorityModelInstanceTrust, lesserapi.SoulAnchorStateHostedOffchain, lesserapi.SoulOperationalBindingHostedBound, replayed)
+}
+
+func instanceAgentDelegationResponse() string {
+	return `{
+		"account": {
+			"id": "https://lesser.example/users/ptah_agent",
+			"username": "ptah_agent",
+			"acct": "ptah_agent",
+			"display_name": "Ptah Agent",
+			"locked": false,
+			"bot": true,
+			"discoverable": true,
+			"group": false,
+			"created_at": "2026-07-15T12:00:00Z",
+			"note": "",
+			"url": "https://lesser.example/@ptah_agent",
+			"avatar": "https://lesser.example/avatars/original/missing.png",
+			"avatar_static": "https://lesser.example/avatars/original/missing.png",
+			"header": "https://lesser.example/headers/original/missing.png",
+			"header_static": "https://lesser.example/headers/original/missing.png",
+			"followers_count": 0,
+			"following_count": 0,
+			"statuses_count": 0,
+			"last_status_at": "",
+			"emojis": [],
+			"fields": []
+		},
+		"token": {
+			"access_token": "mock-access-token",
+			"token_type": "Bearer",
+			"expires_in": 3600,
+			"refresh_token": "mock-refresh-token",
+			"scope": "read write:statuses",
+			"created_at": 1794744000
+		}
+	}`
 }
 
 func firstHeader(headers map[string][]string, name string) string {

--- a/internal/ptahserver/ptahserver.go
+++ b/internal/ptahserver/ptahserver.go
@@ -1,6 +1,7 @@
 package ptahserver
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -8,8 +9,12 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"regexp"
 	"strings"
+	"sync"
+	"time"
 
+	"github.com/equaltoai/lesser-body/internal/agentregistry"
 	"github.com/equaltoai/lesser-body/internal/auth"
 	"github.com/equaltoai/lesser-body/internal/lesserapi"
 	mcpruntime "github.com/theory-cloud/apptheory/runtime/mcp"
@@ -22,15 +27,33 @@ const (
 	EnvSoulBindingIntegrationBearer = "LESSER_SOUL_BINDING_INTEGRATION_BEARER"
 
 	toolAgentBindSoul = "agent_bind_soul"
+	toolAgentCreate   = "agent_create"
 )
 
 type soulBindingClient interface {
 	InitiateSoulBinding(ctx context.Context, integrationBearer string, idempotencyKey string, req lesserapi.SoulBindingRequest) (*lesserapi.SoulBindingResponse, error)
 }
 
+type agentDelegateClient interface {
+	DelegateAgent(ctx context.Context, bearerToken string, req lesserapi.AgentDelegationRequest) (*lesserapi.AgentDelegationResponse, error)
+}
+
+// AgentRegistry is the body-owned Ptah registry dependency used by
+// agent_create. It is exported so instance-plane integration tests can inject a
+// TableTheory-backed fake store without changing instanceapp behavior.
+type AgentRegistry interface {
+	Create(ctx context.Context, in agentregistry.CreateInput) (*agentregistry.Agent, error)
+}
+
 type config struct {
-	client              soulBindingClient
-	clientFactory       func() (soulBindingClient, error)
+	soulBinding        soulBindingClient
+	soulBindingFactory func() (soulBindingClient, error)
+
+	agentDelegateClient  agentDelegateClient
+	agentDelegateFactory func() (agentDelegateClient, error)
+	agentRegistry        AgentRegistry
+	agentRegistryFactory func() (AgentRegistry, error)
+
 	integrationBearerFn func(context.Context) (string, error)
 }
 
@@ -43,7 +66,23 @@ type Option func(*config)
 // agent_bind_soul.
 func WithSoulBindingClient(client soulBindingClient) Option {
 	return func(cfg *config) {
-		cfg.client = client
+		cfg.soulBinding = client
+	}
+}
+
+// WithAgentDelegateClient injects the Lesser delegate client used by
+// agent_create.
+func WithAgentDelegateClient(client agentDelegateClient) Option {
+	return func(cfg *config) {
+		cfg.agentDelegateClient = client
+	}
+}
+
+// WithAgentRegistryStore injects the body-owned agent registry store used by
+// agent_create.
+func WithAgentRegistryStore(store AgentRegistry) Option {
+	return func(cfg *config) {
+		cfg.agentRegistry = store
 	}
 }
 
@@ -54,6 +93,27 @@ func WithIntegrationBearer(bearer string) Option {
 		cfg.integrationBearerFn = func(context.Context) (string, error) {
 			return strings.TrimSpace(bearer), nil
 		}
+	}
+}
+
+var (
+	agentRegistryFactoryMu       sync.RWMutex
+	agentRegistryFactoryForTests func() (AgentRegistry, error)
+)
+
+// SetAgentRegistryFactoryForTests overrides the production registry factory for
+// tests that construct the instance app, whose public New function intentionally
+// does not expose tool-registration dependency injection.
+func SetAgentRegistryFactoryForTests(factory func() (AgentRegistry, error)) func() {
+	agentRegistryFactoryMu.Lock()
+	previous := agentRegistryFactoryForTests
+	agentRegistryFactoryForTests = factory
+	agentRegistryFactoryMu.Unlock()
+
+	return func() {
+		agentRegistryFactoryMu.Lock()
+		agentRegistryFactoryForTests = previous
+		agentRegistryFactoryMu.Unlock()
 	}
 }
 
@@ -70,18 +130,35 @@ func RegisterTools(r *mcpruntime.ToolRegistry, opts ...Option) error {
 		}
 	}
 
-	return r.RegisterTool(agentBindSoulDef(), cfg.handleAgentBindSoul)
+	if err := r.RegisterTool(agentBindSoulDef(), cfg.handleAgentBindSoul); err != nil {
+		return err
+	}
+	return r.RegisterTool(agentCreateDef(), cfg.handleAgentCreate)
 }
 
 func defaultConfig() config {
 	return config{
-		clientFactory: func() (soulBindingClient, error) {
+		soulBindingFactory: func() (soulBindingClient, error) {
 			return lesserapi.Default()
 		},
+		agentDelegateFactory: func() (agentDelegateClient, error) {
+			return lesserapi.Default()
+		},
+		agentRegistryFactory: defaultAgentRegistry,
 		integrationBearerFn: func(context.Context) (string, error) {
 			return strings.TrimSpace(os.Getenv(EnvSoulBindingIntegrationBearer)), nil
 		},
 	}
+}
+
+func defaultAgentRegistry() (AgentRegistry, error) {
+	agentRegistryFactoryMu.RLock()
+	factory := agentRegistryFactoryForTests
+	agentRegistryFactoryMu.RUnlock()
+	if factory != nil {
+		return factory()
+	}
+	return agentregistry.Default()
 }
 
 func agentBindSoulDef() mcpruntime.ToolDef {
@@ -119,6 +196,37 @@ func agentBindSoulDef() mcpruntime.ToolDef {
 	}
 }
 
+func agentCreateDef() mcpruntime.ToolDef {
+	return mcpruntime.ToolDef{
+		Name:        toolAgentCreate,
+		Title:       "Create agent runtime delegation",
+		Description: "Delegate runtime credentials for an existing Lesser local agent account, then create a body-owned account-scoped Ptah registry entry. Requires an account-holder OAuth principal with write scope.",
+		Annotations: additiveMutationToolAnnotations(),
+		InputSchema: json.RawMessage(`{
+			"type":"object",
+			"properties":{
+				"agent_username":{"type":"string","description":"Existing Lesser local agent account username to delegate. This tool does not create the Lesser account."},
+				"scopes":{"type":"array","items":{"type":"string"},"minItems":1,"description":"Requested delegated OAuth scopes for the agent runtime session."},
+				"display_name":{"type":"string","description":"Optional display name passed through to Lesser's delegation endpoint; current Lesser behavior does not create or update accounts with it."},
+				"bio":{"type":"string","description":"Optional bio passed through to Lesser's delegation endpoint; current Lesser behavior does not create or update accounts with it."},
+				"expires_in":{"type":"integer","description":"Optional access-token/runtime-session TTL in seconds. Lesser validates bounds."},
+				"device_label":{"type":"string","description":"Optional runtime-session display label for Lesser."},
+				"agent_info":{"description":"Optional future/legacy agent metadata passed to Lesser. Current Lesser delegation accepts but ignores it for existing-agent delegation."},
+				"actor_username":{"type":"string","description":"Optional explicit account-holder actor username. When supplied it must match the authenticated principal."}
+			},
+			"required":["agent_username","scopes"],
+			"additionalProperties":false
+		}`),
+		OutputSchema: json.RawMessage(`{
+			"type":"object",
+			"properties":{
+				"data":{"type":"object","description":"Safe account and registry summary plus structured delegated token credentials."},
+				"error":{"type":"object","description":"Structured tool error when isError=true."}
+			}
+		}`),
+	}
+}
+
 type agentBindSoulInput struct {
 	SoulAgentID        string                  `json:"soul_agent_id"`
 	IdempotencyKey     string                  `json:"idempotency_key"`
@@ -136,9 +244,20 @@ type agentBindSoulEvidenceIn struct {
 	IssuedAt        string `json:"issued_at"`
 }
 
+type agentCreateInput struct {
+	AgentUsername string   `json:"agent_username"`
+	Scopes        []string `json:"scopes"`
+	DisplayName   string   `json:"display_name"`
+	Bio           string   `json:"bio"`
+	ExpiresIn     int      `json:"expires_in"`
+	DeviceLabel   string   `json:"device_label"`
+	AgentInfo     any      `json:"agent_info"`
+	ActorUsername string   `json:"actor_username"`
+}
+
 func (cfg config) handleAgentBindSoul(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
 	principal := auth.PrincipalFromToolContext(ctx)
-	actorUsername, errResult, err := authenticatedAccountHolderActor(principal)
+	actorUsername, errResult, err := authenticatedAccountHolderActor(principal, toolAgentBindSoul)
 	if errResult != nil || err != nil {
 		return errResult, err
 	}
@@ -203,15 +322,132 @@ func (cfg config) handleAgentBindSoul(ctx context.Context, args json.RawMessage)
 	return soulBindingSuccessResult(actorUsername, in.IdempotencyKey, resp)
 }
 
-func authenticatedAccountHolderActor(principal *auth.Principal) (string, *mcpruntime.ToolResult, error) {
+func (cfg config) handleAgentCreate(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
+	principal := auth.PrincipalFromToolContext(ctx)
+	actorUsername, errResult, err := authenticatedAccountHolderActor(principal, toolAgentCreate)
+	if errResult != nil || err != nil {
+		return errResult, err
+	}
+	if !principalHasWriteScope(principal) {
+		return toolErrorResult("insufficient_scope", "agent_create requires write scope", http.StatusForbidden, map[string]any{
+			"requiredScopes": []string{"write"},
+			"grantedScopes":  normalizedScopes(principal.Claims.Scopes),
+		})
+	}
+
+	in, errResult, err := parseAgentCreateInput(args, actorUsername)
+	if errResult != nil || err != nil {
+		return errResult, err
+	}
+
+	callerBearer := strings.TrimSpace(auth.BearerTokenFromToolContext(ctx))
+	if callerBearer == "" {
+		return toolErrorResult("unauthorized", "agent_create requires the caller OAuth bearer for Lesser delegation", http.StatusUnauthorized, map[string]any{
+			"source": "lesser_agent_delegate",
+		})
+	}
+
+	client, err := cfg.agentDelegate()
+	if err != nil {
+		return toolErrorResult("not_configured", err.Error(), http.StatusInternalServerError, map[string]any{
+			"source": "lesser_body_ptah",
+		})
+	}
+	registry, err := cfg.registry()
+	if err != nil {
+		return toolErrorResult("not_configured", err.Error(), http.StatusInternalServerError, map[string]any{
+			"source": "agent_registry",
+		})
+	}
+
+	slog.InfoContext(ctx, "ptah tool invocation",
+		"tool", toolAgentCreate,
+		"actor_username", actorUsername,
+		"agent_username", in.AgentUsername,
+		"scope_count", len(in.Scopes),
+		"bearer_present", true,
+	)
+
+	resp, err := client.DelegateAgent(ctx, callerBearer, lesserapi.AgentDelegationRequest{
+		AgentUsername: in.AgentUsername,
+		DisplayName:   in.DisplayName,
+		Bio:           in.Bio,
+		Scopes:        append([]string(nil), in.Scopes...),
+		ExpiresIn:     in.ExpiresIn,
+		DeviceLabel:   in.DeviceLabel,
+		AgentInfo:     in.AgentInfo,
+	})
+	if err != nil {
+		return agentDelegateToolResultFromError(err)
+	}
+
+	agentID := delegatedAgentID(resp)
+	if agentID == "" {
+		slog.WarnContext(ctx, "ptah agent_create lesser delegation response missing account id",
+			"tool", toolAgentCreate,
+			"actor_username", actorUsername,
+			"agent_username", in.AgentUsername,
+		)
+		return agentRegistryPartialFailureResult("agent_registry_error", "Lesser delegated credentials but response did not include an account id for registry creation", http.StatusBadGateway, map[string]any{
+			"source":                    "lesser_agent_delegate",
+			"lesserDelegationSucceeded": true,
+			"mintedCredentialsMayExist": true,
+			"reconciliationRequired":    true,
+		})
+	}
+
+	created, err := registry.Create(ctx, agentregistry.CreateInput{
+		Account: actorUsername,
+		AgentID: agentID,
+	})
+	if err != nil {
+		if errors.Is(err, agentregistry.ErrAgentAlreadyExists) {
+			slog.InfoContext(ctx, "ptah agent_create registry duplicate",
+				"tool", toolAgentCreate,
+				"actor_username", actorUsername,
+				"agent_username", in.AgentUsername,
+				"lesser_delegation_succeeded", true,
+			)
+			return toolErrorResult("agent_already_exists", "agent already exists in this account-scoped Ptah registry; Lesser may have minted fresh credentials before the duplicate was detected", http.StatusConflict, map[string]any{
+				"source":                    "agent_registry",
+				"lesserDelegationSucceeded": true,
+				"mintedCredentialsMayExist": true,
+				"reconciliationRequired":    true,
+			})
+		}
+		slog.WarnContext(ctx, "ptah agent_create registry create failed after lesser delegation",
+			"tool", toolAgentCreate,
+			"actor_username", actorUsername,
+			"agent_username", in.AgentUsername,
+			"error", err.Error(),
+			"lesser_delegation_succeeded", true,
+		)
+		return agentRegistryPartialFailureResult("agent_registry_error", "Lesser delegated credentials but Body failed to create the Ptah registry entry", http.StatusInternalServerError, map[string]any{
+			"source":                    "agent_registry",
+			"lesserDelegationSucceeded": true,
+			"mintedCredentialsMayExist": true,
+			"reconciliationRequired":    true,
+		})
+	}
+
+	slog.InfoContext(ctx, "ptah agent_create completed",
+		"tool", toolAgentCreate,
+		"actor_username", actorUsername,
+		"agent_username", in.AgentUsername,
+		"agent_id", agentID,
+	)
+	return agentCreateSuccessResult(actorUsername, resp, created)
+}
+
+func authenticatedAccountHolderActor(principal *auth.Principal, toolName string) (string, *mcpruntime.ToolResult, error) {
 	if principal == nil || principal.Type != auth.PrincipalTypeOAuthToken || principal.Claims == nil || principal.Claims.IsAgent {
-		return "", mustToolErrorResult("forbidden", "agent_bind_soul requires an account-holder OAuth principal", http.StatusForbidden, map[string]any{
+		return "", mustToolErrorResult("forbidden", toolName+" requires an account-holder OAuth principal", http.StatusForbidden, map[string]any{
 			"source": "lesser_body_ptah",
 		}), nil
 	}
 	actorUsername := normalizeActorUsername(firstNonEmpty(principal.Claims.GetUsername(), principal.Identity))
 	if actorUsername == "" {
-		return "", mustToolErrorResult("forbidden", "agent_bind_soul requires an authenticated actor username", http.StatusForbidden, map[string]any{
+		return "", mustToolErrorResult("forbidden", toolName+" requires an authenticated actor username", http.StatusForbidden, map[string]any{
 			"source": "lesser_body_ptah",
 		}), nil
 	}
@@ -256,14 +492,73 @@ func parseAgentBindSoulInput(args json.RawMessage, actorUsername string) (agentB
 	return in, nil, nil
 }
 
-func (cfg config) soulBindingClient() (soulBindingClient, error) {
-	if cfg.client != nil {
-		return cfg.client, nil
+func parseAgentCreateInput(args json.RawMessage, actorUsername string) (agentCreateInput, *mcpruntime.ToolResult, error) {
+	raw := strings.TrimSpace(string(args))
+	if raw == "" || raw == "null" {
+		raw = "{}"
 	}
-	if cfg.clientFactory == nil {
+
+	var in agentCreateInput
+	dec := json.NewDecoder(bytes.NewReader([]byte(raw)))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&in); err != nil {
+		return agentCreateInput{}, mustToolErrorResult("invalid_request", "invalid args: "+err.Error(), http.StatusBadRequest, nil), nil
+	}
+	in.AgentUsername = strings.TrimSpace(in.AgentUsername)
+	in.DisplayName = strings.TrimSpace(in.DisplayName)
+	in.Bio = strings.TrimSpace(in.Bio)
+	in.DeviceLabel = strings.TrimSpace(in.DeviceLabel)
+	in.ActorUsername = normalizeActorUsername(in.ActorUsername)
+
+	if in.AgentUsername == "" {
+		return agentCreateInput{}, mustToolErrorResult("invalid_request", "agent_username is required", http.StatusBadRequest, nil), nil
+	}
+	if len(in.Scopes) == 0 {
+		return agentCreateInput{}, mustToolErrorResult("invalid_request", "scopes are required", http.StatusBadRequest, nil), nil
+	}
+	for i, scope := range in.Scopes {
+		scope = strings.TrimSpace(scope)
+		if scope == "" {
+			return agentCreateInput{}, mustToolErrorResult("invalid_request", "scopes cannot contain empty values", http.StatusBadRequest, nil), nil
+		}
+		in.Scopes[i] = scope
+	}
+	if in.ActorUsername != "" && in.ActorUsername != actorUsername {
+		return agentCreateInput{}, mustToolErrorResult("forbidden", "actor_username must match authenticated principal", http.StatusForbidden, map[string]any{
+			"source": "lesser_body_ptah",
+		}), nil
+	}
+	return in, nil, nil
+}
+
+func (cfg config) soulBindingClient() (soulBindingClient, error) {
+	if cfg.soulBinding != nil {
+		return cfg.soulBinding, nil
+	}
+	if cfg.soulBindingFactory == nil {
 		return nil, fmt.Errorf("soul-binding client is not configured")
 	}
-	return cfg.clientFactory()
+	return cfg.soulBindingFactory()
+}
+
+func (cfg config) agentDelegate() (agentDelegateClient, error) {
+	if cfg.agentDelegateClient != nil {
+		return cfg.agentDelegateClient, nil
+	}
+	if cfg.agentDelegateFactory == nil {
+		return nil, fmt.Errorf("agent delegate client is not configured")
+	}
+	return cfg.agentDelegateFactory()
+}
+
+func (cfg config) registry() (AgentRegistry, error) {
+	if cfg.agentRegistry != nil {
+		return cfg.agentRegistry, nil
+	}
+	if cfg.agentRegistryFactory == nil {
+		return nil, fmt.Errorf("agent registry store is not configured")
+	}
+	return cfg.agentRegistryFactory()
 }
 
 func (cfg config) integrationBearer(ctx context.Context) (string, error) {
@@ -337,6 +632,67 @@ func soulBindingSuccessResult(actorUsername string, idempotencyKey string, resp 
 	return toolJSONTextResult(text, map[string]any{"data": data})
 }
 
+func agentCreateSuccessResult(actorUsername string, resp *lesserapi.AgentDelegationResponse, registry *agentregistry.Agent) (*mcpruntime.ToolResult, error) {
+	if resp == nil {
+		return nil, fmt.Errorf("agent delegation response is nil")
+	}
+	accountMap, err := mapFromJSON(resp.Account)
+	if err != nil {
+		return nil, err
+	}
+	tokenMap, err := mapFromJSON(resp.Token)
+	if err != nil {
+		return nil, err
+	}
+
+	accountSummary := map[string]any{
+		"id":           resp.Account.ID,
+		"username":     resp.Account.Username,
+		"acct":         resp.Account.Acct,
+		"display_name": resp.Account.DisplayName,
+		"bot":          resp.Account.Bot,
+		"url":          resp.Account.URL,
+	}
+	tokenMetadata := map[string]any{
+		"token_type":          resp.Token.TokenType,
+		"expires_in":          resp.Token.ExpiresIn,
+		"scope":               resp.Token.Scope,
+		"created_at":          resp.Token.CreatedAt,
+		"has_refresh_token":   resp.Token.RefreshToken != "",
+		"credential_location": "structuredContent.data.token",
+	}
+
+	registrySummary := map[string]any{}
+	if registry != nil {
+		registrySummary = map[string]any{
+			"account":    registry.Account,
+			"agent_id":   registry.AgentID,
+			"created_at": formatTime(registry.CreatedAt),
+			"updated_at": formatTime(registry.UpdatedAt),
+		}
+	}
+
+	data := map[string]any{
+		"actor_username":       actorUsername,
+		"current_behavior":     "delegates_existing_lesser_agent_account",
+		"lesser_account":       accountMap,
+		"account_summary":      accountSummary,
+		"registry":             registrySummary,
+		"token":                tokenMap,
+		"token_metadata":       tokenMetadata,
+		"reconciliation_notes": "Lesser delegation is non-idempotent; if registry creation fails after delegation, Body cannot roll back minted Lesser credentials.",
+	}
+
+	text := map[string]any{
+		"summary":        "Lesser agent runtime credentials delegated and Ptah registry entry created",
+		"account":        accountSummary,
+		"registry":       registrySummary,
+		"token_metadata": tokenMetadata,
+		"data":           map[string]any{"location": "structuredContent.data"},
+	}
+	return toolJSONTextResult(text, map[string]any{"data": data})
+}
+
 func soulBindingToolResultFromError(err error) (*mcpruntime.ToolResult, error) {
 	if err == nil {
 		return nil, nil
@@ -358,6 +714,38 @@ func soulBindingToolResultFromError(err error) (*mcpruntime.ToolResult, error) {
 	return toolErrorResult("upstream_error", err.Error(), http.StatusBadGateway, map[string]any{
 		"source": "lesser_soul_binding",
 	})
+}
+
+func agentDelegateToolResultFromError(err error) (*mcpruntime.ToolResult, error) {
+	if err == nil {
+		return nil, nil
+	}
+
+	var apiErr *lesserapi.APIError
+	if errors.As(err, &apiErr) {
+		details := map[string]any{
+			"source":         "lesser_agent_delegate",
+			"upstreamStatus": apiErr.Status,
+			"upstreamBody":   redactedAPIErrorBody(apiErr.Body),
+		}
+		if parsed := parseJSONObject(apiErr.Body); parsed != nil {
+			redactCredentialFields(parsed)
+			details["upstreamJSON"] = parsed
+		}
+		return toolErrorResult(lesserAPIErrorCode(apiErr.Status), "Lesser agent delegation API request failed", apiErr.Status, details)
+	}
+
+	return toolErrorResult("upstream_error", err.Error(), http.StatusBadGateway, map[string]any{
+		"source": "lesser_agent_delegate",
+	})
+}
+
+func agentRegistryPartialFailureResult(code string, message string, status int, details map[string]any) (*mcpruntime.ToolResult, error) {
+	if details == nil {
+		details = map[string]any{}
+	}
+	details["partialFailure"] = true
+	return toolErrorResult(code, message, status, details)
 }
 
 func lesserAPIErrorCode(status int) string {
@@ -485,17 +873,31 @@ func firstNonEmpty(values ...string) string {
 	return ""
 }
 
+func delegatedAgentID(resp *lesserapi.AgentDelegationResponse) string {
+	if resp == nil {
+		return ""
+	}
+	return strings.TrimSpace(resp.Account.ID)
+}
+
+func formatTime(value time.Time) string {
+	if value.IsZero() {
+		return ""
+	}
+	return value.UTC().Format(time.RFC3339Nano)
+}
+
 func mapFromJSON(value any) (map[string]any, error) {
 	if value == nil {
 		return map[string]any{}, nil
 	}
 	b, err := json.Marshal(value)
 	if err != nil {
-		return nil, fmt.Errorf("marshal lesser soul-binding response: %w", err)
+		return nil, fmt.Errorf("marshal structured value: %w", err)
 	}
 	var out map[string]any
 	if err := json.Unmarshal(b, &out); err != nil {
-		return nil, fmt.Errorf("unmarshal lesser soul-binding response: %w", err)
+		return nil, fmt.Errorf("unmarshal structured value: %w", err)
 	}
 	if out == nil {
 		out = map[string]any{}
@@ -513,4 +915,40 @@ func parseJSONObject(raw []byte) map[string]any {
 		return nil
 	}
 	return out
+}
+
+var credentialFieldPattern = regexp.MustCompile(`(?i)("(?:access|refresh)_token"\s*:\s*)"[^"]*"`)
+
+func redactedAPIErrorBody(raw []byte) string {
+	raw = []byte(strings.TrimSpace(string(raw)))
+	if len(raw) == 0 {
+		return ""
+	}
+
+	var decoded any
+	if err := json.Unmarshal(raw, &decoded); err == nil {
+		redactCredentialFields(decoded)
+		if b, err := json.Marshal(decoded); err == nil {
+			return string(b)
+		}
+	}
+	return credentialFieldPattern.ReplaceAllString(string(raw), `${1}"<redacted>"`)
+}
+
+func redactCredentialFields(value any) {
+	switch v := value.(type) {
+	case map[string]any:
+		for key, child := range v {
+			switch strings.ToLower(strings.TrimSpace(key)) {
+			case "access_token", "refresh_token":
+				v[key] = "<redacted>"
+			default:
+				redactCredentialFields(child)
+			}
+		}
+	case []any:
+		for _, child := range v {
+			redactCredentialFields(child)
+		}
+	}
 }

--- a/internal/ptahserver/ptahserver_test.go
+++ b/internal/ptahserver/ptahserver_test.go
@@ -3,24 +3,27 @@ package ptahserver
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/equaltoai/lesser-body/internal/agentregistry"
 	"github.com/equaltoai/lesser-body/internal/auth"
 	"github.com/equaltoai/lesser-body/internal/lesserapi"
 	mcpruntime "github.com/theory-cloud/apptheory/runtime/mcp"
 )
 
-func TestRegisterToolsRegistersAgentBindSoulDefinition(t *testing.T) {
+func TestRegisterToolsRegistersPtahDefinitions(t *testing.T) {
 	registry := mcpruntime.NewToolRegistry()
 	if err := RegisterTools(registry); err != nil {
 		t.Fatalf("RegisterTools: %v", err)
 	}
 
 	tools := registry.List()
-	if len(tools) != 1 {
-		t.Fatalf("registered tools = %d, want 1", len(tools))
+	if got, want := toolDefNames(tools), []string{toolAgentBindSoul, toolAgentCreate}; strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("registered tool order = %v, want %v", got, want)
 	}
 	def := tools[0]
 	if def.Name != toolAgentBindSoul {
@@ -48,6 +51,37 @@ func TestRegisterToolsRegistersAgentBindSoulDefinition(t *testing.T) {
 	}
 	if _, ok := schema.Props["actor_username"]; !ok {
 		t.Fatalf("input schema should advertise optional actor_username mismatch guard")
+	}
+
+	createDef := tools[1]
+	if createDef.Name != toolAgentCreate {
+		t.Fatalf("second tool name = %q, want %q", createDef.Name, toolAgentCreate)
+	}
+	if createDef.Annotations == nil || createDef.Annotations.ReadOnlyHint == nil || *createDef.Annotations.ReadOnlyHint {
+		t.Fatalf("agent_create must not be read-only: %+v", createDef.Annotations)
+	}
+	if createDef.Annotations.DestructiveHint == nil || *createDef.Annotations.DestructiveHint {
+		t.Fatalf("agent_create must be additive/non-destructive in Body registry: %+v", createDef.Annotations)
+	}
+	if createDef.Annotations.IdempotentHint == nil || *createDef.Annotations.IdempotentHint {
+		t.Fatalf("agent_create is not globally idempotent because Lesser delegation mints credentials: %+v", createDef.Annotations)
+	}
+	var createSchema struct {
+		Required []string       `json:"required"`
+		Props    map[string]any `json:"properties"`
+	}
+	if err := json.Unmarshal(createDef.InputSchema, &createSchema); err != nil {
+		t.Fatalf("agent_create input schema invalid json: %v", err)
+	}
+	for _, required := range []string{"agent_username", "scopes"} {
+		if !contains(createSchema.Required, required) {
+			t.Fatalf("agent_create required = %v, missing %s", createSchema.Required, required)
+		}
+	}
+	for _, prop := range []string{"actor_username", "display_name", "bio", "expires_in", "device_label", "agent_info"} {
+		if _, ok := createSchema.Props[prop]; !ok {
+			t.Fatalf("agent_create schema missing %s", prop)
+		}
 	}
 }
 
@@ -171,6 +205,226 @@ func TestAgentBindSoulPreservesLesserAPIErrorStatusAndBody(t *testing.T) {
 	}
 }
 
+func TestAgentCreateDelegatesWithCallerBearerAndCreatesRegistry(t *testing.T) {
+	client := &fakeAgentDelegateClient{resp: successfulAgentDelegationResponse()}
+	store := &fakeAgentRegistry{agent: &agentregistry.Agent{
+		Account:   "drone-ada",
+		AgentID:   "https://lesser.example/users/ptah_agent",
+		CreatedAt: time.Date(2026, 7, 15, 12, 10, 0, 0, time.UTC),
+		UpdatedAt: time.Date(2026, 7, 15, 12, 10, 0, 0, time.UTC),
+	}}
+	registry := mcpruntime.NewToolRegistry()
+	if err := RegisterTools(registry, WithAgentDelegateClient(client), WithAgentRegistryStore(store)); err != nil {
+		t.Fatalf("RegisterTools: %v", err)
+	}
+
+	result, err := registry.Call(toolContext("Drone-Ada", []string{"read", "write"}, "owner-oauth-token"), toolAgentCreate, json.RawMessage(`{
+		"agent_username":"ptah_agent",
+		"actor_username":"drone-ada",
+		"display_name":"Ptah Agent",
+		"bio":"delegated runtime",
+		"scopes":[" read ","write:statuses"],
+		"expires_in":3600,
+		"device_label":"ptah-instance-plane",
+		"agent_info":{"version":"1"}
+	}`))
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if result == nil || result.IsError {
+		t.Fatalf("result = %+v", result)
+	}
+	if client.calls != 1 {
+		t.Fatalf("DelegateAgent calls = %d, want 1", client.calls)
+	}
+	if client.bearer != "owner-oauth-token" {
+		t.Fatalf("DelegateAgent bearer = %q, want caller bearer", client.bearer)
+	}
+	if client.bearer == "integration-secret" {
+		t.Fatalf("agent_create used the dedicated soul-binding bearer")
+	}
+	if client.req.AgentUsername != "ptah_agent" || client.req.DisplayName != "Ptah Agent" || client.req.Bio != "delegated runtime" {
+		t.Fatalf("delegate request identity fields = %+v", client.req)
+	}
+	if got := strings.Join(client.req.Scopes, ","); got != "read,write:statuses" {
+		t.Fatalf("delegate scopes = %q", got)
+	}
+	if client.req.ExpiresIn != 3600 || client.req.DeviceLabel != "ptah-instance-plane" {
+		t.Fatalf("delegate token options = %+v", client.req)
+	}
+	if info, ok := client.req.AgentInfo.(map[string]any); !ok || info["version"] != "1" {
+		t.Fatalf("agent_info = %#v", client.req.AgentInfo)
+	}
+	if store.calls != 1 {
+		t.Fatalf("registry Create calls = %d, want 1", store.calls)
+	}
+	if store.in.Account != "drone-ada" || store.in.AgentID != "https://lesser.example/users/ptah_agent" {
+		t.Fatalf("registry input = %+v", store.in)
+	}
+
+	data := structuredData(t, result)
+	token, _ := data["token"].(map[string]any)
+	if token["access_token"] != "mock-access-token" || token["refresh_token"] != "mock-refresh-token" {
+		t.Fatalf("structured token = %+v", token)
+	}
+	if result.Content == nil || strings.Contains(result.Content[0].Text, "mock-access-token") || strings.Contains(result.Content[0].Text, "mock-refresh-token") {
+		t.Fatalf("text content leaked token credentials: %+v", result.Content)
+	}
+	registrySummary, _ := data["registry"].(map[string]any)
+	if registrySummary["account"] != "drone-ada" || registrySummary["agent_id"] != "https://lesser.example/users/ptah_agent" {
+		t.Fatalf("registry summary = %+v", registrySummary)
+	}
+}
+
+func TestAgentCreateMapsDuplicateRegistryConflictWithoutLeakingCrossAccountState(t *testing.T) {
+	client := &fakeAgentDelegateClient{resp: successfulAgentDelegationResponse()}
+	store := &fakeAgentRegistry{err: fmt.Errorf("%w: hidden account/agent details", agentregistry.ErrAgentAlreadyExists)}
+	registry := mcpruntime.NewToolRegistry()
+	if err := RegisterTools(registry, WithAgentDelegateClient(client), WithAgentRegistryStore(store)); err != nil {
+		t.Fatalf("RegisterTools: %v", err)
+	}
+
+	result, err := registry.Call(toolContext("drone-ada", []string{"write"}, "owner-oauth-token"), toolAgentCreate, json.RawMessage(`{"agent_username":"ptah_agent","scopes":["read"]}`))
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	payload := assertToolError(t, result, "agent_already_exists", 409)
+	if client.calls != 1 || store.calls != 1 {
+		t.Fatalf("calls delegate=%d registry=%d, want 1/1", client.calls, store.calls)
+	}
+	textBytes, _ := json.Marshal(payload)
+	if strings.Contains(string(textBytes), "hidden account/agent details") || strings.Contains(string(textBytes), "mock-access-token") || strings.Contains(string(textBytes), "mock-refresh-token") {
+		t.Fatalf("duplicate error leaked registry details or credentials: %s", string(textBytes))
+	}
+	details, _ := payload["details"].(map[string]any)
+	if details["reconciliationRequired"] != true || details["mintedCredentialsMayExist"] != true {
+		t.Fatalf("duplicate details should document partial mint reconciliation: %+v", details)
+	}
+}
+
+func TestAgentCreateRejectsBeforeSideEffects(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		ctx       context.Context
+		args      string
+		wantCode  string
+		wantState int
+	}{
+		{
+			name:      "insufficient scope",
+			ctx:       toolContext("drone-ada", []string{"read"}, "owner-oauth-token"),
+			args:      `{"agent_username":"ptah_agent","scopes":["read"]}`,
+			wantCode:  "insufficient_scope",
+			wantState: 403,
+		},
+		{
+			name:      "agent principal",
+			ctx:       toolContextWithAgent("drone-ada", []string{"write"}, "agent-runtime-token", true),
+			args:      `{"agent_username":"ptah_agent","scopes":["read"]}`,
+			wantCode:  "forbidden",
+			wantState: 403,
+		},
+		{
+			name:      "missing bearer",
+			ctx:       toolContext("drone-ada", []string{"write"}, ""),
+			args:      `{"agent_username":"ptah_agent","scopes":["read"]}`,
+			wantCode:  "unauthorized",
+			wantState: 401,
+		},
+		{
+			name:      "missing username",
+			ctx:       toolContext("drone-ada", []string{"write"}, "owner-oauth-token"),
+			args:      `{"scopes":["read"]}`,
+			wantCode:  "invalid_request",
+			wantState: 400,
+		},
+		{
+			name:      "missing scopes",
+			ctx:       toolContext("drone-ada", []string{"write"}, "owner-oauth-token"),
+			args:      `{"agent_username":"ptah_agent","scopes":[]}`,
+			wantCode:  "invalid_request",
+			wantState: 400,
+		},
+		{
+			name:      "mismatched actor username",
+			ctx:       toolContext("drone-ada", []string{"write"}, "owner-oauth-token"),
+			args:      `{"agent_username":"ptah_agent","scopes":["read"],"actor_username":"other"}`,
+			wantCode:  "forbidden",
+			wantState: 403,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &fakeAgentDelegateClient{resp: successfulAgentDelegationResponse()}
+			store := &fakeAgentRegistry{agent: &agentregistry.Agent{Account: "drone-ada", AgentID: "https://lesser.example/users/ptah_agent"}}
+			registry := mcpruntime.NewToolRegistry()
+			if err := RegisterTools(registry, WithAgentDelegateClient(client), WithAgentRegistryStore(store)); err != nil {
+				t.Fatalf("RegisterTools: %v", err)
+			}
+
+			result, err := registry.Call(tc.ctx, toolAgentCreate, json.RawMessage(tc.args))
+			if err != nil {
+				t.Fatalf("Call: %v", err)
+			}
+			assertToolError(t, result, tc.wantCode, tc.wantState)
+			if client.calls != 0 || store.calls != 0 {
+				t.Fatalf("side effects occurred before rejection: delegate=%d registry=%d", client.calls, store.calls)
+			}
+		})
+	}
+}
+
+func TestAgentCreatePreservesLesserAPIErrorStatusAndDetails(t *testing.T) {
+	client := &fakeAgentDelegateClient{err: &lesserapi.APIError{Status: 503, Body: []byte(`{"error":"agent delegation failed","error_code":"AGENT_DELEGATION_TEST","access_token":"should-redact","refresh_token":"also-redact"}`)}}
+	store := &fakeAgentRegistry{agent: &agentregistry.Agent{Account: "drone-ada", AgentID: "https://lesser.example/users/ptah_agent"}}
+	registry := mcpruntime.NewToolRegistry()
+	if err := RegisterTools(registry, WithAgentDelegateClient(client), WithAgentRegistryStore(store)); err != nil {
+		t.Fatalf("RegisterTools: %v", err)
+	}
+
+	result, err := registry.Call(toolContext("drone-ada", []string{"write"}, "owner-oauth-token"), toolAgentCreate, json.RawMessage(`{"agent_username":"ptah_agent","scopes":["read"]}`))
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	payload := assertToolError(t, result, "upstream_unavailable", 503)
+	if client.calls != 1 || store.calls != 0 {
+		t.Fatalf("calls delegate=%d registry=%d, want 1/0", client.calls, store.calls)
+	}
+	details, _ := payload["details"].(map[string]any)
+	if details["source"] != "lesser_agent_delegate" || details["upstreamStatus"] != 503 {
+		t.Fatalf("details did not preserve status/source: %+v", details)
+	}
+	body := details["upstreamBody"].(string)
+	if !strings.Contains(body, "AGENT_DELEGATION_TEST") || strings.Contains(body, "should-redact") || strings.Contains(body, "also-redact") {
+		t.Fatalf("upstream body did not preserve code with redaction: %s", body)
+	}
+}
+
+func TestAgentCreateDocumentsPartialFailureWhenRegistryCreateFails(t *testing.T) {
+	client := &fakeAgentDelegateClient{resp: successfulAgentDelegationResponse()}
+	store := &fakeAgentRegistry{err: errors.New("registry table unavailable")}
+	registry := mcpruntime.NewToolRegistry()
+	if err := RegisterTools(registry, WithAgentDelegateClient(client), WithAgentRegistryStore(store)); err != nil {
+		t.Fatalf("RegisterTools: %v", err)
+	}
+
+	result, err := registry.Call(toolContext("drone-ada", []string{"write"}, "owner-oauth-token"), toolAgentCreate, json.RawMessage(`{"agent_username":"ptah_agent","scopes":["read"]}`))
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	payload := assertToolError(t, result, "agent_registry_error", 500)
+	if client.calls != 1 || store.calls != 1 {
+		t.Fatalf("calls delegate=%d registry=%d, want 1/1", client.calls, store.calls)
+	}
+	encoded, _ := json.Marshal(payload)
+	if strings.Contains(string(encoded), "mock-access-token") || strings.Contains(string(encoded), "mock-refresh-token") {
+		t.Fatalf("partial failure leaked minted credentials: %s", string(encoded))
+	}
+	details, _ := payload["details"].(map[string]any)
+	if details["partialFailure"] != true || details["lesserDelegationSucceeded"] != true || details["reconciliationRequired"] != true {
+		t.Fatalf("partial failure details = %+v", details)
+	}
+}
+
 type fakeSoulBindingClient struct {
 	calls             int
 	integrationBearer string
@@ -191,13 +445,52 @@ func (f *fakeSoulBindingClient) InitiateSoulBinding(_ context.Context, integrati
 	return f.resp, nil
 }
 
+type fakeAgentDelegateClient struct {
+	calls  int
+	bearer string
+	req    lesserapi.AgentDelegationRequest
+	resp   *lesserapi.AgentDelegationResponse
+	err    error
+}
+
+func (f *fakeAgentDelegateClient) DelegateAgent(_ context.Context, bearerToken string, req lesserapi.AgentDelegationRequest) (*lesserapi.AgentDelegationResponse, error) {
+	f.calls++
+	f.bearer = bearerToken
+	f.req = req
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.resp, nil
+}
+
+type fakeAgentRegistry struct {
+	calls int
+	in    agentregistry.CreateInput
+	agent *agentregistry.Agent
+	err   error
+}
+
+func (f *fakeAgentRegistry) Create(_ context.Context, in agentregistry.CreateInput) (*agentregistry.Agent, error) {
+	f.calls++
+	f.in = in
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.agent, nil
+}
+
 func toolContext(username string, scopes []string, bearer string) context.Context {
+	return toolContextWithAgent(username, scopes, bearer, false)
+}
+
+func toolContextWithAgent(username string, scopes []string, bearer string, isAgent bool) context.Context {
 	return auth.InjectToolContext(context.Background(), &auth.Principal{
 		Type:     auth.PrincipalTypeOAuthToken,
 		Identity: username,
 		Claims: &auth.Claims{
 			Username: username,
 			Scopes:   scopes,
+			IsAgent:  isAgent,
 		},
 	}, bearer)
 }
@@ -233,6 +526,27 @@ func successfulBindingResponse(replayed bool) *lesserapi.SoulBindingResponse {
 	}
 }
 
+func successfulAgentDelegationResponse() *lesserapi.AgentDelegationResponse {
+	return &lesserapi.AgentDelegationResponse{
+		Account: lesserapi.AgentDelegationAccount{
+			ID:          "https://lesser.example/users/ptah_agent",
+			Username:    "ptah_agent",
+			Acct:        "ptah_agent",
+			DisplayName: "Ptah Agent",
+			Bot:         true,
+			URL:         "https://lesser.example/@ptah_agent",
+		},
+		Token: lesserapi.AgentDelegationToken{
+			AccessToken:  "mock-access-token",
+			TokenType:    "Bearer",
+			ExpiresIn:    3600,
+			RefreshToken: "mock-refresh-token",
+			Scope:        "read write:statuses",
+			CreatedAt:    1794744000,
+		},
+	}
+}
+
 func structuredData(t *testing.T, result *mcpruntime.ToolResult) map[string]any {
 	t.Helper()
 	if result == nil || result.StructuredContent == nil {
@@ -258,6 +572,14 @@ func assertToolError(t *testing.T, result *mcpruntime.ToolResult, wantCode strin
 		t.Fatalf("error payload = %+v, want code=%s status=%d", payload, wantCode, wantStatus)
 	}
 	return payload
+}
+
+func toolDefNames(defs []mcpruntime.ToolDef) []string {
+	out := make([]string, 0, len(defs))
+	for _, def := range defs {
+		out = append(out, def.Name)
+	}
+	return out
 }
 
 func contains(values []string, want string) bool {


### PR DESCRIPTION
## Milestone
Project 48 M4/B7 — Ptah core minting: register `agent_create`

Closes #347
Parent: #344

## Classification
Tool-surface / MCP-contract additive / lesser-integration / scope-profile / security

## Surfaces affected
- `internal/ptahserver`: registers `agent_create` through AppTheory `mcpruntime.ToolRegistry` and implements handler/result mapping.
- `internal/instanceapp` tests: verifies Ptah tools/list includes `agent_create` while Ba remains empty.
- `docs/mcp.md`: documents current Lesser producer constraint, token handling, and partial-failure reconciliation.

## Source evidence / framework adoption
- AppTheory v1.17.0 MCP runtime: used existing `ToolRegistry.RegisterTool`, deterministic registration order, `ToolResult` structured content.
- TableTheory-backed Body registry: handler persists only via `internal/agentregistry.Store.Create` / `AgentRegistry.Create`; no local registry substitute and no Lesser table writes.
- Lesser delegate client: handler calls `internal/lesserapi.Client.DelegateAgent` exactly once using the caller bearer; no raw HTTP reimplementation and no automatic retry.
- Lesser source contract checked against `lesser/docs/contracts/agent-delegate-api.md`, `cmd/api/routes.go`, `cmd/api/handlers/agents.go`, and `cmd/api/models/agents.go`: current `POST /api/v1/agents/delegate` delegates to an existing local agent account and does not create a new Lesser account.

## Behavior notes
- `agent_create` requires an account-holder OAuth principal and write scope.
- Agent principals, read-only principals, missing caller bearer, invalid input, and `actor_username` mismatch fail before Lesser or registry side effects.
- Success delegates existing Lesser agent runtime credentials and creates an account-scoped Body registry entry keyed by the authenticated account-holder and Lesser `account.id`.
- Duplicate Body registry conflicts map to `agent_already_exists` without registry cross-account detail leakage.
- Lesser API errors preserve upstream status/body details under source `lesser_agent_delegate`, with defensive token-field redaction.
- Delegated credentials are returned only in `structuredContent.data.token`, not logs or text content.

## Current Lesser producer constraint
This PR does not fabricate account creation in Body. The source-backed Lesser endpoint currently mints credentials for a pre-existing local agent account. The dormant Lesser creation helper is not modeled as current behavior.

## Partial-failure reconciliation
Lesser delegation is non-idempotent and can mint credentials before Body registry creation fails or observes a duplicate. Body does not retry `DelegateAgent` and cannot roll back minted Lesser credentials in this milestone; docs/tests cover this reconciliation caveat.

## Specialist walks referenced
- Tool surface: additive Ptah-only `agent_create`; write-scoped mutation annotations; no Ba/Ka registration.
- MCP contract: additive Ptah `tools/list` change only; public actor-scoped discovery remains the Ka contract.
- Lesser integration: consumes existing source-backed delegate API via `internal/lesserapi`; no Lesser source edits.
- Framework: idiomatic AppTheory/TableTheory consumption; no local framework substitutes.

## Validation
- `go build ./...` ✅
- `gofmt -l .` ✅ empty
- `go test ./...` ✅
- `go vet ./...` ✅
- `bash scripts/build.sh` ✅
- `bash gov-infra/verifiers/gov-verify-rubric.sh` ⚠️ ran; produced `gov_rubric_report.v1` status FAIL only because GOV-3 enforces governance-only diffs and this is a product-code branch. Generated evidence was reverted per repo convention; all functional checks inside the verifier passed (17 pass / 1 fail / 0 blocked).

## Stage rollout plan
- [ ] Merged to git branch `staging`
- [ ] Deployed to lab/dev
- [ ] Lab soak complete
- [ ] Deployed to deploy-stage staging if used
- [ ] Staging soak complete
- [ ] Live only with explicit operator authorization
