### PR TITLE
feat(ptah): add versioned draft content store for souls and instructions

### DIFF
--- a/internal/agentcontent/store.go
+++ b/internal/agentcontent/store.go
@@ -1,0 +1,517 @@
+package agentcontent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/theory-cloud/tabletheory/v2"
+	tablecore "github.com/theory-cloud/tabletheory/v2/pkg/core"
+	tableerrors "github.com/theory-cloud/tabletheory/v2/pkg/errors"
+	"github.com/theory-cloud/tabletheory/v2/pkg/session"
+)
+
+const (
+	// EnvInstanceContentTable is the body-owned instance-plane content table.
+	// It is provisioned by this repo's CDK stack as INSTANCE_CONTENT_TABLE and
+	// must not be confused with Lesser's LESSER_TABLE_NAME actor data table.
+	EnvInstanceContentTable = "INSTANCE_CONTENT_TABLE"
+
+	envAWSRegion = "AWS_REGION"
+
+	accountPKPrefix = "ACCOUNT#"
+	agentPKSegment  = "#AGENT#"
+	contentSKPrefix = "CONTENT#"
+
+	// MaxAgentSoulBytes bounds a single draft soul body. The default is kept
+	// below DynamoDB's item limit so future metadata can fit beside the content.
+	MaxAgentSoulBytes = 64 * 1024
+
+	// MaxAgentInstructionsBytes bounds a single draft instructions body. The
+	// default is kept below DynamoDB's item limit so future metadata can fit
+	// beside the content.
+	MaxAgentInstructionsBytes = 64 * 1024
+
+	updateRetryLimit = 3
+)
+
+// ContentType identifies the exact Ptah-authored content families this store
+// accepts. Unknown types fail closed with ErrInvalidContentType.
+type ContentType string
+
+const (
+	ContentTypeAgentSoul         ContentType = "agent_soul"
+	ContentTypeAgentInstructions ContentType = "agent_instructions"
+)
+
+// LifecycleState is the record lifecycle exposed to later Ptah authoring tools.
+type LifecycleState string
+
+const (
+	LifecycleStateDraft    LifecycleState = "draft"
+	LifecycleStateArchived LifecycleState = "archived"
+)
+
+var (
+	// ErrContentNotFound is returned when the requested account/agent/content
+	// record is absent. Cross-account reads intentionally map here.
+	ErrContentNotFound = errors.New("agent content not found")
+
+	// ErrInvalidContentType is returned for any content type outside AgentSoul
+	// and AgentInstructions.
+	ErrInvalidContentType = errors.New("invalid agent content type")
+
+	// ErrInvalidLifecycleState is returned when persisted state is not one of
+	// draft or archived.
+	ErrInvalidLifecycleState = errors.New("invalid agent content lifecycle state")
+
+	// ErrContentTooLarge is returned when draft content exceeds the configured
+	// per-type byte limit.
+	ErrContentTooLarge = errors.New("agent content too large")
+
+	// ErrMissingUpdatedBySubjectID is returned when a write does not carry the
+	// source-backed subject id supplied by the service/tool layer.
+	ErrMissingUpdatedBySubjectID = errors.New("updated by subject id is required")
+
+	// ErrContentConflict is returned when a conditional write loses an optimistic
+	// concurrency race after bounded retries.
+	ErrContentConflict = errors.New("agent content write conflict")
+)
+
+// SizeError describes a content-size validation failure while preserving
+// errors.Is(err, ErrContentTooLarge).
+type SizeError struct {
+	Type   ContentType
+	Limit  int
+	Actual int
+}
+
+func (e *SizeError) Error() string {
+	if e == nil {
+		return ErrContentTooLarge.Error()
+	}
+	return fmt.Sprintf("%s: type %s has %d bytes, limit %d", ErrContentTooLarge, e.Type, e.Actual, e.Limit)
+}
+
+func (e *SizeError) Unwrap() error { return ErrContentTooLarge }
+
+// Record is the current account-scoped draft/archived content record for one
+// account, agent, and content type.
+type Record struct {
+	CreatedAt          time.Time      `json:"created_at"`
+	UpdatedAt          time.Time      `json:"updated_at"`
+	Account            string         `json:"account"`
+	AgentID            string         `json:"agent_id"`
+	Type               ContentType    `json:"type"`
+	Content            string         `json:"content"`
+	Version            int64          `json:"version"`
+	LifecycleState     LifecycleState `json:"lifecycle_state"`
+	UpdatedBySubjectID string         `json:"updated_by_subject_id"`
+}
+
+// UpsertInput describes a create-or-update draft write. UpdatedBySubjectID is
+// intentionally a source-backed service input so later Ptah handlers can pass
+// Claims.Subject (or another stable authenticated subject) without this store
+// reaching into auth context itself.
+type UpsertInput struct {
+	Account            string
+	AgentID            string
+	Type               ContentType
+	Content            string
+	UpdatedBySubjectID string
+}
+
+// ArchiveInput describes an idempotent lifecycle transition to archived.
+type ArchiveInput struct {
+	Account            string
+	AgentID            string
+	Type               ContentType
+	UpdatedBySubjectID string
+}
+
+// Store persists Ptah-authored versioned drafts in a body-owned instance table.
+type Store struct {
+	db        tablecore.DB
+	tableName string
+}
+
+// NewStore constructs a Store over an injected TableTheory DB. tableName should
+// be the configured INSTANCE_CONTENT_TABLE value.
+func NewStore(db tablecore.DB, tableName string) (*Store, error) {
+	if db == nil {
+		return nil, fmt.Errorf("agent content db is required")
+	}
+	tableName = strings.TrimSpace(tableName)
+	if tableName == "" {
+		return nil, fmt.Errorf("%s is required", EnvInstanceContentTable)
+	}
+	return &Store{db: db, tableName: tableName}, nil
+}
+
+// Default creates the production TableTheory-backed content store from process
+// configuration.
+func Default() (*Store, error) {
+	tableName := strings.TrimSpace(os.Getenv(EnvInstanceContentTable))
+	if tableName == "" {
+		return nil, fmt.Errorf("%s is required", EnvInstanceContentTable)
+	}
+
+	db, err := tabletheory.NewBasic(session.Config{Region: os.Getenv(envAWSRegion)})
+	if err != nil {
+		return nil, fmt.Errorf("create tabletheory client: %w", err)
+	}
+	return NewStore(db, tableName)
+}
+
+// Upsert creates or updates draft content and increments this content type's
+// version monotonically. Soul and instructions counters are independent because
+// they are stored as separate sort-key records.
+func (s *Store) Upsert(ctx context.Context, in UpsertInput) (*Record, error) {
+	if s == nil {
+		return nil, fmt.Errorf("agent content store is nil")
+	}
+	validated, err := validateUpsertInput(in)
+	if err != nil {
+		return nil, err
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	now := time.Now().UTC()
+	created := s.recordFor(validated.account, validated.agentID, validated.contentType)
+	created.Content = in.Content
+	created.Version = 1
+	created.LifecycleState = string(LifecycleStateDraft)
+	created.ContentCreatedAt = now
+	created.ContentUpdatedAt = now
+	created.UpdatedBySubjectID = validated.updatedBySubjectID
+
+	err = s.db.Model(created).WithContext(ctx).IfNotExists().Create()
+	switch {
+	case err == nil:
+		return created.toRecord()
+	case !tableerrors.IsConditionFailed(err):
+		return nil, fmt.Errorf("create agent content record: %w", err)
+	}
+
+	for attempt := 0; attempt < updateRetryLimit; attempt++ {
+		current, err := s.loadRecord(ctx, validated.account, validated.agentID, validated.contentType)
+		if err != nil {
+			return nil, err
+		}
+
+		updated := s.emptyRecord()
+		err = s.db.Model(s.emptyRecord()).
+			WithContext(ctx).
+			Where("PK", "=", contentPartitionKey(validated.account, validated.agentID)).
+			Where("SK", "=", contentSortKey(validated.contentType)).
+			UpdateBuilder().
+			Set("Content", in.Content).
+			Set("LifecycleState", string(LifecycleStateDraft)).
+			Set("ContentUpdatedAt", now).
+			Set("UpdatedBySubjectID", validated.updatedBySubjectID).
+			Add("Version", 1).
+			ConditionVersion(current.Version).
+			ReturnValues("ALL_NEW").
+			ExecuteWithResult(updated)
+		switch {
+		case err == nil:
+			return updated.toRecord()
+		case tableerrors.IsConditionFailed(err):
+			continue
+		default:
+			return nil, fmt.Errorf("update agent content record: %w", err)
+		}
+	}
+
+	return nil, fmt.Errorf("%w: upsert agent content", ErrContentConflict)
+}
+
+// Get returns the current record for an account, agent, and content type. A
+// wrong account and an absent record both map to ErrContentNotFound.
+func (s *Store) Get(ctx context.Context, account string, agentID string, contentType ContentType) (*Record, error) {
+	if s == nil {
+		return nil, fmt.Errorf("agent content store is nil")
+	}
+	account = normalizeAccount(account)
+	if account == "" {
+		return nil, fmt.Errorf("account is required")
+	}
+	agentID = normalizeAgentID(agentID)
+	if agentID == "" {
+		return nil, fmt.Errorf("agent id is required")
+	}
+	typ, err := normalizeContentType(contentType)
+	if err != nil {
+		return nil, err
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	record, err := s.loadRecord(ctx, account, agentID, typ)
+	if err != nil {
+		return nil, err
+	}
+	return record.toRecord()
+}
+
+// Archive idempotently marks the current content record archived. It preserves
+// the content version while updating lifecycle and audit fields.
+func (s *Store) Archive(ctx context.Context, in ArchiveInput) (*Record, error) {
+	if s == nil {
+		return nil, fmt.Errorf("agent content store is nil")
+	}
+	validated, err := validateArchiveInput(in)
+	if err != nil {
+		return nil, err
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	now := time.Now().UTC()
+	for attempt := 0; attempt < updateRetryLimit; attempt++ {
+		current, err := s.loadRecord(ctx, validated.account, validated.agentID, validated.contentType)
+		if err != nil {
+			return nil, err
+		}
+
+		updated := s.emptyRecord()
+		err = s.db.Model(s.emptyRecord()).
+			WithContext(ctx).
+			Where("PK", "=", contentPartitionKey(validated.account, validated.agentID)).
+			Where("SK", "=", contentSortKey(validated.contentType)).
+			UpdateBuilder().
+			Set("LifecycleState", string(LifecycleStateArchived)).
+			Set("ContentUpdatedAt", now).
+			Set("UpdatedBySubjectID", validated.updatedBySubjectID).
+			ConditionVersion(current.Version).
+			ReturnValues("ALL_NEW").
+			ExecuteWithResult(updated)
+		switch {
+		case err == nil:
+			return updated.toRecord()
+		case tableerrors.IsConditionFailed(err):
+			continue
+		default:
+			return nil, fmt.Errorf("archive agent content record: %w", err)
+		}
+	}
+
+	return nil, fmt.Errorf("%w: archive agent content", ErrContentConflict)
+}
+
+func (s *Store) loadRecord(ctx context.Context, account string, agentID string, contentType ContentType) (*contentRecord, error) {
+	record := s.emptyRecord()
+	err := s.db.Model(s.emptyRecord()).
+		WithContext(ctx).
+		Where("PK", "=", contentPartitionKey(account, agentID)).
+		Where("SK", "=", contentSortKey(contentType)).
+		First(record)
+	switch {
+	case err == nil:
+		if _, err := record.toRecord(); err != nil {
+			return nil, err
+		}
+		return record, nil
+	case tableerrors.IsNotFound(err):
+		return nil, ErrContentNotFound
+	default:
+		return nil, fmt.Errorf("get agent content record: %w", err)
+	}
+}
+
+func (s *Store) emptyRecord() *contentRecord {
+	return &contentRecord{tableName: s.tableName}
+}
+
+func (s *Store) recordFor(account string, agentID string, contentType ContentType) *contentRecord {
+	return &contentRecord{
+		tableName:   s.tableName,
+		PK:          contentPartitionKey(account, agentID),
+		SK:          contentSortKey(contentType),
+		Account:     normalizeAccount(account),
+		AgentID:     normalizeAgentID(agentID),
+		ContentType: string(contentType),
+	}
+}
+
+type contentRecord struct {
+	tableName string
+
+	PK string `theorydb:"pk,attr:pk" json:"pk"`
+	SK string `theorydb:"sk,attr:sk" json:"sk"`
+
+	ContentCreatedAt   time.Time `theorydb:"attr:createdAt" json:"created_at"`
+	ContentUpdatedAt   time.Time `theorydb:"attr:updatedAt" json:"updated_at"`
+	Account            string    `theorydb:"attr:account" json:"account"`
+	AgentID            string    `theorydb:"attr:agentId" json:"agent_id"`
+	ContentType        string    `theorydb:"attr:contentType" json:"content_type"`
+	Content            string    `theorydb:"attr:content" json:"content"`
+	Version            int64     `theorydb:"version,attr:version" json:"version"`
+	LifecycleState     string    `theorydb:"attr:lifecycleState" json:"lifecycle_state"`
+	UpdatedBySubjectID string    `theorydb:"attr:updatedBySubjectId" json:"updated_by_subject_id"`
+}
+
+func (r contentRecord) TableName() string {
+	if tableName := strings.TrimSpace(r.tableName); tableName != "" {
+		return tableName
+	}
+	return strings.TrimSpace(os.Getenv(EnvInstanceContentTable))
+}
+
+func (r *contentRecord) toRecord() (*Record, error) {
+	if r == nil {
+		return nil, nil
+	}
+	typ, err := normalizeContentType(ContentType(r.ContentType))
+	if err != nil {
+		return nil, err
+	}
+	state, err := normalizeLifecycleState(LifecycleState(r.LifecycleState))
+	if err != nil {
+		return nil, err
+	}
+	return &Record{
+		Account:            normalizeAccount(r.Account),
+		AgentID:            normalizeAgentID(r.AgentID),
+		Type:               typ,
+		Content:            r.Content,
+		Version:            r.Version,
+		LifecycleState:     state,
+		CreatedAt:          r.ContentCreatedAt.UTC(),
+		UpdatedAt:          r.ContentUpdatedAt.UTC(),
+		UpdatedBySubjectID: strings.TrimSpace(r.UpdatedBySubjectID),
+	}, nil
+}
+
+type validatedWriteInput struct {
+	account            string
+	agentID            string
+	contentType        ContentType
+	updatedBySubjectID string
+}
+
+func validateUpsertInput(in UpsertInput) (validatedWriteInput, error) {
+	validated, err := validateWriteScope(in.Account, in.AgentID, in.Type, in.UpdatedBySubjectID)
+	if err != nil {
+		return validatedWriteInput{}, err
+	}
+	if err := validateContentSize(validated.contentType, in.Content); err != nil {
+		return validatedWriteInput{}, err
+	}
+	return validated, nil
+}
+
+func validateArchiveInput(in ArchiveInput) (validatedWriteInput, error) {
+	return validateWriteScope(in.Account, in.AgentID, in.Type, in.UpdatedBySubjectID)
+}
+
+func validateWriteScope(account string, agentID string, contentType ContentType, updatedBySubjectID string) (validatedWriteInput, error) {
+	account = normalizeAccount(account)
+	if account == "" {
+		return validatedWriteInput{}, fmt.Errorf("account is required")
+	}
+	agentID = normalizeAgentID(agentID)
+	if agentID == "" {
+		return validatedWriteInput{}, fmt.Errorf("agent id is required")
+	}
+	typ, err := normalizeContentType(contentType)
+	if err != nil {
+		return validatedWriteInput{}, err
+	}
+	updatedBySubjectID = strings.TrimSpace(updatedBySubjectID)
+	if updatedBySubjectID == "" {
+		return validatedWriteInput{}, ErrMissingUpdatedBySubjectID
+	}
+	return validatedWriteInput{
+		account:            account,
+		agentID:            agentID,
+		contentType:        typ,
+		updatedBySubjectID: updatedBySubjectID,
+	}, nil
+}
+
+func validateContentSize(contentType ContentType, content string) error {
+	limit := maxContentBytes(contentType)
+	actual := len([]byte(content))
+	if actual > limit {
+		return &SizeError{Type: contentType, Limit: limit, Actual: actual}
+	}
+	return nil
+}
+
+func maxContentBytes(contentType ContentType) int {
+	switch contentType {
+	case ContentTypeAgentSoul:
+		return MaxAgentSoulBytes
+	case ContentTypeAgentInstructions:
+		return MaxAgentInstructionsBytes
+	default:
+		return 0
+	}
+}
+
+func contentPartitionKey(account string, agentID string) string {
+	account = normalizeAccount(account)
+	agentID = normalizeAgentID(agentID)
+	if account == "" || agentID == "" {
+		return ""
+	}
+	return accountPKPrefix + account + agentPKSegment + agentID
+}
+
+func contentSortKey(contentType ContentType) string {
+	typ, err := normalizeContentType(contentType)
+	if err != nil {
+		return ""
+	}
+	return contentSKPrefix + string(typ)
+}
+
+func normalizeContentType(contentType ContentType) (ContentType, error) {
+	token := normalizeEnumToken(string(contentType))
+	switch token {
+	case "agentsoul":
+		return ContentTypeAgentSoul, nil
+	case "agentinstructions":
+		return ContentTypeAgentInstructions, nil
+	default:
+		return "", fmt.Errorf("%w: %q", ErrInvalidContentType, strings.TrimSpace(string(contentType)))
+	}
+}
+
+func normalizeLifecycleState(state LifecycleState) (LifecycleState, error) {
+	switch strings.ToLower(strings.TrimSpace(string(state))) {
+	case string(LifecycleStateDraft):
+		return LifecycleStateDraft, nil
+	case string(LifecycleStateArchived):
+		return LifecycleStateArchived, nil
+	default:
+		return "", fmt.Errorf("%w: %q", ErrInvalidLifecycleState, strings.TrimSpace(string(state)))
+	}
+}
+
+func normalizeEnumToken(value string) string {
+	var b strings.Builder
+	for _, r := range strings.TrimSpace(value) {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			b.WriteRune(unicode.ToLower(r))
+		}
+	}
+	return b.String()
+}
+
+func normalizeAccount(account string) string {
+	return strings.ToLower(strings.TrimSpace(account))
+}
+
+func normalizeAgentID(agentID string) string {
+	return strings.TrimSpace(agentID)
+}

--- a/internal/agentcontent/store_test.go
+++ b/internal/agentcontent/store_test.go
@@ -1,0 +1,345 @@
+package agentcontent
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/theory-cloud/tabletheory/v2"
+	"github.com/theory-cloud/tabletheory/v2/pkg/session"
+	"github.com/theory-cloud/tabletheory/v2/pkg/testing/fakedb"
+)
+
+func TestUpsertCreateUpdateGetFlow(t *testing.T) {
+	store, _ := newTestStore(t)
+
+	created, err := store.Upsert(context.Background(), UpsertInput{
+		Account:            " Account-A ",
+		AgentID:            "agent-123",
+		Type:               ContentTypeAgentSoul,
+		Content:            "first soul draft",
+		UpdatedBySubjectID: " subject-create ",
+	})
+	if err != nil {
+		t.Fatalf("Upsert(create) error = %v", err)
+	}
+	if created.Account != "account-a" || created.AgentID != "agent-123" || created.Type != ContentTypeAgentSoul {
+		t.Fatalf("created scope/type = %+v, want normalized account, agent, type", created)
+	}
+	if created.Content != "first soul draft" || created.Version != 1 || created.LifecycleState != LifecycleStateDraft {
+		t.Fatalf("created content/version/state = %+v, want draft version 1", created)
+	}
+	if created.UpdatedBySubjectID != "subject-create" {
+		t.Fatalf("created UpdatedBySubjectID = %q", created.UpdatedBySubjectID)
+	}
+	if created.CreatedAt.IsZero() || created.UpdatedAt.IsZero() {
+		t.Fatalf("created timestamps are zero: %+v", created)
+	}
+
+	updated, err := store.Upsert(context.Background(), UpsertInput{
+		Account:            "account-a",
+		AgentID:            "agent-123",
+		Type:               "AgentSoul",
+		Content:            "second soul draft",
+		UpdatedBySubjectID: "subject-update",
+	})
+	if err != nil {
+		t.Fatalf("Upsert(update) error = %v", err)
+	}
+	if updated.Content != "second soul draft" || updated.Version != 2 || updated.LifecycleState != LifecycleStateDraft {
+		t.Fatalf("updated content/version/state = %+v, want draft version 2", updated)
+	}
+	if updated.UpdatedBySubjectID != "subject-update" {
+		t.Fatalf("updated UpdatedBySubjectID = %q", updated.UpdatedBySubjectID)
+	}
+	if !updated.CreatedAt.Equal(created.CreatedAt) {
+		t.Fatalf("updated CreatedAt = %s, want original %s", updated.CreatedAt, created.CreatedAt)
+	}
+	if updated.UpdatedAt.Before(created.UpdatedAt) {
+		t.Fatalf("updated UpdatedAt = %s before created UpdatedAt %s", updated.UpdatedAt, created.UpdatedAt)
+	}
+
+	got, err := store.Get(context.Background(), "account-a", "agent-123", ContentTypeAgentSoul)
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if got.Content != updated.Content || got.Version != updated.Version || got.UpdatedBySubjectID != updated.UpdatedBySubjectID {
+		t.Fatalf("Get() = %+v, want updated %+v", got, updated)
+	}
+}
+
+func TestIndependentVersionCounters(t *testing.T) {
+	store, _ := newTestStore(t)
+	ctx := context.Background()
+
+	soul, err := store.Upsert(ctx, UpsertInput{
+		Account:            "account-a",
+		AgentID:            "agent-123",
+		Type:               ContentTypeAgentSoul,
+		Content:            "soul v1",
+		UpdatedBySubjectID: "subject-1",
+	})
+	if err != nil {
+		t.Fatalf("Upsert(soul) error = %v", err)
+	}
+	instructions, err := store.Upsert(ctx, UpsertInput{
+		Account:            "account-a",
+		AgentID:            "agent-123",
+		Type:               ContentTypeAgentInstructions,
+		Content:            "instructions v1",
+		UpdatedBySubjectID: "subject-2",
+	})
+	if err != nil {
+		t.Fatalf("Upsert(instructions) error = %v", err)
+	}
+	if soul.Version != 1 || instructions.Version != 1 {
+		t.Fatalf("initial versions soul=%d instructions=%d, want both 1", soul.Version, instructions.Version)
+	}
+
+	soul, err = store.Upsert(ctx, UpsertInput{
+		Account:            "account-a",
+		AgentID:            "agent-123",
+		Type:               ContentTypeAgentSoul,
+		Content:            "soul v2",
+		UpdatedBySubjectID: "subject-3",
+	})
+	if err != nil {
+		t.Fatalf("Upsert(soul v2) error = %v", err)
+	}
+	instructions, err = store.Get(ctx, "account-a", "agent-123", ContentTypeAgentInstructions)
+	if err != nil {
+		t.Fatalf("Get(instructions) error = %v", err)
+	}
+	if soul.Version != 2 {
+		t.Fatalf("soul version = %d, want 2", soul.Version)
+	}
+	if instructions.Version != 1 || instructions.Content != "instructions v1" {
+		t.Fatalf("instructions after soul update = %+v, want unchanged version 1", instructions)
+	}
+}
+
+func TestCrossAccountGetReturnsNotFound(t *testing.T) {
+	store, _ := newTestStore(t)
+	if _, err := store.Upsert(context.Background(), UpsertInput{
+		Account:            "account-a",
+		AgentID:            "agent-123",
+		Type:               ContentTypeAgentSoul,
+		Content:            "soul",
+		UpdatedBySubjectID: "subject-1",
+	}); err != nil {
+		t.Fatalf("Upsert() error = %v", err)
+	}
+
+	got, err := store.Get(context.Background(), "account-b", "agent-123", ContentTypeAgentSoul)
+	if got != nil {
+		t.Fatalf("cross-account Get() returned %+v, want nil", got)
+	}
+	if !errors.Is(err, ErrContentNotFound) {
+		t.Fatalf("cross-account Get() error = %v, want ErrContentNotFound", err)
+	}
+}
+
+func TestSizeBounds(t *testing.T) {
+	store, _ := newTestStore(t)
+	cases := []struct {
+		name  string
+		typ   ContentType
+		limit int
+	}{
+		{name: "agent soul", typ: ContentTypeAgentSoul, limit: MaxAgentSoulBytes},
+		{name: "agent instructions", typ: ContentTypeAgentInstructions, limit: MaxAgentInstructionsBytes},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name+" accepts limit", func(t *testing.T) {
+			_, err := store.Upsert(context.Background(), UpsertInput{
+				Account:            "account-a",
+				AgentID:            "agent-" + strings.ReplaceAll(tc.name, " ", "-"),
+				Type:               tc.typ,
+				Content:            strings.Repeat("a", tc.limit),
+				UpdatedBySubjectID: "subject-limit",
+			})
+			if err != nil {
+				t.Fatalf("Upsert(at limit) error = %v", err)
+			}
+		})
+
+		t.Run(tc.name+" rejects over limit", func(t *testing.T) {
+			_, err := store.Upsert(context.Background(), UpsertInput{
+				Account:            "account-a",
+				AgentID:            "agent-over-" + strings.ReplaceAll(tc.name, " ", "-"),
+				Type:               tc.typ,
+				Content:            strings.Repeat("b", tc.limit+1),
+				UpdatedBySubjectID: "subject-over",
+			})
+			if !errors.Is(err, ErrContentTooLarge) {
+				t.Fatalf("Upsert(over limit) error = %v, want ErrContentTooLarge", err)
+			}
+			var sizeErr *SizeError
+			if !errors.As(err, &sizeErr) || sizeErr.Type != tc.typ || sizeErr.Limit != tc.limit || sizeErr.Actual != tc.limit+1 {
+				t.Fatalf("size error = %#v, want typed details for %s", err, tc.typ)
+			}
+		})
+	}
+}
+
+func TestArchiveIsIdempotentAndCapturesAudit(t *testing.T) {
+	store, _ := newTestStore(t)
+	ctx := context.Background()
+	created, err := store.Upsert(ctx, UpsertInput{
+		Account:            "account-a",
+		AgentID:            "agent-123",
+		Type:               ContentTypeAgentInstructions,
+		Content:            "instructions draft",
+		UpdatedBySubjectID: "subject-create",
+	})
+	if err != nil {
+		t.Fatalf("Upsert() error = %v", err)
+	}
+
+	archived, err := store.Archive(ctx, ArchiveInput{
+		Account:            "account-a",
+		AgentID:            "agent-123",
+		Type:               ContentTypeAgentInstructions,
+		UpdatedBySubjectID: "subject-archive",
+	})
+	if err != nil {
+		t.Fatalf("Archive() error = %v", err)
+	}
+	if archived.LifecycleState != LifecycleStateArchived || archived.Version != created.Version || archived.Content != created.Content {
+		t.Fatalf("archived = %+v, want archived with same content/version", archived)
+	}
+	if archived.UpdatedBySubjectID != "subject-archive" {
+		t.Fatalf("archived UpdatedBySubjectID = %q", archived.UpdatedBySubjectID)
+	}
+
+	again, err := store.Archive(ctx, ArchiveInput{
+		Account:            "account-a",
+		AgentID:            "agent-123",
+		Type:               ContentTypeAgentInstructions,
+		UpdatedBySubjectID: "subject-archive-again",
+	})
+	if err != nil {
+		t.Fatalf("Archive(again) error = %v", err)
+	}
+	if again.LifecycleState != LifecycleStateArchived || again.Version != archived.Version || again.Content != archived.Content {
+		t.Fatalf("Archive(again) = %+v, want idempotent archived content/version", again)
+	}
+	if again.UpdatedBySubjectID != "subject-archive-again" {
+		t.Fatalf("Archive(again) UpdatedBySubjectID = %q", again.UpdatedBySubjectID)
+	}
+
+	draft, err := store.Upsert(ctx, UpsertInput{
+		Account:            "account-a",
+		AgentID:            "agent-123",
+		Type:               ContentTypeAgentInstructions,
+		Content:            "instructions draft after archive",
+		UpdatedBySubjectID: "subject-reopen",
+	})
+	if err != nil {
+		t.Fatalf("Upsert(after archive) error = %v", err)
+	}
+	if draft.LifecycleState != LifecycleStateDraft || draft.Version != archived.Version+1 {
+		t.Fatalf("Upsert(after archive) = %+v, want draft version increment", draft)
+	}
+}
+
+func TestArchiveMissingRecordReturnsNotFound(t *testing.T) {
+	store, _ := newTestStore(t)
+	_, err := store.Archive(context.Background(), ArchiveInput{
+		Account:            "account-a",
+		AgentID:            "missing-agent",
+		Type:               ContentTypeAgentSoul,
+		UpdatedBySubjectID: "subject-archive",
+	})
+	if !errors.Is(err, ErrContentNotFound) {
+		t.Fatalf("Archive(missing) error = %v, want ErrContentNotFound", err)
+	}
+}
+
+func TestInvalidTypeStateAndAuditErrors(t *testing.T) {
+	store, _ := newTestStore(t)
+	if _, err := store.Get(context.Background(), "account-a", "agent-123", "biography"); !errors.Is(err, ErrInvalidContentType) {
+		t.Fatalf("Get(invalid type) error = %v, want ErrInvalidContentType", err)
+	}
+	if _, err := store.Upsert(context.Background(), UpsertInput{
+		Account: "account-a",
+		AgentID: "agent-123",
+		Type:    ContentTypeAgentSoul,
+		Content: "soul",
+	}); !errors.Is(err, ErrMissingUpdatedBySubjectID) {
+		t.Fatalf("Upsert(missing subject) error = %v, want ErrMissingUpdatedBySubjectID", err)
+	}
+
+	record := store.recordFor("account-a", "agent-bad-state", ContentTypeAgentSoul)
+	record.Content = "soul"
+	record.Version = 1
+	record.LifecycleState = "published"
+	record.ContentCreatedAt = time.Now().UTC()
+	record.ContentUpdatedAt = record.ContentCreatedAt
+	record.UpdatedBySubjectID = "subject-seed"
+	if err := store.db.Model(record).Create(); err != nil {
+		t.Fatalf("seed invalid-state record error = %v", err)
+	}
+
+	got, err := store.Get(context.Background(), "account-a", "agent-bad-state", ContentTypeAgentSoul)
+	if got != nil {
+		t.Fatalf("Get(invalid state) returned %+v, want nil", got)
+	}
+	if !errors.Is(err, ErrInvalidLifecycleState) {
+		t.Fatalf("Get(invalid state) error = %v, want ErrInvalidLifecycleState", err)
+	}
+}
+
+func TestWritesUseInstanceContentTableNotLesserTable(t *testing.T) {
+	store, fake := newTestStore(t)
+	if _, err := store.Upsert(context.Background(), UpsertInput{
+		Account:            "account-a",
+		AgentID:            "agent-123",
+		Type:               ContentTypeAgentSoul,
+		Content:            "soul",
+		UpdatedBySubjectID: "subject-create",
+	}); err != nil {
+		t.Fatalf("Upsert() error = %v", err)
+	}
+	if _, err := store.Archive(context.Background(), ArchiveInput{
+		Account:            "account-a",
+		AgentID:            "agent-123",
+		Type:               ContentTypeAgentSoul,
+		UpdatedBySubjectID: "subject-archive",
+	}); err != nil {
+		t.Fatalf("Archive() error = %v", err)
+	}
+
+	contentItems := fake.Items(os.Getenv(EnvInstanceContentTable))
+	if len(contentItems) != 1 {
+		t.Fatalf("content table items = %d, want 1", len(contentItems))
+	}
+	lesserItems := fake.Items(os.Getenv("LESSER_TABLE_NAME"))
+	if len(lesserItems) != 0 {
+		t.Fatalf("LESSER_TABLE_NAME items = %d, want 0", len(lesserItems))
+	}
+}
+
+func newTestStore(t *testing.T) (*Store, *fakedb.Fake) {
+	t.Helper()
+	t.Setenv(EnvInstanceContentTable, "body-instance-content-test")
+	t.Setenv("LESSER_TABLE_NAME", "lesser-stage-table-test")
+
+	fake := fakedb.New()
+	db, err := tabletheory.NewWithClient(session.Config{Region: "us-east-1"}, fake)
+	if err != nil {
+		t.Fatalf("NewWithClient() error = %v", err)
+	}
+	store, err := NewStore(db, os.Getenv(EnvInstanceContentTable))
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	if err := db.CreateTable(store.emptyRecord()); err != nil {
+		t.Fatalf("CreateTable() error = %v", err)
+	}
+	return store, fake
+}


