### PR TITLE
feat(ptah): register agent_get and agent_list tools

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -431,6 +431,72 @@ surface or Ba's `/instance/ba/mcp` surface. Clients discover them with an authen
 |------|-------|-------------|
 | `agent_bind_soul` | Write | Orchestrate Lesser's hosted soul/body binding ceremony for the authenticated account-holder actor. |
 | `agent_create` | Write | Delegate runtime credentials for an existing Lesser local agent account and create a Body/Ptah account-scoped registry entry. |
+| `agent_get` | Read | Read one Body/Ptah account-scoped registry entry for the authenticated account-holder actor. |
+| `agent_list` | Read | List Body/Ptah account-scoped registry entries with cursor pagination. |
+
+`agent_get` input:
+
+- Required: `agent_id`.
+- Derived: the account scope is always the authenticated account-holder OAuth principal. Callers cannot supply an
+  account override. Optional `actor_username`, when supplied, must match the authenticated principal after normalization
+  or the tool fails closed.
+
+`agent_get` requires an account-holder OAuth principal with read-capable scope. `read`, `write`, and `admin` are
+read-capable for this instance-plane read surface; agent-delegated principals and non-account-holder principals are
+rejected before the registry is read. The tool calls only the Body-owned `internal/agentregistry.Store.Get` path over the
+`INSTANCE_REGISTRY_TABLE`; it does not call Lesser and does not read `LESSER_TABLE_NAME`.
+
+Successful output has `structuredContent.data.registry`:
+
+```json
+{
+  "account": "<authenticated account username>",
+  "agent_id": "<agent id>",
+  "created_at": "<RFC3339 timestamp>",
+  "updated_at": "<RFC3339 timestamp>"
+}
+```
+
+The current registry record stores only account, agent id, and registry timestamps. It does not yet have a source-backed
+content-version field or content summary. Until a future source-backed field exists, `agent_get` returns explicit
+placeholders:
+
+```json
+{
+  "content_version": {"status": "not_available", "source": "agentregistry"},
+  "content_summary": {"status": "not_available", "source": "agentregistry"}
+}
+```
+
+Missing records and cross-account lookups return tool error code `not_found` with no account/agent detail leakage.
+Malformed input returns `invalid_request`; registry read failures return `agent_registry_error`.
+
+`agent_list` input:
+
+- Optional: `limit` (default `25`, maximum `100`) and opaque `cursor`.
+- Not accepted: account overrides. The account partition is always derived from the authenticated account-holder
+  principal.
+
+`agent_list` requires the same account-holder/read-capable authority as `agent_get`. It uses
+`internal/agentregistry.Store.List`, which performs a TableTheory query over the `ACCOUNT#<account>` partition and
+`AGENT#` sort-key prefix in `INSTANCE_REGISTRY_TABLE`; it does not scan the table, read Lesser's table, or call Lesser.
+
+Successful output includes `structuredContent.data.agents`, where each item contains `registry`, `content_version`, and
+`content_summary` using the same shapes and current `not_available` placeholders as `agent_get`, plus pagination
+metadata:
+
+```json
+{
+  "pagination": {
+    "limit": 25,
+    "next_cursor": "<opaque cursor or empty string>",
+    "has_more": false,
+    "count": 0
+  }
+}
+```
+
+Invalid `limit` or `cursor` values return `invalid_request`. Registry failures return `agent_registry_error`.
 
 `agent_create` input:
 