### PR DESCRIPTION
## Milestone
Project 48 M5/B9 — Ptah authoring data layer for versioned draft souls + instructions.

Parent: #349

Closes #350

## Classification
Tool-surface data layer / body-owned instance-plane persistence. No public Ptah tool registration in this PR; #351 and #352 own tool exposure.

## Surfaces affected
- New `internal/agentcontent` package.
- Uses existing body-owned `INSTANCE_CONTENT_TABLE`; does not write `LESSER_TABLE_NAME`.

## Source/framework evidence inspected
- Body storage idioms: `internal/agentregistry/store.go`, `internal/agentregistry/store_test.go`.
- Body auth/audit fields: `internal/auth/auth.go`, `internal/auth/toolctx.go`; `Claims` embeds `jwt.RegisteredClaims`, so later Ptah handlers can source `UpdatedBySubjectID` from `Claims.Subject` or another stable subject.
- Ptah naming/account-scope context: `internal/ptahserver/ptahserver.go`, `docs/mcp.md`.
- TableTheory `github.com/theory-cloud/tabletheory/v2 v2.0.3`: conditional create, `UpdateBuilder` `Set`/`Add`, `ConditionVersion`, typed errors, and `pkg/testing/fakedb` consumer-test pattern.

## Proprietary/source boundary
The issue references a TheoryMCP/SoulStore/AgentInstructionsStore specialist pattern, but authoritative proprietary `theory-mcp-server` source was not available in this repo or routed agent surface. This implementation is based only on body-local source truth, issue acceptance criteria, and inspected TableTheory public module source/API/tests; no proprietary service code was vendored, ported, or claimed as inspected.

## Behavior
- Generic store for exactly two content types: `agent_soul` and `agent_instructions`.
- Account+agent scoped keys with separate sort-key records per content type, giving independent monotonic version counters.
- `Upsert` creates/updates draft content and increments the target content type version.
- `Archive` is idempotent for lifecycle/content/version, preserves content version, and updates audit fields.
- `Get` returns current record or maps wrong-account/absent records to not-found semantics.
- `UpdatedBySubjectID` is required on writes and preserved on create/update/archive.
- Conservative exported byte limits: 64 KiB each for soul and instructions content.
- Typed errors cover not found, invalid content type, invalid lifecycle state, oversize content, missing audit subject, and optimistic write conflict.

## Validation
- Targeted: `go test ./internal/agentcontent -run Test -v` ✅
- Baseline before edits: `gofmt -l .`, `go build ./...`, `go test ./...`, `go vet ./...`, `bash scripts/build.sh` ✅
- Final: `gofmt -l .` ✅ empty
- Final: `go build ./...` ✅
- Final: `go test ./...` ✅
- Final: `go vet ./...` ✅
- Final: `bash scripts/build.sh` ✅
- Final: `bash gov-infra/verifiers/gov-verify-rubric.sh` ⚠️ failed only `GOV-3` because this product branch has product diffs; all generated `gov-infra/evidence/*` changes were reverted per repo convention.

Note: local generated `cdk/node_modules` was temporarily moved outside the repo for raw Go traversal and restored afterward.

## Cross-repo / deploy scope
None in this PR. No CDK/deploy/sibling repo changes.

## Follow-ons
- #351: `agent_soul_*` tools should inject `UpdatedBySubjectID` from source-backed principal/subject input.
- #352: `agent_instructions_*` tools should align with exported content-size constants and the idempotent archive semantics.