--- a/internal/agentregistry/store.go
+++ b/internal/agentregistry/store.go
@@ -24,6 +24,12 @@ const (
 
 	accountPKPrefix = "ACCOUNT#"
 	agentSKPrefix   = "AGENT#"
+
+	// DefaultListLimit is the page size used when callers do not request one.
+	DefaultListLimit = 25
+
+	// MaxListLimit is the largest page size accepted by the registry list API.
+	MaxListLimit = 100
 )
 
 var (
@@ -35,6 +41,14 @@ var (
 	// supplied account scope and agent id. Cross-account reads intentionally map
 	// here rather than disclosing that the agent id exists under another account.
 	ErrAgentNotFound = errors.New("agent not found")
+
+	// ErrInvalidCursor is returned when a pagination cursor cannot be decoded by
+	// TableTheory for this account-scoped registry query.
+	ErrInvalidCursor = errors.New("invalid cursor")
+
+	// ErrInvalidLimit is returned when callers request a nonsensical or
+	// unsupported registry list page size.
+	ErrInvalidLimit = errors.New("invalid limit")
 )
 
 // Agent is the account-scoped registry projection for a Ptah-created agent.
@@ -49,6 +63,21 @@ type Agent struct {
 type CreateInput struct {
 	Account string
 	AgentID string
+}
+
+// ListInput describes an account-scoped registry list request.
+type ListInput struct {
+	Account string
+	Cursor  string
+	Limit   int
+}
+
+// ListResult is a single account-scoped registry page.
+type ListResult struct {
+	Agents     []*Agent `json:"agents"`
+	NextCursor string   `json:"next_cursor"`
+	HasMore    bool     `json:"has_more"`
+	Count      int      `json:"count"`
 }
 
 // Store persists Ptah-created agent registry entries in a body-owned table.
@@ -154,6 +183,65 @@ func (s *Store) Get(ctx context.Context, account string, agentID string) (*Agent
 	}
 }
 
+// List returns a paginated page of registry records for one account partition.
+// It uses TableTheory query pagination over ACCOUNT#<account> and never scans or
+// accepts a caller-supplied account override outside this store API.
+func (s *Store) List(ctx context.Context, in ListInput) (*ListResult, error) {
+	if s == nil {
+		return nil, fmt.Errorf("agent registry store is nil")
+	}
+	account := normalizeAccount(in.Account)
+	if account == "" {
+		return nil, fmt.Errorf("account is required")
+	}
+	limit, err := normalizeListLimit(in.Limit)
+	if err != nil {
+		return nil, err
+	}
+	cursor := strings.TrimSpace(in.Cursor)
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	var records []agentRecord
+	query := s.db.Model(s.emptyRecord()).
+		WithContext(ctx).
+		Where("PK", "=", accountPartitionKey(account)).
+		Where("SK", "begins_with", agentSKPrefix).
+		Limit(limit)
+	if cursor != "" {
+		if err := query.SetCursor(cursor); err != nil {
+			return nil, fmt.Errorf("%w: %v", ErrInvalidCursor, err)
+		}
+	}
+
+	page, err := query.AllPaginated(&records)
+	if err != nil {
+		if cursor != "" && strings.Contains(strings.ToLower(err.Error()), "invalid cursor") {
+			return nil, fmt.Errorf("%w: %v", ErrInvalidCursor, err)
+		}
+		return nil, fmt.Errorf("list agent registry records: %w", err)
+	}
+
+	agents := make([]*Agent, 0, len(records))
+	for i := range records {
+		agents = append(agents, records[i].toAgent())
+	}
+
+	result := &ListResult{
+		Agents: agents,
+		Count:  len(agents),
+	}
+	if page != nil {
+		result.NextCursor = page.NextCursor
+		result.HasMore = page.HasMore
+		if page.Count > 0 || len(agents) == 0 {
+			result.Count = page.Count
+		}
+	}
+	return result, nil
+}
+
 func (s *Store) emptyRecord() *agentRecord {
 	return &agentRecord{tableName: s.tableName}
 }
@@ -221,4 +309,17 @@ func normalizeAccount(account string) string {
 
 func normalizeAgentID(agentID string) string {
 	return strings.TrimSpace(agentID)
+}
+
+func normalizeListLimit(limit int) (int, error) {
+	switch {
+	case limit == 0:
+		return DefaultListLimit, nil
+	case limit < 0:
+		return 0, fmt.Errorf("%w: limit must be positive", ErrInvalidLimit)
+	case limit > MaxListLimit:
+		return 0, fmt.Errorf("%w: limit must be <= %d", ErrInvalidLimit, MaxListLimit)
+	default:
+		return limit, nil
+	}
 }

--- a/internal/agentregistry/store_test.go
+++ b/internal/agentregistry/store_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"reflect"
 	"testing"
 
 	"github.com/theory-cloud/tabletheory/v2"
@@ -67,6 +68,66 @@ func TestCrossAccountGetReturnsNotFound(t *testing.T) {
 	}
 }
 
+func TestListReturnsAccountScopedPaginatedAgents(t *testing.T) {
+	store, _ := newTestStore(t)
+	for _, in := range []CreateInput{
+		{Account: "account-a", AgentID: "agent-001"},
+		{Account: "account-a", AgentID: "agent-002"},
+		{Account: "account-a", AgentID: "agent-003"},
+		{Account: "account-b", AgentID: "agent-000"},
+	} {
+		if _, err := store.Create(context.Background(), in); err != nil {
+			t.Fatalf("Create(%+v) error = %v", in, err)
+		}
+	}
+
+	first, err := store.List(context.Background(), ListInput{Account: " ACCOUNT-A ", Limit: 2})
+	if err != nil {
+		t.Fatalf("first List() error = %v", err)
+	}
+	if got, want := agentIDs(first.Agents), []string{"agent-001", "agent-002"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("first page agent ids = %v, want %v", got, want)
+	}
+	if first.Count != 2 || !first.HasMore || first.NextCursor == "" {
+		t.Fatalf("first page metadata = %+v, want count=2 has_more cursor", first)
+	}
+
+	second, err := store.List(context.Background(), ListInput{Account: "account-a", Limit: 2, Cursor: first.NextCursor})
+	if err != nil {
+		t.Fatalf("second List() error = %v", err)
+	}
+	if got, want := agentIDs(second.Agents), []string{"agent-003"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("second page agent ids = %v, want %v", got, want)
+	}
+	if second.Count != 1 || second.HasMore || second.NextCursor != "" {
+		t.Fatalf("second page metadata = %+v, want final page count=1", second)
+	}
+}
+
+func TestListEmptyAccountReturnsEmptyPage(t *testing.T) {
+	store, _ := newTestStore(t)
+	page, err := store.List(context.Background(), ListInput{Account: "account-a", Limit: 10})
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(page.Agents) != 0 || page.Count != 0 || page.HasMore || page.NextCursor != "" {
+		t.Fatalf("empty page = %+v, want empty terminal page", page)
+	}
+}
+
+func TestListRejectsInvalidCursorAndLimit(t *testing.T) {
+	store, _ := newTestStore(t)
+	if _, err := store.List(context.Background(), ListInput{Account: "account-a", Limit: -1}); !errors.Is(err, ErrInvalidLimit) {
+		t.Fatalf("negative limit error = %v, want ErrInvalidLimit", err)
+	}
+	if _, err := store.List(context.Background(), ListInput{Account: "account-a", Limit: MaxListLimit + 1}); !errors.Is(err, ErrInvalidLimit) {
+		t.Fatalf("too-large limit error = %v, want ErrInvalidLimit", err)
+	}
+	if _, err := store.List(context.Background(), ListInput{Account: "account-a", Limit: 10, Cursor: "not-a-valid-cursor"}); !errors.Is(err, ErrInvalidCursor) {
+		t.Fatalf("invalid cursor error = %v, want ErrInvalidCursor", err)
+	}
+}
+
 func TestCreateUsesInstanceRegistryTableNotLesserTable(t *testing.T) {
 	store, fake := newTestStore(t)
 	if _, err := store.Create(context.Background(), CreateInput{Account: "account-a", AgentID: "agent-123"}); err != nil {
@@ -80,6 +141,29 @@ func TestCreateUsesInstanceRegistryTableNotLesserTable(t *testing.T) {
 	lesserItems := fake.Items(os.Getenv("LESSER_TABLE_NAME"))
 	if len(lesserItems) != 0 {
 		t.Fatalf("LESSER_TABLE_NAME items = %d, want 0", len(lesserItems))
+	}
+}
+
+func TestListUsesInstanceRegistryTableNotLesserTable(t *testing.T) {
+	store, fake := newTestStore(t)
+	for _, in := range []CreateInput{
+		{Account: "account-a", AgentID: "agent-001"},
+		{Account: "account-a", AgentID: "agent-002"},
+	} {
+		if _, err := store.Create(context.Background(), in); err != nil {
+			t.Fatalf("Create(%+v) error = %v", in, err)
+		}
+	}
+
+	page, err := store.List(context.Background(), ListInput{Account: "account-a", Limit: 10})
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if got, want := agentIDs(page.Agents), []string{"agent-001", "agent-002"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("agent ids = %v, want %v", got, want)
+	}
+	if len(fake.Items(os.Getenv("LESSER_TABLE_NAME"))) != 0 {
+		t.Fatalf("List/Create used LESSER_TABLE_NAME items: %+v", fake.Items(os.Getenv("LESSER_TABLE_NAME")))
 	}
 }
 
@@ -101,4 +185,16 @@ func newTestStore(t *testing.T) (*Store, *fakedb.Fake) {
 		t.Fatalf("CreateTable() error = %v", err)
 	}
 	return store, fake
+}
+
+func agentIDs(agents []*Agent) []string {
+	out := make([]string, 0, len(agents))
+	for _, agent := range agents {
+		if agent == nil {
+			out = append(out, "<nil>")
+			continue
+		}
+		out = append(out, agent.AgentID)
+	}
+	return out
 }

--- a/internal/instanceapp/app_test.go
+++ b/internal/instanceapp/app_test.go
@@ -44,7 +44,7 @@ func TestInstancePlaneMCP_InitializeAndToolsList(t *testing.T) {
 		serverName string
 		wantTools  []string
 	}{
-		{name: "ptah", path: "/instance/ptah/mcp", serverName: "lesser-body-instance-ptah", wantTools: []string{"agent_bind_soul", "agent_create"}},
+		{name: "ptah", path: "/instance/ptah/mcp", serverName: "lesser-body-instance-ptah", wantTools: []string{"agent_bind_soul", "agent_create", "agent_get", "agent_list"}},
 		{name: "ba", path: "/instance/ba/mcp", serverName: "lesser-body-instance-ba", wantTools: []string{}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -113,6 +113,14 @@ func TestInstancePlaneMCP_InitializeAndToolsList(t *testing.T) {
 				createDef := listBody.Result.Tools[1]
 				if createDef.Name != "agent_create" || createDef.Annotations == nil || createDef.Annotations.ReadOnlyHint == nil || *createDef.Annotations.ReadOnlyHint || createDef.Annotations.DestructiveHint == nil || *createDef.Annotations.DestructiveHint {
 					t.Fatalf("agent_create annotations not write/additive: %+v", createDef)
+				}
+				getDef := listBody.Result.Tools[2]
+				if getDef.Name != "agent_get" || getDef.Annotations == nil || getDef.Annotations.ReadOnlyHint == nil || !*getDef.Annotations.ReadOnlyHint {
+					t.Fatalf("agent_get annotations not read-only: %+v", getDef)
+				}
+				listDef := listBody.Result.Tools[3]
+				if listDef.Name != "agent_list" || listDef.Annotations == nil || listDef.Annotations.ReadOnlyHint == nil || !*listDef.Annotations.ReadOnlyHint {
+					t.Fatalf("agent_list annotations not read-only: %+v", listDef)
 				}
 			}
 		})
@@ -342,6 +350,108 @@ func TestInstancePlaneMCP_AgentCreateDelegatesWithCallerBearerAndRegistry(t *tes
 	}
 	if len(out.Result.Content) == 0 || strings.Contains(out.Result.Content[0].Text, "mock-access-token") || strings.Contains(out.Result.Content[0].Text, "mock-refresh-token") {
 		t.Fatalf("text content leaked delegated credentials: %+v", out.Result.Content)
+	}
+}
+
+func TestInstancePlaneMCP_AgentGetAndListReadRegistry(t *testing.T) {
+	registryStore := newInstanceAgentRegistryStore(t)
+	for _, in := range []agentregistry.CreateInput{
+		{Account: "agent1", AgentID: "agent-001"},
+		{Account: "agent1", AgentID: "agent-002"},
+		{Account: "agent2", AgentID: "agent-000"},
+	} {
+		if _, err := registryStore.Create(context.Background(), in); err != nil {
+			t.Fatalf("Create(%+v): %v", in, err)
+		}
+	}
+	resetRegistry := ptahserver.SetAgentRegistryFactoryForTests(func() (ptahserver.AgentRegistry, error) {
+		return registryStore, nil
+	})
+	t.Cleanup(resetRegistry)
+
+	t.Setenv("JWT_SECRET", "test-secret")
+	auth.ResetForTests()
+
+	app, err := instanceapp.New("lesser-body-instance", "dev")
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+	env := testkit.New()
+	userToken := newTestTokenWithAudience(t, "test-secret", "agent1", []string{"read"}, audienceForPath("/instance/ptah/mcp"))
+	headers := initializedMCPHeaders(t, env, app, "/instance/ptah/mcp", userToken)
+
+	getOut := callMCPTool(t, env, app, "/instance/ptah/mcp", headers, "agent_get", map[string]any{
+		"agent_id": "agent-001",
+	})
+	if getOut.Result == nil || getOut.Result.IsError {
+		t.Fatalf("agent_get result = %+v error = %+v", getOut.Result, getOut.Error)
+	}
+	getData := toolResultData(t, getOut.Result)
+	registrySummary, _ := getData["registry"].(map[string]any)
+	if registrySummary["account"] != "agent1" || registrySummary["agent_id"] != "agent-001" {
+		t.Fatalf("agent_get registry summary = %+v", registrySummary)
+	}
+	contentVersion, _ := getData["content_version"].(map[string]any)
+	if contentVersion["status"] != "not_available" {
+		t.Fatalf("content_version = %+v, want not_available", contentVersion)
+	}
+
+	missingOut := callMCPTool(t, env, app, "/instance/ptah/mcp", headers, "agent_get", map[string]any{
+		"agent_id": "agent-000",
+	})
+	if missingOut.Result == nil || !missingOut.Result.IsError {
+		t.Fatalf("cross-account agent_get result = %+v error = %+v", missingOut.Result, missingOut.Error)
+	}
+	missingErr := toolResultError(t, missingOut.Result)
+	if missingErr["code"] != "not_found" || missingErr["status"] != float64(404) {
+		t.Fatalf("cross-account error = %+v, want not_found", missingErr)
+	}
+	if encoded, _ := json.Marshal(missingErr); strings.Contains(string(encoded), "agent-000") || strings.Contains(string(encoded), "agent2") {
+		t.Fatalf("cross-account not_found leaked registry detail: %s", string(encoded))
+	}
+
+	firstPage := callMCPTool(t, env, app, "/instance/ptah/mcp", headers, "agent_list", map[string]any{
+		"limit": 1,
+	})
+	if firstPage.Result == nil || firstPage.Result.IsError {
+		t.Fatalf("first agent_list result = %+v error = %+v", firstPage.Result, firstPage.Error)
+	}
+	firstData := toolResultData(t, firstPage.Result)
+	firstAgents, _ := firstData["agents"].([]any)
+	if len(firstAgents) != 1 {
+		t.Fatalf("first agents = %+v, want one", firstData["agents"])
+	}
+	firstItem, _ := firstAgents[0].(map[string]any)
+	firstRegistry, _ := firstItem["registry"].(map[string]any)
+	if firstRegistry["agent_id"] != "agent-001" || firstRegistry["account"] != "agent1" {
+		t.Fatalf("first registry = %+v, want agent-001/agent1", firstRegistry)
+	}
+	firstPagination, _ := firstData["pagination"].(map[string]any)
+	nextCursor, _ := firstPagination["next_cursor"].(string)
+	if nextCursor == "" || firstPagination["has_more"] != true || firstPagination["count"] != float64(1) {
+		t.Fatalf("first pagination = %+v, want cursor/has_more/count", firstPagination)
+	}
+
+	secondPage := callMCPTool(t, env, app, "/instance/ptah/mcp", headers, "agent_list", map[string]any{
+		"limit":  10,
+		"cursor": nextCursor,
+	})
+	if secondPage.Result == nil || secondPage.Result.IsError {
+		t.Fatalf("second agent_list result = %+v error = %+v", secondPage.Result, secondPage.Error)
+	}
+	secondData := toolResultData(t, secondPage.Result)
+	secondAgents, _ := secondData["agents"].([]any)
+	if len(secondAgents) != 1 {
+		t.Fatalf("second agents = %+v, want one", secondData["agents"])
+	}
+	secondItem, _ := secondAgents[0].(map[string]any)
+	secondRegistry, _ := secondItem["registry"].(map[string]any)
+	if secondRegistry["agent_id"] != "agent-002" || secondRegistry["account"] != "agent1" {
+		t.Fatalf("second registry = %+v, want agent-002/agent1", secondRegistry)
+	}
+	secondPagination, _ := secondData["pagination"].(map[string]any)
+	if secondPagination["has_more"] != false || secondPagination["next_cursor"] != "" || secondPagination["count"] != float64(1) {
+		t.Fatalf("second pagination = %+v, want terminal page", secondPagination)
 	}
 }
 

--- a/internal/ptahserver/ptahserver.go
+++ b/internal/ptahserver/ptahserver.go
@@ -28,6 +28,8 @@ const (
 
 	toolAgentBindSoul = "agent_bind_soul"
 	toolAgentCreate   = "agent_create"
+	toolAgentGet      = "agent_get"
+	toolAgentList     = "agent_list"
 )
 
 type soulBindingClient interface {
@@ -38,11 +40,13 @@ type agentDelegateClient interface {
 	DelegateAgent(ctx context.Context, bearerToken string, req lesserapi.AgentDelegationRequest) (*lesserapi.AgentDelegationResponse, error)
 }
 
-// AgentRegistry is the body-owned Ptah registry dependency used by
-// agent_create. It is exported so instance-plane integration tests can inject a
-// TableTheory-backed fake store without changing instanceapp behavior.
+// AgentRegistry is the body-owned Ptah registry dependency used by Ptah agent
+// registry tools. It is exported so instance-plane integration tests can inject
+// a TableTheory-backed fake store without changing instanceapp behavior.
 type AgentRegistry interface {
 	Create(ctx context.Context, in agentregistry.CreateInput) (*agentregistry.Agent, error)
+	Get(ctx context.Context, account string, agentID string) (*agentregistry.Agent, error)
+	List(ctx context.Context, in agentregistry.ListInput) (*agentregistry.ListResult, error)
 }
 
 type config struct {
@@ -79,7 +83,7 @@ func WithAgentDelegateClient(client agentDelegateClient) Option {
 }
 
 // WithAgentRegistryStore injects the body-owned agent registry store used by
-// agent_create.
+// Ptah agent registry tools.
 func WithAgentRegistryStore(store AgentRegistry) Option {
 	return func(cfg *config) {
 		cfg.agentRegistry = store
@@ -133,7 +137,13 @@ func RegisterTools(r *mcpruntime.ToolRegistry, opts ...Option) error {
 	if err := r.RegisterTool(agentBindSoulDef(), cfg.handleAgentBindSoul); err != nil {
 		return err
 	}
-	return r.RegisterTool(agentCreateDef(), cfg.handleAgentCreate)
+	if err := r.RegisterTool(agentCreateDef(), cfg.handleAgentCreate); err != nil {
+		return err
+	}
+	if err := r.RegisterTool(agentGetDef(), cfg.handleAgentGet); err != nil {
+		return err
+	}
+	return r.RegisterTool(agentListDef(), cfg.handleAgentList)
 }
 
 func defaultConfig() config {
@@ -227,6 +237,55 @@ func agentCreateDef() mcpruntime.ToolDef {
 	}
 }
 
+func agentGetDef() mcpruntime.ToolDef {
+	return mcpruntime.ToolDef{
+		Name:        toolAgentGet,
+		Title:       "Get registered agent",
+		Description: "Read a Body/Ptah account-scoped agent registry entry for the authenticated account-holder principal. Requires read scope.",
+		Annotations: readOnlyToolAnnotations(),
+		InputSchema: json.RawMessage(`{
+			"type":"object",
+			"properties":{
+				"agent_id":{"type":"string","description":"Agent id to read from the authenticated account-holder's Ptah registry partition."},
+				"actor_username":{"type":"string","description":"Optional explicit account-holder actor username. When supplied it must match the authenticated principal."}
+			},
+			"required":["agent_id"],
+			"additionalProperties":false
+		}`),
+		OutputSchema: json.RawMessage(`{
+			"type":"object",
+			"properties":{
+				"data":{"type":"object","description":"Account-scoped registry summary plus source-truth content-version/content-summary availability placeholders."},
+				"error":{"type":"object","description":"Structured tool error when isError=true."}
+			}
+		}`),
+	}
+}
+
+func agentListDef() mcpruntime.ToolDef {
+	return mcpruntime.ToolDef{
+		Name:        toolAgentList,
+		Title:       "List registered agents",
+		Description: "List Body/Ptah account-scoped agent registry entries for the authenticated account-holder principal. Requires read scope.",
+		Annotations: readOnlyToolAnnotations(),
+		InputSchema: json.RawMessage(fmt.Sprintf(`{
+			"type":"object",
+			"properties":{
+				"limit":{"type":"integer","minimum":1,"maximum":%d,"description":"Optional page size. Defaults to %d."},
+				"cursor":{"type":"string","description":"Optional opaque pagination cursor returned by a prior agent_list call."}
+			},
+			"additionalProperties":false
+		}`, agentregistry.MaxListLimit, agentregistry.DefaultListLimit)),
+		OutputSchema: json.RawMessage(`{
+			"type":"object",
+			"properties":{
+				"data":{"type":"object","description":"Account-scoped registry entries and pagination metadata."},
+				"error":{"type":"object","description":"Structured tool error when isError=true."}
+			}
+		}`),
+	}
+}
+
 type agentBindSoulInput struct {
 	SoulAgentID        string                  `json:"soul_agent_id"`
 	IdempotencyKey     string                  `json:"idempotency_key"`
@@ -253,6 +312,16 @@ type agentCreateInput struct {
 	DeviceLabel   string   `json:"device_label"`
 	AgentInfo     any      `json:"agent_info"`
 	ActorUsername string   `json:"actor_username"`
+}
+
+type agentGetInput struct {
+	AgentID       string `json:"agent_id"`
+	ActorUsername string `json:"actor_username"`
+}
+
+type agentListInput struct {
+	Limit  *int   `json:"limit"`
+	Cursor string `json:"cursor"`
 }
 
 func (cfg config) handleAgentBindSoul(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
@@ -439,6 +508,121 @@ func (cfg config) handleAgentCreate(ctx context.Context, args json.RawMessage) (
 	return agentCreateSuccessResult(actorUsername, resp, created)
 }
 
+func (cfg config) handleAgentGet(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
+	principal := auth.PrincipalFromToolContext(ctx)
+	actorUsername, errResult, err := authenticatedAccountHolderActor(principal, toolAgentGet)
+	if errResult != nil || err != nil {
+		return errResult, err
+	}
+	if !principalHasReadScope(principal) {
+		return toolErrorResult("insufficient_scope", "agent_get requires read scope", http.StatusForbidden, map[string]any{
+			"requiredScopes": []string{"read"},
+			"grantedScopes":  normalizedScopes(principal.Claims.Scopes),
+		})
+	}
+
+	in, errResult, err := parseAgentGetInput(args, actorUsername)
+	if errResult != nil || err != nil {
+		return errResult, err
+	}
+
+	registry, err := cfg.registry()
+	if err != nil {
+		return toolErrorResult("not_configured", err.Error(), http.StatusInternalServerError, map[string]any{
+			"source": "agent_registry",
+		})
+	}
+
+	slog.InfoContext(ctx, "ptah tool invocation",
+		"tool", toolAgentGet,
+		"actor_username", actorUsername,
+	)
+
+	agent, err := registry.Get(ctx, actorUsername, in.AgentID)
+	if err != nil {
+		if errors.Is(err, agentregistry.ErrAgentNotFound) {
+			return toolErrorResult("not_found", "agent not found in this account-scoped Ptah registry", http.StatusNotFound, map[string]any{
+				"source": "agent_registry",
+			})
+		}
+		slog.WarnContext(ctx, "ptah agent_get registry read failed",
+			"tool", toolAgentGet,
+			"actor_username", actorUsername,
+			"error", err.Error(),
+		)
+		return toolErrorResult("agent_registry_error", "Body failed to read the Ptah registry entry", http.StatusInternalServerError, map[string]any{
+			"source": "agent_registry",
+		})
+	}
+	return agentGetSuccessResult(actorUsername, agent)
+}
+
+func (cfg config) handleAgentList(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
+	principal := auth.PrincipalFromToolContext(ctx)
+	actorUsername, errResult, err := authenticatedAccountHolderActor(principal, toolAgentList)
+	if errResult != nil || err != nil {
+		return errResult, err
+	}
+	if !principalHasReadScope(principal) {
+		return toolErrorResult("insufficient_scope", "agent_list requires read scope", http.StatusForbidden, map[string]any{
+			"requiredScopes": []string{"read"},
+			"grantedScopes":  normalizedScopes(principal.Claims.Scopes),
+		})
+	}
+
+	in, errResult, err := parseAgentListInput(args)
+	if errResult != nil || err != nil {
+		return errResult, err
+	}
+
+	registry, err := cfg.registry()
+	if err != nil {
+		return toolErrorResult("not_configured", err.Error(), http.StatusInternalServerError, map[string]any{
+			"source": "agent_registry",
+		})
+	}
+
+	limit := agentregistry.DefaultListLimit
+	if in.Limit != nil {
+		limit = *in.Limit
+	}
+
+	slog.InfoContext(ctx, "ptah tool invocation",
+		"tool", toolAgentList,
+		"actor_username", actorUsername,
+		"limit", limit,
+		"cursor_present", strings.TrimSpace(in.Cursor) != "",
+	)
+
+	page, err := registry.List(ctx, agentregistry.ListInput{
+		Account: actorUsername,
+		Limit:   limit,
+		Cursor:  in.Cursor,
+	})
+	if err != nil {
+		switch {
+		case errors.Is(err, agentregistry.ErrInvalidCursor):
+			return toolErrorResult("invalid_request", "cursor is invalid", http.StatusBadRequest, map[string]any{
+				"source": "agent_registry",
+			})
+		case errors.Is(err, agentregistry.ErrInvalidLimit):
+			return toolErrorResult("invalid_request", "limit is invalid", http.StatusBadRequest, map[string]any{
+				"source": "agent_registry",
+			})
+		default:
+			slog.WarnContext(ctx, "ptah agent_list registry list failed",
+				"tool", toolAgentList,
+				"actor_username", actorUsername,
+				"error", err.Error(),
+			)
+			return toolErrorResult("agent_registry_error", "Body failed to list Ptah registry entries", http.StatusInternalServerError, map[string]any{
+				"source": "agent_registry",
+			})
+		}
+	}
+	return agentListSuccessResult(actorUsername, limit, page)
+}
+
 func authenticatedAccountHolderActor(principal *auth.Principal, toolName string) (string, *mcpruntime.ToolResult, error) {
 	if principal == nil || principal.Type != auth.PrincipalTypeOAuthToken || principal.Claims == nil || principal.Claims.IsAgent {
 		return "", mustToolErrorResult("forbidden", toolName+" requires an account-holder OAuth principal", http.StatusForbidden, map[string]any{
@@ -527,6 +711,56 @@ func parseAgentCreateInput(args json.RawMessage, actorUsername string) (agentCre
 		return agentCreateInput{}, mustToolErrorResult("forbidden", "actor_username must match authenticated principal", http.StatusForbidden, map[string]any{
 			"source": "lesser_body_ptah",
 		}), nil
+	}
+	return in, nil, nil
+}
+
+func parseAgentGetInput(args json.RawMessage, actorUsername string) (agentGetInput, *mcpruntime.ToolResult, error) {
+	raw := strings.TrimSpace(string(args))
+	if raw == "" || raw == "null" {
+		raw = "{}"
+	}
+
+	var in agentGetInput
+	dec := json.NewDecoder(bytes.NewReader([]byte(raw)))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&in); err != nil {
+		return agentGetInput{}, mustToolErrorResult("invalid_request", "invalid args: "+err.Error(), http.StatusBadRequest, nil), nil
+	}
+	in.AgentID = strings.TrimSpace(in.AgentID)
+	in.ActorUsername = normalizeActorUsername(in.ActorUsername)
+
+	if in.AgentID == "" {
+		return agentGetInput{}, mustToolErrorResult("invalid_request", "agent_id is required", http.StatusBadRequest, nil), nil
+	}
+	if in.ActorUsername != "" && in.ActorUsername != actorUsername {
+		return agentGetInput{}, mustToolErrorResult("forbidden", "actor_username must match authenticated principal", http.StatusForbidden, map[string]any{
+			"source": "lesser_body_ptah",
+		}), nil
+	}
+	return in, nil, nil
+}
+
+func parseAgentListInput(args json.RawMessage) (agentListInput, *mcpruntime.ToolResult, error) {
+	raw := strings.TrimSpace(string(args))
+	if raw == "" || raw == "null" {
+		raw = "{}"
+	}
+
+	var in agentListInput
+	dec := json.NewDecoder(bytes.NewReader([]byte(raw)))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&in); err != nil {
+		return agentListInput{}, mustToolErrorResult("invalid_request", "invalid args: "+err.Error(), http.StatusBadRequest, nil), nil
+	}
+	in.Cursor = strings.TrimSpace(in.Cursor)
+	if in.Limit != nil {
+		switch limit := *in.Limit; {
+		case limit <= 0:
+			return agentListInput{}, mustToolErrorResult("invalid_request", "limit must be positive", http.StatusBadRequest, nil), nil
+		case limit > agentregistry.MaxListLimit:
+			return agentListInput{}, mustToolErrorResult("invalid_request", fmt.Sprintf("limit must be <= %d", agentregistry.MaxListLimit), http.StatusBadRequest, nil), nil
+		}
 	}
 	return in, nil, nil
 }
@@ -693,6 +927,69 @@ func agentCreateSuccessResult(actorUsername string, resp *lesserapi.AgentDelegat
 	return toolJSONTextResult(text, map[string]any{"data": data})
 }
 
+func agentGetSuccessResult(actorUsername string, agent *agentregistry.Agent) (*mcpruntime.ToolResult, error) {
+	registrySummary := registryAgentSummary(agent)
+	contentVersion := unavailableContentVersion()
+	contentSummary := unavailableContentSummary()
+	data := map[string]any{
+		"actor_username":  actorUsername,
+		"registry":        registrySummary,
+		"content_version": contentVersion,
+		"content_summary": contentSummary,
+	}
+
+	text := map[string]any{
+		"summary":         "Ptah registry entry read",
+		"registry":        registrySummary,
+		"content_version": contentVersion,
+		"content_summary": contentSummary,
+		"data":            map[string]any{"location": "structuredContent.data"},
+	}
+	return toolJSONTextResult(text, map[string]any{"data": data})
+}
+
+func agentListSuccessResult(actorUsername string, limit int, page *agentregistry.ListResult) (*mcpruntime.ToolResult, error) {
+	agents := []*agentregistry.Agent(nil)
+	nextCursor := ""
+	hasMore := false
+	count := 0
+	if page != nil {
+		agents = page.Agents
+		nextCursor = page.NextCursor
+		hasMore = page.HasMore
+		count = page.Count
+	}
+	items := make([]map[string]any, 0, len(agents))
+	for _, agent := range agents {
+		items = append(items, map[string]any{
+			"registry":        registryAgentSummary(agent),
+			"content_version": unavailableContentVersion(),
+			"content_summary": unavailableContentSummary(),
+		})
+	}
+
+	pagination := map[string]any{
+		"limit":       limit,
+		"next_cursor": nextCursor,
+		"has_more":    hasMore,
+		"count":       count,
+	}
+	data := map[string]any{
+		"actor_username": actorUsername,
+		"agents":         items,
+		"pagination":     pagination,
+	}
+
+	text := map[string]any{
+		"summary":    "Ptah registry entries listed",
+		"count":      count,
+		"has_more":   hasMore,
+		"pagination": pagination,
+		"data":       map[string]any{"location": "structuredContent.data"},
+	}
+	return toolJSONTextResult(text, map[string]any{"data": data})
+}
+
 func soulBindingToolResultFromError(err error) (*mcpruntime.ToolResult, error) {
 	if err == nil {
 		return nil, nil
@@ -818,6 +1115,14 @@ func toolErrorResultPayload(payload map[string]any) (*mcpruntime.ToolResult, err
 	}, nil
 }
 
+func readOnlyToolAnnotations() *mcpruntime.ToolAnnotations {
+	return &mcpruntime.ToolAnnotations{
+		ReadOnlyHint:    boolHint(true),
+		DestructiveHint: boolHint(false),
+		IdempotentHint:  boolHint(true),
+	}
+}
+
 func additiveMutationToolAnnotations() *mcpruntime.ToolAnnotations {
 	return &mcpruntime.ToolAnnotations{
 		ReadOnlyHint:    boolHint(false),
@@ -828,6 +1133,19 @@ func additiveMutationToolAnnotations() *mcpruntime.ToolAnnotations {
 
 func boolHint(value bool) *bool {
 	return &value
+}
+
+func principalHasReadScope(principal *auth.Principal) bool {
+	if principal == nil || principal.Claims == nil {
+		return false
+	}
+	for _, scope := range principal.Claims.Scopes {
+		switch strings.ToLower(strings.TrimSpace(scope)) {
+		case "read", "write", "admin":
+			return true
+		}
+	}
+	return false
 }
 
 func principalHasWriteScope(principal *auth.Principal) bool {
@@ -871,6 +1189,34 @@ func firstNonEmpty(values ...string) string {
 		}
 	}
 	return ""
+}
+
+func registryAgentSummary(agent *agentregistry.Agent) map[string]any {
+	if agent == nil {
+		return map[string]any{}
+	}
+	return map[string]any{
+		"account":    agent.Account,
+		"agent_id":   agent.AgentID,
+		"created_at": formatTime(agent.CreatedAt),
+		"updated_at": formatTime(agent.UpdatedAt),
+	}
+}
+
+func unavailableContentVersion() map[string]any {
+	return map[string]any{
+		"status": "not_available",
+		"source": "agentregistry",
+		"reason": "Body/Ptah registry records do not currently store source-backed content version metadata.",
+	}
+}
+
+func unavailableContentSummary() map[string]any {
+	return map[string]any{
+		"status": "not_available",
+		"source": "agentregistry",
+		"reason": "Body/Ptah registry records do not currently store source-backed content summary metadata.",
+	}
 }
 
 func delegatedAgentID(resp *lesserapi.AgentDelegationResponse) string {

--- a/internal/ptahserver/ptahserver_test.go
+++ b/internal/ptahserver/ptahserver_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -22,7 +23,7 @@ func TestRegisterToolsRegistersPtahDefinitions(t *testing.T) {
 	}
 
 	tools := registry.List()
-	if got, want := toolDefNames(tools), []string{toolAgentBindSoul, toolAgentCreate}; strings.Join(got, ",") != strings.Join(want, ",") {
+	if got, want := toolDefNames(tools), []string{toolAgentBindSoul, toolAgentCreate, toolAgentGet, toolAgentList}; strings.Join(got, ",") != strings.Join(want, ",") {
 		t.Fatalf("registered tool order = %v, want %v", got, want)
 	}
 	def := tools[0]
@@ -81,6 +82,42 @@ func TestRegisterToolsRegistersPtahDefinitions(t *testing.T) {
 	for _, prop := range []string{"actor_username", "display_name", "bio", "expires_in", "device_label", "agent_info"} {
 		if _, ok := createSchema.Props[prop]; !ok {
 			t.Fatalf("agent_create schema missing %s", prop)
+		}
+	}
+
+	getDef := tools[2]
+	if getDef.Name != toolAgentGet {
+		t.Fatalf("third tool name = %q, want %q", getDef.Name, toolAgentGet)
+	}
+	assertReadOnlyToolDef(t, getDef)
+	var getSchema struct {
+		Required []string       `json:"required"`
+		Props    map[string]any `json:"properties"`
+	}
+	if err := json.Unmarshal(getDef.InputSchema, &getSchema); err != nil {
+		t.Fatalf("agent_get input schema invalid json: %v", err)
+	}
+	if !contains(getSchema.Required, "agent_id") {
+		t.Fatalf("agent_get required = %v, missing agent_id", getSchema.Required)
+	}
+	if _, ok := getSchema.Props["actor_username"]; !ok {
+		t.Fatalf("agent_get schema should advertise optional actor_username mismatch guard")
+	}
+
+	listDef := tools[3]
+	if listDef.Name != toolAgentList {
+		t.Fatalf("fourth tool name = %q, want %q", listDef.Name, toolAgentList)
+	}
+	assertReadOnlyToolDef(t, listDef)
+	var listSchema struct {
+		Props map[string]any `json:"properties"`
+	}
+	if err := json.Unmarshal(listDef.InputSchema, &listSchema); err != nil {
+		t.Fatalf("agent_list input schema invalid json: %v", err)
+	}
+	for _, prop := range []string{"limit", "cursor"} {
+		if _, ok := listSchema.Props[prop]; !ok {
+			t.Fatalf("agent_list schema missing %s", prop)
 		}
 	}
 }
@@ -425,6 +462,270 @@ func TestAgentCreateDocumentsPartialFailureWhenRegistryCreateFails(t *testing.T)
 	}
 }
 
+func TestAgentGetReadsAccountScopedRegistryWithReadCapableScopes(t *testing.T) {
+	for _, scope := range []string{"read", "write", "admin"} {
+		t.Run(scope, func(t *testing.T) {
+			store := &fakeAgentRegistry{getAgent: &agentregistry.Agent{
+				Account:   "drone-ada",
+				AgentID:   "agent-123",
+				CreatedAt: time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC),
+				UpdatedAt: time.Date(2026, 7, 15, 12, 30, 0, 0, time.UTC),
+			}}
+			registry := mcpruntime.NewToolRegistry()
+			if err := RegisterTools(registry, WithAgentRegistryStore(store)); err != nil {
+				t.Fatalf("RegisterTools: %v", err)
+			}
+
+			result, err := registry.Call(toolContext("Drone-Ada", []string{scope}, "owner-oauth-token"), toolAgentGet, json.RawMessage(`{"agent_id":" agent-123 ","actor_username":"drone-ada"}`))
+			if err != nil {
+				t.Fatalf("Call: %v", err)
+			}
+			if result == nil || result.IsError {
+				t.Fatalf("result = %+v", result)
+			}
+			if store.getCalls != 1 || store.getAccount != "drone-ada" || store.getAgentID != "agent-123" {
+				t.Fatalf("registry Get calls/account/id = %d/%q/%q, want 1/drone-ada/agent-123", store.getCalls, store.getAccount, store.getAgentID)
+			}
+			data := structuredData(t, result)
+			registrySummary, _ := data["registry"].(map[string]any)
+			if registrySummary["account"] != "drone-ada" || registrySummary["agent_id"] != "agent-123" {
+				t.Fatalf("registry summary = %+v", registrySummary)
+			}
+			contentVersion, _ := data["content_version"].(map[string]any)
+			contentSummary, _ := data["content_summary"].(map[string]any)
+			if contentVersion["status"] != "not_available" || contentSummary["status"] != "not_available" {
+				t.Fatalf("content placeholders = version %+v summary %+v", contentVersion, contentSummary)
+			}
+		})
+	}
+}
+
+func TestAgentGetNotFoundDoesNotLeakRegistryDetails(t *testing.T) {
+	store := &fakeAgentRegistry{getErr: fmt.Errorf("%w: hidden account/agent details", agentregistry.ErrAgentNotFound)}
+	registry := mcpruntime.NewToolRegistry()
+	if err := RegisterTools(registry, WithAgentRegistryStore(store)); err != nil {
+		t.Fatalf("RegisterTools: %v", err)
+	}
+
+	result, err := registry.Call(toolContext("drone-ada", []string{"read"}, "owner-oauth-token"), toolAgentGet, json.RawMessage(`{"agent_id":"agent-elsewhere"}`))
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	payload := assertToolError(t, result, "not_found", 404)
+	encoded, _ := json.Marshal(payload)
+	if strings.Contains(string(encoded), "hidden account/agent details") || strings.Contains(string(encoded), "agent-elsewhere") || strings.Contains(string(encoded), "drone-ada") {
+		t.Fatalf("not_found leaked account/agent details: %s", string(encoded))
+	}
+	if store.getCalls != 1 {
+		t.Fatalf("registry Get calls = %d, want 1", store.getCalls)
+	}
+}
+
+func TestAgentGetRejectsInvalidInputAndPrincipalsBeforeRegistryRead(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		ctx       context.Context
+		args      string
+		wantCode  string
+		wantState int
+	}{
+		{
+			name:      "missing agent_id",
+			ctx:       toolContext("drone-ada", []string{"read"}, "owner-oauth-token"),
+			args:      `{}`,
+			wantCode:  "invalid_request",
+			wantState: 400,
+		},
+		{
+			name:      "unknown field",
+			ctx:       toolContext("drone-ada", []string{"read"}, "owner-oauth-token"),
+			args:      `{"agent_id":"agent-123","account":"other"}`,
+			wantCode:  "invalid_request",
+			wantState: 400,
+		},
+		{
+			name:      "mismatched actor username",
+			ctx:       toolContext("drone-ada", []string{"read"}, "owner-oauth-token"),
+			args:      `{"agent_id":"agent-123","actor_username":"other"}`,
+			wantCode:  "forbidden",
+			wantState: 403,
+		},
+		{
+			name:      "insufficient scope",
+			ctx:       toolContext("drone-ada", []string{"follow"}, "owner-oauth-token"),
+			args:      `{"agent_id":"agent-123"}`,
+			wantCode:  "insufficient_scope",
+			wantState: 403,
+		},
+		{
+			name:      "agent principal",
+			ctx:       toolContextWithAgent("drone-ada", []string{"read"}, "agent-runtime-token", true),
+			args:      `{"agent_id":"agent-123"}`,
+			wantCode:  "forbidden",
+			wantState: 403,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := &fakeAgentRegistry{getAgent: &agentregistry.Agent{Account: "drone-ada", AgentID: "agent-123"}}
+			registry := mcpruntime.NewToolRegistry()
+			if err := RegisterTools(registry, WithAgentRegistryStore(store)); err != nil {
+				t.Fatalf("RegisterTools: %v", err)
+			}
+
+			result, err := registry.Call(tc.ctx, toolAgentGet, json.RawMessage(tc.args))
+			if err != nil {
+				t.Fatalf("Call: %v", err)
+			}
+			assertToolError(t, result, tc.wantCode, tc.wantState)
+			if store.getCalls != 0 {
+				t.Fatalf("registry Get calls = %d, want 0", store.getCalls)
+			}
+		})
+	}
+}
+
+func TestAgentListReadsAccountScopedRegistryWithPagination(t *testing.T) {
+	store := &fakeAgentRegistry{listResult: &agentregistry.ListResult{
+		Agents: []*agentregistry.Agent{
+			{
+				Account:   "drone-ada",
+				AgentID:   "agent-001",
+				CreatedAt: time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC),
+				UpdatedAt: time.Date(2026, 7, 15, 12, 1, 0, 0, time.UTC),
+			},
+			{
+				Account:   "drone-ada",
+				AgentID:   "agent-002",
+				CreatedAt: time.Date(2026, 7, 15, 12, 2, 0, 0, time.UTC),
+				UpdatedAt: time.Date(2026, 7, 15, 12, 3, 0, 0, time.UTC),
+			},
+		},
+		NextCursor: "cursor-2",
+		HasMore:    true,
+		Count:      2,
+	}}
+	registry := mcpruntime.NewToolRegistry()
+	if err := RegisterTools(registry, WithAgentRegistryStore(store)); err != nil {
+		t.Fatalf("RegisterTools: %v", err)
+	}
+
+	result, err := registry.Call(toolContext("Drone-Ada", []string{"read"}, "owner-oauth-token"), toolAgentList, json.RawMessage(`{"limit":2,"cursor":"cursor-1"}`))
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if result == nil || result.IsError {
+		t.Fatalf("result = %+v", result)
+	}
+	if store.listCalls != 1 || store.listIn.Account != "drone-ada" || store.listIn.Limit != 2 || store.listIn.Cursor != "cursor-1" {
+		t.Fatalf("registry List input = calls %d %+v, want account-scoped limit/cursor", store.listCalls, store.listIn)
+	}
+	data := structuredData(t, result)
+	agents, _ := data["agents"].([]map[string]any)
+	if len(agents) != 2 {
+		t.Fatalf("agents = %+v, want two", data["agents"])
+	}
+	gotIDs := []string{}
+	for _, item := range agents {
+		registrySummary, _ := item["registry"].(map[string]any)
+		gotIDs = append(gotIDs, registrySummary["agent_id"].(string))
+		contentVersion, _ := item["content_version"].(map[string]any)
+		if contentVersion["status"] != "not_available" {
+			t.Fatalf("content_version = %+v, want not_available", contentVersion)
+		}
+	}
+	if want := []string{"agent-001", "agent-002"}; !reflect.DeepEqual(gotIDs, want) {
+		t.Fatalf("agent ids = %v, want %v", gotIDs, want)
+	}
+	pagination, _ := data["pagination"].(map[string]any)
+	if pagination["next_cursor"] != "cursor-2" || pagination["has_more"] != true || pagination["count"] != 2 || pagination["limit"] != 2 {
+		t.Fatalf("pagination = %+v", pagination)
+	}
+}
+
+func TestAgentListRejectsInvalidInputAndPrincipalsBeforeRegistryRead(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		ctx       context.Context
+		args      string
+		wantCode  string
+		wantState int
+	}{
+		{
+			name:      "zero limit",
+			ctx:       toolContext("drone-ada", []string{"read"}, "owner-oauth-token"),
+			args:      `{"limit":0}`,
+			wantCode:  "invalid_request",
+			wantState: 400,
+		},
+		{
+			name:      "too large limit",
+			ctx:       toolContext("drone-ada", []string{"read"}, "owner-oauth-token"),
+			args:      fmt.Sprintf(`{"limit":%d}`, agentregistry.MaxListLimit+1),
+			wantCode:  "invalid_request",
+			wantState: 400,
+		},
+		{
+			name:      "caller-supplied account rejected",
+			ctx:       toolContext("drone-ada", []string{"read"}, "owner-oauth-token"),
+			args:      `{"account":"other"}`,
+			wantCode:  "invalid_request",
+			wantState: 400,
+		},
+		{
+			name:      "insufficient scope",
+			ctx:       toolContext("drone-ada", []string{"follow"}, "owner-oauth-token"),
+			args:      `{}`,
+			wantCode:  "insufficient_scope",
+			wantState: 403,
+		},
+		{
+			name:      "agent principal",
+			ctx:       toolContextWithAgent("drone-ada", []string{"read"}, "agent-runtime-token", true),
+			args:      `{}`,
+			wantCode:  "forbidden",
+			wantState: 403,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := &fakeAgentRegistry{listResult: &agentregistry.ListResult{}}
+			registry := mcpruntime.NewToolRegistry()
+			if err := RegisterTools(registry, WithAgentRegistryStore(store)); err != nil {
+				t.Fatalf("RegisterTools: %v", err)
+			}
+
+			result, err := registry.Call(tc.ctx, toolAgentList, json.RawMessage(tc.args))
+			if err != nil {
+				t.Fatalf("Call: %v", err)
+			}
+			assertToolError(t, result, tc.wantCode, tc.wantState)
+			if store.listCalls != 0 {
+				t.Fatalf("registry List calls = %d, want 0", store.listCalls)
+			}
+		})
+	}
+}
+
+func TestAgentListMapsInvalidCursor(t *testing.T) {
+	store := &fakeAgentRegistry{listErr: fmt.Errorf("%w: hidden cursor decode detail", agentregistry.ErrInvalidCursor)}
+	registry := mcpruntime.NewToolRegistry()
+	if err := RegisterTools(registry, WithAgentRegistryStore(store)); err != nil {
+		t.Fatalf("RegisterTools: %v", err)
+	}
+
+	result, err := registry.Call(toolContext("drone-ada", []string{"read"}, "owner-oauth-token"), toolAgentList, json.RawMessage(`{"cursor":"bad-cursor"}`))
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	payload := assertToolError(t, result, "invalid_request", 400)
+	encoded, _ := json.Marshal(payload)
+	if strings.Contains(string(encoded), "hidden cursor decode detail") {
+		t.Fatalf("invalid cursor leaked store detail: %s", string(encoded))
+	}
+	if store.listCalls != 1 || store.listIn.Account != "drone-ada" || store.listIn.Limit != agentregistry.DefaultListLimit || store.listIn.Cursor != "bad-cursor" {
+		t.Fatalf("registry List input = calls %d %+v, want default-limit account scoped cursor", store.listCalls, store.listIn)
+	}
+}
+
 type fakeSoulBindingClient struct {
 	calls             int
 	integrationBearer string
@@ -468,6 +769,17 @@ type fakeAgentRegistry struct {
 	in    agentregistry.CreateInput
 	agent *agentregistry.Agent
 	err   error
+
+	getCalls   int
+	getAccount string
+	getAgentID string
+	getAgent   *agentregistry.Agent
+	getErr     error
+
+	listCalls  int
+	listIn     agentregistry.ListInput
+	listResult *agentregistry.ListResult
+	listErr    error
 }
 
 func (f *fakeAgentRegistry) Create(_ context.Context, in agentregistry.CreateInput) (*agentregistry.Agent, error) {
@@ -477,6 +789,31 @@ func (f *fakeAgentRegistry) Create(_ context.Context, in agentregistry.CreateInp
 		return nil, f.err
 	}
 	return f.agent, nil
+}
+
+func (f *fakeAgentRegistry) Get(_ context.Context, account string, agentID string) (*agentregistry.Agent, error) {
+	f.getCalls++
+	f.getAccount = account
+	f.getAgentID = agentID
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	if f.getAgent != nil {
+		return f.getAgent, nil
+	}
+	return f.agent, nil
+}
+
+func (f *fakeAgentRegistry) List(_ context.Context, in agentregistry.ListInput) (*agentregistry.ListResult, error) {
+	f.listCalls++
+	f.listIn = in
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	if f.listResult != nil {
+		return f.listResult, nil
+	}
+	return &agentregistry.ListResult{}, nil
 }
 
 func toolContext(username string, scopes []string, bearer string) context.Context {
@@ -589,4 +926,20 @@ func contains(values []string, want string) bool {
 		}
 	}
 	return false
+}
+
+func assertReadOnlyToolDef(t testing.TB, def mcpruntime.ToolDef) {
+	t.Helper()
+	if def.Annotations == nil {
+		t.Fatalf("%s annotations missing", def.Name)
+	}
+	if def.Annotations.ReadOnlyHint == nil || !*def.Annotations.ReadOnlyHint {
+		t.Fatalf("%s should advertise readOnlyHint=true: %+v", def.Name, def.Annotations)
+	}
+	if def.Annotations.DestructiveHint == nil || *def.Annotations.DestructiveHint {
+		t.Fatalf("%s should advertise destructiveHint=false: %+v", def.Name, def.Annotations)
+	}
+	if def.Annotations.IdempotentHint == nil || !*def.Annotations.IdempotentHint {
+		t.Fatalf("%s should advertise idempotentHint=true: %+v", def.Name, def.Annotations)
+	}
 }


### PR DESCRIPTION
## Milestone
Project 48 M4/B8 — Ptah core registry read surface

Closes #348
Parent: #344

## Classification
- Tool-surface / MCP-contract additive change on the instance-plane Ptah MCP surface.
- Registry read support through existing TableTheory-backed `internal/agentregistry` store.

## Surfaces affected
- `internal/ptahserver`: static registration and handlers for `agent_get` and `agent_list`.
- `internal/agentregistry`: minimal account-scoped paginated `List` API using TableTheory `Where`, `Limit`, `SetCursor`, and `AllPaginated`.
- `internal/instanceapp` tests: Ptah `tools/list` now includes `agent_bind_soul`, `agent_create`, `agent_get`, `agent_list`; Ba remains empty.
- `docs/mcp.md`: input/output/error shape, account scoping, pagination, scope requirement, and content-version limitation.

## Specialist/source evidence
- Repo-local steward context verified via `AGENTS.md`; `.codex/skills/github-provenance/SKILL.md` is not present, so I used the available `github-via-theorymcp` guidance and routed TheoryMCP reads where supported.
- TheoryMCP route/scoped memory verified before edits: `memory_recent` succeeded and `github_list_repos` showed `equaltoai/lesser-body` with current installation grant.
- Assignment issue/comment inspected: #348 plus factory assignment comment 4983248823.
- Source inspected before editing:
  - `internal/ptahserver/ptahserver.go`, `internal/ptahserver/ptahserver_test.go`
  - `internal/instanceapp/app.go`, `internal/instanceapp/app_test.go`
  - `internal/agentregistry/store.go`, `internal/agentregistry/store_test.go`
  - `internal/auth/toolctx.go`
  - `docs/mcp.md`
- Framework/source pins inspected:
  - `github.com/theory-cloud/apptheory v1.17.0` `runtime/mcp` `ToolRegistry` / `ToolResult`
  - `github.com/theory-cloud/tabletheory/v2 v2.0.3` Query API (`Where`, `Limit`, `SetCursor`, `AllPaginated`, `PaginatedResult`)

## Security / scope notes
- `agent_get` and `agent_list` require account-holder OAuth principals; agent principals are rejected before registry reads.
- Read-capable means `read`, `write`, or `admin` for these read-only tools.
- Account scope is derived only from the authenticated account-holder username; callers cannot provide an account override.
- Cross-account/missing `agent_get` maps to `not_found` without account/agent detail leakage.
- `agent_list` queries only `ACCOUNT#<account>` + `AGENT#` through TableTheory; no table scan, no Lesser API call, no `LESSER_TABLE_NAME` usage.
- x402 behavior remains unchanged/inert for instance-plane calls.

## Content-version limitation
The current registry record stores only account, agent id, and registry timestamps. This PR does not fabricate source versions. `agent_get` and `agent_list` return explicit `content_version` / `content_summary` placeholders with `status: "not_available"` until a source-backed field exists.

## Validation
- Baseline on `origin/staging` before edits:
  - `gofmt -l .` — pass/empty
  - `go test ./...` — pass
  - `go vet ./...` — pass
  - `bash scripts/build.sh` — pass
- Targeted after implementation:
  - `go test ./internal/agentregistry` — pass
  - `go test ./internal/ptahserver` — pass
  - `go test ./internal/instanceapp` — pass
  - `go test ./internal/ptahserver ./internal/agentregistry ./internal/instanceapp` — pass
- Final full validation:
  - `gofmt -l .` — pass/empty
  - `go build ./...` — pass
  - `go test ./...` — pass
  - `go vet ./...` — pass
  - `bash scripts/build.sh` — pass
- Governance verifier:
  - `bash gov-infra/verifiers/gov-verify-rubric.sh` — failed only `GOV-3` because this product branch has product diffs; all other 17 checks passed. Generated evidence was reverted per repo convention.

## GitHub provenance note
TheoryMCP GitHub reads were used where available. The prepared branch is a non-agent-scoped branch (`project48-m4.4-ptah-agent-get-list`), while TheoryMCP branch/commit/PR write tools are constrained to agent-scoped branches, so the local commit/push and PR creation used the ambient git/gh fallback for that unsupported path.
