### PR TITLE
feat(ptah): register agent_soul tools

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -433,6 +433,9 @@ surface or Ba's `/instance/ba/mcp` surface. Clients discover them with an authen
 | `agent_create` | Write | Delegate runtime credentials for an existing Lesser local agent account and create a Body/Ptah account-scoped registry entry. |
 | `agent_get` | Read | Read one Body/Ptah account-scoped registry entry for the authenticated account-holder actor. |
 | `agent_list` | Read | List Body/Ptah account-scoped registry entries with cursor pagination. |
+| `agent_soul_get` | Read | Read the current account-scoped Ptah `agent_soul` draft/archived record. Schema marker: `provisional_agent_soul_schema_pending_lesser_soul_s1`. |
+| `agent_soul_upsert` | Write | Create or update account-scoped Ptah `agent_soul` draft content through `internal/agentcontent.Store`. Schema marker: `provisional_agent_soul_schema_pending_lesser_soul_s1`. |
+| `agent_soul_archive` | Write | Idempotently archive the current account-scoped Ptah `agent_soul` record through `internal/agentcontent.Store`. Schema marker: `provisional_agent_soul_schema_pending_lesser_soul_s1`. |
 
 `agent_get` input:
 
@@ -497,6 +500,74 @@ metadata:
 ```
 
 Invalid `limit` or `cursor` values return `invalid_request`. Registry failures return `agent_registry_error`.
+
+`agent_soul_get` input:
+
+- Required: `agent_id`.
+- Derived: the account scope is always the authenticated account-holder OAuth principal. Callers cannot supply an
+  account override. Optional `actor_username`, when supplied, must match the authenticated principal after normalization
+  or the tool fails closed.
+
+`agent_soul_get` requires an account-holder OAuth principal with read-capable scope. It calls only the Body-owned
+`internal/agentcontent.Store.Get` path with content type `agent_soul`; it does not call Lesser, read `LESSER_TABLE_NAME`,
+or accept cross-account selectors. Missing records and cross-account lookups return structured tool error code
+`not_found` without account/agent detail leakage.
+
+Successful output has `structuredContent.data.agent_soul`:
+
+```json
+{
+  "account": "<authenticated account username>",
+  "agent_id": "<agent id>",
+  "type": "agent_soul",
+  "content": "<draft soul content>",
+  "content_bytes": 123,
+  "version": 1,
+  "lifecycle_state": "draft",
+  "created_at": "<RFC3339 timestamp>",
+  "updated_at": "<RFC3339 timestamp>",
+  "updated_by_subject_id": "<authenticated JWT subject>"
+}
+```
+
+The result also includes `structuredContent.data.schema` with status `provisional` and marker
+`provisional_agent_soul_schema_pending_lesser_soul_s1`. This marker must remain until the lesser-soul S1/Panonomous
+contract is governance-unblocked and a follow-up commit finalizes the schema. The text content stays concise and points
+to `structuredContent.data.agent_soul.content` instead of duplicating the draft body.
+
+`agent_soul_upsert` input:
+
+- Required: `agent_id`, `content`.
+- Derived: account scope is the authenticated account-holder OAuth principal; `updated_by_subject_id` is the
+  authenticated JWT subject. Optional `actor_username`, when supplied, must match that principal.
+
+`agent_soul_upsert` requires write scope. It stores draft soul content through `internal/agentcontent.Store.Upsert` with
+content type `agent_soul`, so the TableTheory-backed instance content store owns version increments, lifecycle state, and
+size bounds. It does not introduce a separate persistence layer, DynamoDB client, or Lesser-table write. Successful
+upserts return the same `agent_soul` record shape with `lifecycle_state:"draft"` and the incremented `version`.
+
+`agent_soul_archive` input:
+
+- Required: `agent_id`.
+- Derived: account scope is the authenticated account-holder OAuth principal; `updated_by_subject_id` is the
+  authenticated JWT subject. Optional `actor_username`, when supplied, must match that principal.
+
+`agent_soul_archive` requires write scope. It archives through `internal/agentcontent.Store.Archive`, preserves the
+store's idempotent archive behavior, and reports:
+
+```json
+{
+  "already_archived": false,
+  "idempotent": true
+}
+```
+
+`already_archived` is true when the current account-scoped record was already archived before the archive call. The
+returned `agent_soul` record keeps the store-owned version and has `lifecycle_state:"archived"`.
+
+For all `agent_soul_*` tools, malformed input returns `invalid_request`; agent-delegated or mismatched principals return
+`forbidden`; missing content records return `not_found`; optimistic write races return `conflict`; and unexpected
+content-store failures return `internal` with sanitized `source:"agent_content"` details.
 
 `agent_create` input:
 

--- a/internal/instanceapp/app_test.go
+++ b/internal/instanceapp/app_test.go
@@ -44,7 +44,7 @@ func TestInstancePlaneMCP_InitializeAndToolsList(t *testing.T) {
 		serverName string
 		wantTools  []string
 	}{
-		{name: "ptah", path: "/instance/ptah/mcp", serverName: "lesser-body-instance-ptah", wantTools: []string{"agent_bind_soul", "agent_create", "agent_get", "agent_list"}},
+		{name: "ptah", path: "/instance/ptah/mcp", serverName: "lesser-body-instance-ptah", wantTools: []string{"agent_bind_soul", "agent_create", "agent_get", "agent_list", "agent_soul_get", "agent_soul_upsert", "agent_soul_archive"}},
 		{name: "ba", path: "/instance/ba/mcp", serverName: "lesser-body-instance-ba", wantTools: []string{}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -121,6 +121,18 @@ func TestInstancePlaneMCP_InitializeAndToolsList(t *testing.T) {
 				listDef := listBody.Result.Tools[3]
 				if listDef.Name != "agent_list" || listDef.Annotations == nil || listDef.Annotations.ReadOnlyHint == nil || !*listDef.Annotations.ReadOnlyHint {
 					t.Fatalf("agent_list annotations not read-only: %+v", listDef)
+				}
+				soulGetDef := listBody.Result.Tools[4]
+				if soulGetDef.Name != "agent_soul_get" || soulGetDef.Annotations == nil || soulGetDef.Annotations.ReadOnlyHint == nil || !*soulGetDef.Annotations.ReadOnlyHint || !strings.Contains(soulGetDef.Description, "provisional_agent_soul_schema_pending_lesser_soul_s1") {
+					t.Fatalf("agent_soul_get annotations/description invalid: %+v", soulGetDef)
+				}
+				soulUpsertDef := listBody.Result.Tools[5]
+				if soulUpsertDef.Name != "agent_soul_upsert" || soulUpsertDef.Annotations == nil || soulUpsertDef.Annotations.ReadOnlyHint == nil || *soulUpsertDef.Annotations.ReadOnlyHint || soulUpsertDef.Annotations.IdempotentHint == nil || *soulUpsertDef.Annotations.IdempotentHint {
+					t.Fatalf("agent_soul_upsert annotations invalid: %+v", soulUpsertDef)
+				}
+				soulArchiveDef := listBody.Result.Tools[6]
+				if soulArchiveDef.Name != "agent_soul_archive" || soulArchiveDef.Annotations == nil || soulArchiveDef.Annotations.ReadOnlyHint == nil || *soulArchiveDef.Annotations.ReadOnlyHint || soulArchiveDef.Annotations.IdempotentHint == nil || !*soulArchiveDef.Annotations.IdempotentHint {
+					t.Fatalf("agent_soul_archive annotations invalid: %+v", soulArchiveDef)
 				}
 			}
 		})

--- a/internal/ptahserver/ptahserver.go
+++ b/internal/ptahserver/ptahserver.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/equaltoai/lesser-body/internal/agentcontent"
 	"github.com/equaltoai/lesser-body/internal/agentregistry"
 	"github.com/equaltoai/lesser-body/internal/auth"
 	"github.com/equaltoai/lesser-body/internal/lesserapi"
@@ -30,6 +31,13 @@ const (
 	toolAgentCreate   = "agent_create"
 	toolAgentGet      = "agent_get"
 	toolAgentList     = "agent_list"
+
+	toolAgentSoulGet     = "agent_soul_get"
+	toolAgentSoulUpsert  = "agent_soul_upsert"
+	toolAgentSoulArchive = "agent_soul_archive"
+
+	agentSoulProvisionalMarker = "provisional_agent_soul_schema_pending_lesser_soul_s1"
+	agentSoulProvisionalText   = "Provisional schema marker " + agentSoulProvisionalMarker + ": agent_soul content is an opaque Ptah-authored draft string pending lesser-soul S1 governance-policy unblock; clients must not treat it as the final Panonomous soul contract."
 )
 
 type soulBindingClient interface {
@@ -38,6 +46,15 @@ type soulBindingClient interface {
 
 type agentDelegateClient interface {
 	DelegateAgent(ctx context.Context, bearerToken string, req lesserapi.AgentDelegationRequest) (*lesserapi.AgentDelegationResponse, error)
+}
+
+// AgentContentStore is the body-owned Ptah content dependency used by Ptah
+// authoring tools. The production implementation is internal/agentcontent.Store,
+// which is TableTheory-backed over INSTANCE_CONTENT_TABLE.
+type AgentContentStore interface {
+	Get(ctx context.Context, account string, agentID string, contentType agentcontent.ContentType) (*agentcontent.Record, error)
+	Upsert(ctx context.Context, in agentcontent.UpsertInput) (*agentcontent.Record, error)
+	Archive(ctx context.Context, in agentcontent.ArchiveInput) (*agentcontent.Record, error)
 }
 
 // AgentRegistry is the body-owned Ptah registry dependency used by Ptah agent
@@ -57,6 +74,9 @@ type config struct {
 	agentDelegateFactory func() (agentDelegateClient, error)
 	agentRegistry        AgentRegistry
 	agentRegistryFactory func() (AgentRegistry, error)
+
+	agentContent        AgentContentStore
+	agentContentFactory func() (AgentContentStore, error)
 
 	integrationBearerFn func(context.Context) (string, error)
 }
@@ -87,6 +107,14 @@ func WithAgentDelegateClient(client agentDelegateClient) Option {
 func WithAgentRegistryStore(store AgentRegistry) Option {
 	return func(cfg *config) {
 		cfg.agentRegistry = store
+	}
+}
+
+// WithAgentContentStore injects the body-owned agent content store used by
+// Ptah authoring tools.
+func WithAgentContentStore(store AgentContentStore) Option {
+	return func(cfg *config) {
+		cfg.agentContent = store
 	}
 }
 
@@ -143,7 +171,16 @@ func RegisterTools(r *mcpruntime.ToolRegistry, opts ...Option) error {
 	if err := r.RegisterTool(agentGetDef(), cfg.handleAgentGet); err != nil {
 		return err
 	}
-	return r.RegisterTool(agentListDef(), cfg.handleAgentList)
+	if err := r.RegisterTool(agentListDef(), cfg.handleAgentList); err != nil {
+		return err
+	}
+	if err := r.RegisterTool(agentSoulGetDef(), cfg.handleAgentSoulGet); err != nil {
+		return err
+	}
+	if err := r.RegisterTool(agentSoulUpsertDef(), cfg.handleAgentSoulUpsert); err != nil {
+		return err
+	}
+	return r.RegisterTool(agentSoulArchiveDef(), cfg.handleAgentSoulArchive)
 }
 
 func defaultConfig() config {
@@ -155,6 +192,9 @@ func defaultConfig() config {
 			return lesserapi.Default()
 		},
 		agentRegistryFactory: defaultAgentRegistry,
+		agentContentFactory: func() (AgentContentStore, error) {
+			return agentcontent.Default()
+		},
 		integrationBearerFn: func(context.Context) (string, error) {
 			return strings.TrimSpace(os.Getenv(EnvSoulBindingIntegrationBearer)), nil
 		},
@@ -286,6 +326,74 @@ func agentListDef() mcpruntime.ToolDef {
 	}
 }
 
+func agentSoulGetDef() mcpruntime.ToolDef {
+	return mcpruntime.ToolDef{
+		Name:        toolAgentSoulGet,
+		Title:       "Get draft agent soul",
+		Description: "Read the current account-scoped Ptah agent_soul draft/archived record for the authenticated account-holder principal. Requires read scope. " + agentSoulProvisionalText,
+		Annotations: readOnlyToolAnnotations(),
+		InputSchema: json.RawMessage(`{
+			"type":"object",
+			"properties":{
+				"agent_id":{"type":"string","description":"Agent id whose agent_soul content is read from the authenticated account-holder's Ptah content partition."},
+				"actor_username":{"type":"string","description":"Optional explicit account-holder actor username. When supplied it must match the authenticated principal."}
+			},
+			"required":["agent_id"],
+			"additionalProperties":false
+		}`),
+		OutputSchema: agentSoulOutputSchema(),
+	}
+}
+
+func agentSoulUpsertDef() mcpruntime.ToolDef {
+	return mcpruntime.ToolDef{
+		Name:        toolAgentSoulUpsert,
+		Title:       "Upsert draft agent soul",
+		Description: "Create or update an account-scoped Ptah agent_soul draft through the canonical internal/agentcontent Store. Requires write scope and increments the per-content version via the store. " + agentSoulProvisionalText,
+		Annotations: additiveMutationToolAnnotations(),
+		InputSchema: json.RawMessage(`{
+			"type":"object",
+			"properties":{
+				"agent_id":{"type":"string","description":"Agent id whose agent_soul draft is written in the authenticated account-holder's Ptah content partition."},
+				"content":{"type":"string","description":"Provisional agent_soul draft payload. Opaque string pending lesser-soul S1; maximum 65536 bytes."},
+				"actor_username":{"type":"string","description":"Optional explicit account-holder actor username. When supplied it must match the authenticated principal."}
+			},
+			"required":["agent_id","content"],
+			"additionalProperties":false
+		}`),
+		OutputSchema: agentSoulOutputSchema(),
+	}
+}
+
+func agentSoulArchiveDef() mcpruntime.ToolDef {
+	return mcpruntime.ToolDef{
+		Name:        toolAgentSoulArchive,
+		Title:       "Archive draft agent soul",
+		Description: "Idempotently archive the current account-scoped Ptah agent_soul record through the canonical internal/agentcontent Store. Requires write scope. " + agentSoulProvisionalText,
+		Annotations: idempotentMutationToolAnnotations(),
+		InputSchema: json.RawMessage(`{
+			"type":"object",
+			"properties":{
+				"agent_id":{"type":"string","description":"Agent id whose agent_soul record is archived in the authenticated account-holder's Ptah content partition."},
+				"actor_username":{"type":"string","description":"Optional explicit account-holder actor username. When supplied it must match the authenticated principal."}
+			},
+			"required":["agent_id"],
+			"additionalProperties":false
+		}`),
+		OutputSchema: agentSoulOutputSchema(),
+	}
+}
+
+func agentSoulOutputSchema() json.RawMessage {
+	return json.RawMessage(`{
+		"type":"object",
+		"properties":{
+			"data":{"type":"object","description":"Structured account-scoped agent_soul record, provisional schema marker, and archive idempotency metadata when applicable."},
+			"error":{"type":"object","description":"Structured tool error when isError=true."}
+		}
+	}`)
+}
+
 type agentBindSoulInput struct {
 	SoulAgentID        string                  `json:"soul_agent_id"`
 	IdempotencyKey     string                  `json:"idempotency_key"`
@@ -322,6 +430,22 @@ type agentGetInput struct {
 type agentListInput struct {
 	Limit  *int   `json:"limit"`
 	Cursor string `json:"cursor"`
+}
+
+type agentSoulGetInput struct {
+	AgentID       string `json:"agent_id"`
+	ActorUsername string `json:"actor_username"`
+}
+
+type agentSoulUpsertInput struct {
+	AgentID       string  `json:"agent_id"`
+	Content       *string `json:"content"`
+	ActorUsername string  `json:"actor_username"`
+}
+
+type agentSoulArchiveInput struct {
+	AgentID       string `json:"agent_id"`
+	ActorUsername string `json:"actor_username"`
 }
 
 func (cfg config) handleAgentBindSoul(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
@@ -623,6 +747,149 @@ func (cfg config) handleAgentList(ctx context.Context, args json.RawMessage) (*m
 	return agentListSuccessResult(actorUsername, limit, page)
 }
 
+func (cfg config) handleAgentSoulGet(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
+	principal := auth.PrincipalFromToolContext(ctx)
+	actorUsername, errResult, err := authenticatedAccountHolderActor(principal, toolAgentSoulGet)
+	if errResult != nil || err != nil {
+		return errResult, err
+	}
+	if !principalHasReadScope(principal) {
+		return toolErrorResult("insufficient_scope", "agent_soul_get requires read scope", http.StatusForbidden, map[string]any{
+			"requiredScopes": []string{"read"},
+			"grantedScopes":  normalizedScopes(principal.Claims.Scopes),
+		})
+	}
+
+	in, errResult, err := parseAgentSoulGetInput(args, actorUsername)
+	if errResult != nil || err != nil {
+		return errResult, err
+	}
+
+	store, err := cfg.content()
+	if err != nil {
+		return toolErrorResult("not_configured", err.Error(), http.StatusInternalServerError, map[string]any{
+			"source": "agent_content",
+		})
+	}
+
+	slog.InfoContext(ctx, "ptah tool invocation",
+		"tool", toolAgentSoulGet,
+		"actor_username", actorUsername,
+	)
+
+	record, err := store.Get(ctx, actorUsername, in.AgentID, agentcontent.ContentTypeAgentSoul)
+	if err != nil {
+		return agentContentToolResultFromError(err)
+	}
+	return agentSoulSuccessResult("Ptah agent_soul record read", actorUsername, record, nil)
+}
+
+func (cfg config) handleAgentSoulUpsert(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
+	principal := auth.PrincipalFromToolContext(ctx)
+	actorUsername, errResult, err := authenticatedAccountHolderActor(principal, toolAgentSoulUpsert)
+	if errResult != nil || err != nil {
+		return errResult, err
+	}
+	if !principalHasWriteScope(principal) {
+		return toolErrorResult("insufficient_scope", "agent_soul_upsert requires write scope", http.StatusForbidden, map[string]any{
+			"requiredScopes": []string{"write"},
+			"grantedScopes":  normalizedScopes(principal.Claims.Scopes),
+		})
+	}
+	subjectID, errResult := authenticatedSubjectID(principal, toolAgentSoulUpsert)
+	if errResult != nil {
+		return errResult, nil
+	}
+
+	in, errResult, err := parseAgentSoulUpsertInput(args, actorUsername)
+	if errResult != nil || err != nil {
+		return errResult, err
+	}
+
+	store, err := cfg.content()
+	if err != nil {
+		return toolErrorResult("not_configured", err.Error(), http.StatusInternalServerError, map[string]any{
+			"source": "agent_content",
+		})
+	}
+
+	content := ""
+	if in.Content != nil {
+		content = *in.Content
+	}
+	slog.InfoContext(ctx, "ptah tool invocation",
+		"tool", toolAgentSoulUpsert,
+		"actor_username", actorUsername,
+		"content_bytes", len([]byte(content)),
+	)
+
+	record, err := store.Upsert(ctx, agentcontent.UpsertInput{
+		Account:            actorUsername,
+		AgentID:            in.AgentID,
+		Type:               agentcontent.ContentTypeAgentSoul,
+		Content:            content,
+		UpdatedBySubjectID: subjectID,
+	})
+	if err != nil {
+		return agentContentToolResultFromError(err)
+	}
+	return agentSoulSuccessResult("Ptah agent_soul draft upserted", actorUsername, record, nil)
+}
+
+func (cfg config) handleAgentSoulArchive(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
+	principal := auth.PrincipalFromToolContext(ctx)
+	actorUsername, errResult, err := authenticatedAccountHolderActor(principal, toolAgentSoulArchive)
+	if errResult != nil || err != nil {
+		return errResult, err
+	}
+	if !principalHasWriteScope(principal) {
+		return toolErrorResult("insufficient_scope", "agent_soul_archive requires write scope", http.StatusForbidden, map[string]any{
+			"requiredScopes": []string{"write"},
+			"grantedScopes":  normalizedScopes(principal.Claims.Scopes),
+		})
+	}
+	subjectID, errResult := authenticatedSubjectID(principal, toolAgentSoulArchive)
+	if errResult != nil {
+		return errResult, nil
+	}
+
+	in, errResult, err := parseAgentSoulArchiveInput(args, actorUsername)
+	if errResult != nil || err != nil {
+		return errResult, err
+	}
+
+	store, err := cfg.content()
+	if err != nil {
+		return toolErrorResult("not_configured", err.Error(), http.StatusInternalServerError, map[string]any{
+			"source": "agent_content",
+		})
+	}
+
+	slog.InfoContext(ctx, "ptah tool invocation",
+		"tool", toolAgentSoulArchive,
+		"actor_username", actorUsername,
+	)
+
+	current, err := store.Get(ctx, actorUsername, in.AgentID, agentcontent.ContentTypeAgentSoul)
+	if err != nil {
+		return agentContentToolResultFromError(err)
+	}
+	alreadyArchived := current != nil && current.LifecycleState == agentcontent.LifecycleStateArchived
+	record, err := store.Archive(ctx, agentcontent.ArchiveInput{
+		Account:            actorUsername,
+		AgentID:            in.AgentID,
+		Type:               agentcontent.ContentTypeAgentSoul,
+		UpdatedBySubjectID: subjectID,
+	})
+	if err != nil {
+		return agentContentToolResultFromError(err)
+	}
+	return agentSoulSuccessResult("Ptah agent_soul record archived", actorUsername, record, map[string]any{
+		"already_archived": alreadyArchived,
+		"idempotent":       true,
+	})
+}
+
 func authenticatedAccountHolderActor(principal *auth.Principal, toolName string) (string, *mcpruntime.ToolResult, error) {
 	if principal == nil || principal.Type != auth.PrincipalTypeOAuthToken || principal.Claims == nil || principal.Claims.IsAgent {
 		return "", mustToolErrorResult("forbidden", toolName+" requires an account-holder OAuth principal", http.StatusForbidden, map[string]any{
@@ -636,6 +903,19 @@ func authenticatedAccountHolderActor(principal *auth.Principal, toolName string)
 		}), nil
 	}
 	return actorUsername, nil, nil
+}
+
+func authenticatedSubjectID(principal *auth.Principal, toolName string) (string, *mcpruntime.ToolResult) {
+	subjectID := ""
+	if principal != nil && principal.Claims != nil {
+		subjectID = strings.TrimSpace(principal.Claims.Subject)
+	}
+	if subjectID == "" {
+		return "", mustToolErrorResult("forbidden", toolName+" requires an authenticated subject id", http.StatusForbidden, map[string]any{
+			"source": "lesser_body_ptah",
+		})
+	}
+	return subjectID, nil
 }
 
 func parseAgentBindSoulInput(args json.RawMessage, actorUsername string) (agentBindSoulInput, *mcpruntime.ToolResult, error) {
@@ -765,6 +1045,84 @@ func parseAgentListInput(args json.RawMessage) (agentListInput, *mcpruntime.Tool
 	return in, nil, nil
 }
 
+func parseAgentSoulGetInput(args json.RawMessage, actorUsername string) (agentSoulGetInput, *mcpruntime.ToolResult, error) {
+	raw := strings.TrimSpace(string(args))
+	if raw == "" || raw == "null" {
+		raw = "{}"
+	}
+
+	var in agentSoulGetInput
+	dec := json.NewDecoder(bytes.NewReader([]byte(raw)))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&in); err != nil {
+		return agentSoulGetInput{}, mustToolErrorResult("invalid_request", "invalid args: "+err.Error(), http.StatusBadRequest, nil), nil
+	}
+	in.AgentID = strings.TrimSpace(in.AgentID)
+	in.ActorUsername = normalizeActorUsername(in.ActorUsername)
+	if in.AgentID == "" {
+		return agentSoulGetInput{}, mustToolErrorResult("invalid_request", "agent_id is required", http.StatusBadRequest, nil), nil
+	}
+	if in.ActorUsername != "" && in.ActorUsername != actorUsername {
+		return agentSoulGetInput{}, mustToolErrorResult("forbidden", "actor_username must match authenticated principal", http.StatusForbidden, map[string]any{
+			"source": "lesser_body_ptah",
+		}), nil
+	}
+	return in, nil, nil
+}
+
+func parseAgentSoulUpsertInput(args json.RawMessage, actorUsername string) (agentSoulUpsertInput, *mcpruntime.ToolResult, error) {
+	raw := strings.TrimSpace(string(args))
+	if raw == "" || raw == "null" {
+		raw = "{}"
+	}
+
+	var in agentSoulUpsertInput
+	dec := json.NewDecoder(bytes.NewReader([]byte(raw)))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&in); err != nil {
+		return agentSoulUpsertInput{}, mustToolErrorResult("invalid_request", "invalid args: "+err.Error(), http.StatusBadRequest, nil), nil
+	}
+	in.AgentID = strings.TrimSpace(in.AgentID)
+	in.ActorUsername = normalizeActorUsername(in.ActorUsername)
+	if in.AgentID == "" {
+		return agentSoulUpsertInput{}, mustToolErrorResult("invalid_request", "agent_id is required", http.StatusBadRequest, nil), nil
+	}
+	if in.Content == nil {
+		return agentSoulUpsertInput{}, mustToolErrorResult("invalid_request", "content is required", http.StatusBadRequest, nil), nil
+	}
+	if in.ActorUsername != "" && in.ActorUsername != actorUsername {
+		return agentSoulUpsertInput{}, mustToolErrorResult("forbidden", "actor_username must match authenticated principal", http.StatusForbidden, map[string]any{
+			"source": "lesser_body_ptah",
+		}), nil
+	}
+	return in, nil, nil
+}
+
+func parseAgentSoulArchiveInput(args json.RawMessage, actorUsername string) (agentSoulArchiveInput, *mcpruntime.ToolResult, error) {
+	raw := strings.TrimSpace(string(args))
+	if raw == "" || raw == "null" {
+		raw = "{}"
+	}
+
+	var in agentSoulArchiveInput
+	dec := json.NewDecoder(bytes.NewReader([]byte(raw)))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&in); err != nil {
+		return agentSoulArchiveInput{}, mustToolErrorResult("invalid_request", "invalid args: "+err.Error(), http.StatusBadRequest, nil), nil
+	}
+	in.AgentID = strings.TrimSpace(in.AgentID)
+	in.ActorUsername = normalizeActorUsername(in.ActorUsername)
+	if in.AgentID == "" {
+		return agentSoulArchiveInput{}, mustToolErrorResult("invalid_request", "agent_id is required", http.StatusBadRequest, nil), nil
+	}
+	if in.ActorUsername != "" && in.ActorUsername != actorUsername {
+		return agentSoulArchiveInput{}, mustToolErrorResult("forbidden", "actor_username must match authenticated principal", http.StatusForbidden, map[string]any{
+			"source": "lesser_body_ptah",
+		}), nil
+	}
+	return in, nil, nil
+}
+
 func (cfg config) soulBindingClient() (soulBindingClient, error) {
 	if cfg.soulBinding != nil {
 		return cfg.soulBinding, nil
@@ -793,6 +1151,16 @@ func (cfg config) registry() (AgentRegistry, error) {
 		return nil, fmt.Errorf("agent registry store is not configured")
 	}
 	return cfg.agentRegistryFactory()
+}
+
+func (cfg config) content() (AgentContentStore, error) {
+	if cfg.agentContent != nil {
+		return cfg.agentContent, nil
+	}
+	if cfg.agentContentFactory == nil {
+		return nil, fmt.Errorf("agent content store is not configured")
+	}
+	return cfg.agentContentFactory()
 }
 
 func (cfg config) integrationBearer(ctx context.Context) (string, error) {
@@ -990,6 +1358,37 @@ func agentListSuccessResult(actorUsername string, limit int, page *agentregistry
 	return toolJSONTextResult(text, map[string]any{"data": data})
 }
 
+func agentSoulSuccessResult(summary string, actorUsername string, record *agentcontent.Record, extra map[string]any) (*mcpruntime.ToolResult, error) {
+	recordSummary := agentSoulRecordSummary(record)
+	data := map[string]any{
+		"actor_username": actorUsername,
+		"agent_soul":     recordSummary,
+		"schema":         agentSoulSchemaMarker(),
+	}
+	for key, value := range extra {
+		data[key] = value
+	}
+
+	text := map[string]any{
+		"summary": summary,
+		"agent_soul": map[string]any{
+			"account":          recordSummary["account"],
+			"agent_id":         recordSummary["agent_id"],
+			"version":          recordSummary["version"],
+			"lifecycle_state":  recordSummary["lifecycle_state"],
+			"content_bytes":    recordSummary["content_bytes"],
+			"schema_marker":    agentSoulProvisionalMarker,
+			"content_location": "structuredContent.data.agent_soul.content",
+		},
+		"schema": agentSoulSchemaMarker(),
+		"data":   map[string]any{"location": "structuredContent.data"},
+	}
+	if len(extra) > 0 {
+		text["metadata"] = extra
+	}
+	return toolJSONTextResult(text, map[string]any{"data": data})
+}
+
 func soulBindingToolResultFromError(err error) (*mcpruntime.ToolResult, error) {
 	if err == nil {
 		return nil, nil
@@ -1035,6 +1434,36 @@ func agentDelegateToolResultFromError(err error) (*mcpruntime.ToolResult, error)
 	return toolErrorResult("upstream_error", err.Error(), http.StatusBadGateway, map[string]any{
 		"source": "lesser_agent_delegate",
 	})
+}
+
+func agentContentToolResultFromError(err error) (*mcpruntime.ToolResult, error) {
+	if err == nil {
+		return nil, nil
+	}
+
+	details := map[string]any{
+		"source":       "agent_content",
+		"content_type": string(agentcontent.ContentTypeAgentSoul),
+	}
+	var sizeErr *agentcontent.SizeError
+	switch {
+	case errors.Is(err, agentcontent.ErrContentNotFound):
+		return toolErrorResult("not_found", "agent_soul record not found in this account-scoped Ptah content store", http.StatusNotFound, details)
+	case errors.As(err, &sizeErr):
+		details["limit_bytes"] = sizeErr.Limit
+		details["actual_bytes"] = sizeErr.Actual
+		return toolErrorResult("invalid_request", "agent_soul content exceeds the per-record size limit", http.StatusBadRequest, details)
+	case errors.Is(err, agentcontent.ErrInvalidContentType):
+		return toolErrorResult("invalid_request", "invalid agent content type", http.StatusBadRequest, details)
+	case errors.Is(err, agentcontent.ErrMissingUpdatedBySubjectID):
+		return toolErrorResult("forbidden", "agent_soul writes require an authenticated subject id", http.StatusForbidden, details)
+	case errors.Is(err, agentcontent.ErrContentConflict):
+		return toolErrorResult("conflict", "agent_soul content update conflict; retry the operation", http.StatusConflict, details)
+	case errors.Is(err, agentcontent.ErrInvalidLifecycleState):
+		return toolErrorResult("internal", "agent_soul content record has invalid lifecycle state", http.StatusInternalServerError, details)
+	default:
+		return toolErrorResult("internal", "Body failed to access the Ptah agent_soul content record", http.StatusInternalServerError, details)
+	}
 }
 
 func agentRegistryPartialFailureResult(code string, message string, status int, details map[string]any) (*mcpruntime.ToolResult, error) {
@@ -1131,6 +1560,14 @@ func additiveMutationToolAnnotations() *mcpruntime.ToolAnnotations {
 	}
 }
 
+func idempotentMutationToolAnnotations() *mcpruntime.ToolAnnotations {
+	return &mcpruntime.ToolAnnotations{
+		ReadOnlyHint:    boolHint(false),
+		DestructiveHint: boolHint(false),
+		IdempotentHint:  boolHint(true),
+	}
+}
+
 func boolHint(value bool) *bool {
 	return &value
 }
@@ -1216,6 +1653,33 @@ func unavailableContentSummary() map[string]any {
 		"status": "not_available",
 		"source": "agentregistry",
 		"reason": "Body/Ptah registry records do not currently store source-backed content summary metadata.",
+	}
+}
+
+func agentSoulRecordSummary(record *agentcontent.Record) map[string]any {
+	if record == nil {
+		return map[string]any{}
+	}
+	return map[string]any{
+		"account":               record.Account,
+		"agent_id":              record.AgentID,
+		"type":                  string(record.Type),
+		"content":               record.Content,
+		"content_bytes":         len([]byte(record.Content)),
+		"version":               record.Version,
+		"lifecycle_state":       string(record.LifecycleState),
+		"created_at":            formatTime(record.CreatedAt),
+		"updated_at":            formatTime(record.UpdatedAt),
+		"updated_by_subject_id": record.UpdatedBySubjectID,
+	}
+}
+
+func agentSoulSchemaMarker() map[string]any {
+	return map[string]any{
+		"content_type": string(agentcontent.ContentTypeAgentSoul),
+		"status":       "provisional",
+		"marker":       agentSoulProvisionalMarker,
+		"description":  agentSoulProvisionalText,
 	}
 }
 

--- a/internal/ptahserver/ptahserver_test.go
+++ b/internal/ptahserver/ptahserver_test.go
@@ -10,9 +10,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/equaltoai/lesser-body/internal/agentcontent"
 	"github.com/equaltoai/lesser-body/internal/agentregistry"
 	"github.com/equaltoai/lesser-body/internal/auth"
 	"github.com/equaltoai/lesser-body/internal/lesserapi"
+	"github.com/golang-jwt/jwt/v5"
 	mcpruntime "github.com/theory-cloud/apptheory/runtime/mcp"
 )
 
@@ -23,7 +25,7 @@ func TestRegisterToolsRegistersPtahDefinitions(t *testing.T) {
 	}
 
 	tools := registry.List()
-	if got, want := toolDefNames(tools), []string{toolAgentBindSoul, toolAgentCreate, toolAgentGet, toolAgentList}; strings.Join(got, ",") != strings.Join(want, ",") {
+	if got, want := toolDefNames(tools), []string{toolAgentBindSoul, toolAgentCreate, toolAgentGet, toolAgentList, toolAgentSoulGet, toolAgentSoulUpsert, toolAgentSoulArchive}; strings.Join(got, ",") != strings.Join(want, ",") {
 		t.Fatalf("registered tool order = %v, want %v", got, want)
 	}
 	def := tools[0]
@@ -119,6 +121,70 @@ func TestRegisterToolsRegistersPtahDefinitions(t *testing.T) {
 		if _, ok := listSchema.Props[prop]; !ok {
 			t.Fatalf("agent_list schema missing %s", prop)
 		}
+	}
+
+	soulGetDef := tools[4]
+	if soulGetDef.Name != toolAgentSoulGet {
+		t.Fatalf("fifth tool name = %q, want %q", soulGetDef.Name, toolAgentSoulGet)
+	}
+	assertReadOnlyToolDef(t, soulGetDef)
+	assertContains(t, soulGetDef.Description, agentSoulProvisionalMarker)
+	var soulGetSchema struct {
+		Required []string       `json:"required"`
+		Props    map[string]any `json:"properties"`
+	}
+	if err := json.Unmarshal(soulGetDef.InputSchema, &soulGetSchema); err != nil {
+		t.Fatalf("agent_soul_get input schema invalid json: %v", err)
+	}
+	if !contains(soulGetSchema.Required, "agent_id") {
+		t.Fatalf("agent_soul_get required = %v, missing agent_id", soulGetSchema.Required)
+	}
+	if _, ok := soulGetSchema.Props["actor_username"]; !ok {
+		t.Fatalf("agent_soul_get schema should advertise optional actor_username mismatch guard")
+	}
+
+	soulUpsertDef := tools[5]
+	if soulUpsertDef.Name != toolAgentSoulUpsert {
+		t.Fatalf("sixth tool name = %q, want %q", soulUpsertDef.Name, toolAgentSoulUpsert)
+	}
+	assertMutationToolDef(t, soulUpsertDef, false)
+	assertContains(t, soulUpsertDef.Description, agentSoulProvisionalMarker)
+	var soulUpsertSchema struct {
+		Required []string       `json:"required"`
+		Props    map[string]any `json:"properties"`
+	}
+	if err := json.Unmarshal(soulUpsertDef.InputSchema, &soulUpsertSchema); err != nil {
+		t.Fatalf("agent_soul_upsert input schema invalid json: %v", err)
+	}
+	for _, required := range []string{"agent_id", "content"} {
+		if !contains(soulUpsertSchema.Required, required) {
+			t.Fatalf("agent_soul_upsert required = %v, missing %s", soulUpsertSchema.Required, required)
+		}
+	}
+	for _, prop := range []string{"actor_username", "content"} {
+		if _, ok := soulUpsertSchema.Props[prop]; !ok {
+			t.Fatalf("agent_soul_upsert schema missing %s", prop)
+		}
+	}
+
+	soulArchiveDef := tools[6]
+	if soulArchiveDef.Name != toolAgentSoulArchive {
+		t.Fatalf("seventh tool name = %q, want %q", soulArchiveDef.Name, toolAgentSoulArchive)
+	}
+	assertMutationToolDef(t, soulArchiveDef, true)
+	assertContains(t, soulArchiveDef.Description, agentSoulProvisionalMarker)
+	var soulArchiveSchema struct {
+		Required []string       `json:"required"`
+		Props    map[string]any `json:"properties"`
+	}
+	if err := json.Unmarshal(soulArchiveDef.InputSchema, &soulArchiveSchema); err != nil {
+		t.Fatalf("agent_soul_archive input schema invalid json: %v", err)
+	}
+	if !contains(soulArchiveSchema.Required, "agent_id") {
+		t.Fatalf("agent_soul_archive required = %v, missing agent_id", soulArchiveSchema.Required)
+	}
+	if _, ok := soulArchiveSchema.Props["actor_username"]; !ok {
+		t.Fatalf("agent_soul_archive schema should advertise optional actor_username mismatch guard")
 	}
 }
 
@@ -726,6 +792,258 @@ func TestAgentListMapsInvalidCursor(t *testing.T) {
 	}
 }
 
+func TestAgentSoulGetReadsAccountScopedContentWithReadCapableScopes(t *testing.T) {
+	for _, scope := range []string{"read", "write", "admin"} {
+		t.Run(scope, func(t *testing.T) {
+			store := &fakeAgentContentStore{getRecord: agentSoulRecord("drone-ada", "agent-123", "draft soul", 3, agentcontent.LifecycleStateDraft, "subject-prev")}
+			registry := mcpruntime.NewToolRegistry()
+			if err := RegisterTools(registry, WithAgentContentStore(store)); err != nil {
+				t.Fatalf("RegisterTools: %v", err)
+			}
+
+			result, err := registry.Call(toolContextWithSubject("Drone-Ada", []string{scope}, "owner-oauth-token", "subject-reader"), toolAgentSoulGet, json.RawMessage(`{"agent_id":" agent-123 ","actor_username":"drone-ada"}`))
+			if err != nil {
+				t.Fatalf("Call: %v", err)
+			}
+			if result == nil || result.IsError {
+				t.Fatalf("result = %+v", result)
+			}
+			if store.getCalls != 1 || store.getAccount != "drone-ada" || store.getAgentID != "agent-123" || store.getType != agentcontent.ContentTypeAgentSoul {
+				t.Fatalf("content Get calls/account/id/type = %d/%q/%q/%q, want account-scoped agent_soul", store.getCalls, store.getAccount, store.getAgentID, store.getType)
+			}
+			data := structuredData(t, result)
+			record, _ := data["agent_soul"].(map[string]any)
+			if record["account"] != "drone-ada" || record["agent_id"] != "agent-123" || record["content"] != "draft soul" || record["version"] != int64(3) {
+				t.Fatalf("agent_soul record = %+v", record)
+			}
+			schema, _ := data["schema"].(map[string]any)
+			if schema["marker"] != agentSoulProvisionalMarker || schema["status"] != "provisional" {
+				t.Fatalf("schema marker = %+v", schema)
+			}
+		})
+	}
+}
+
+func TestAgentSoulUpsertUsesAgentContentStoreWithSubject(t *testing.T) {
+	store := &fakeAgentContentStore{upsertRecord: agentSoulRecord("drone-ada", "agent-123", "draft soul v1", 1, agentcontent.LifecycleStateDraft, "subject-writer")}
+	registry := mcpruntime.NewToolRegistry()
+	if err := RegisterTools(registry, WithAgentContentStore(store)); err != nil {
+		t.Fatalf("RegisterTools: %v", err)
+	}
+
+	result, err := registry.Call(toolContextWithSubject("Drone-Ada", []string{"write"}, "owner-oauth-token", "subject-writer"), toolAgentSoulUpsert, json.RawMessage(`{
+		"agent_id":" agent-123 ",
+		"actor_username":"drone-ada",
+		"content":"draft soul v1"
+	}`))
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if result == nil || result.IsError {
+		t.Fatalf("result = %+v", result)
+	}
+	if store.upsertCalls != 1 {
+		t.Fatalf("Upsert calls = %d, want 1", store.upsertCalls)
+	}
+	if store.upsertIn.Account != "drone-ada" || store.upsertIn.AgentID != "agent-123" || store.upsertIn.Type != agentcontent.ContentTypeAgentSoul || store.upsertIn.Content != "draft soul v1" || store.upsertIn.UpdatedBySubjectID != "subject-writer" {
+		t.Fatalf("Upsert input = %+v, want account-scoped agent_soul with subject", store.upsertIn)
+	}
+	data := structuredData(t, result)
+	record, _ := data["agent_soul"].(map[string]any)
+	if record["updated_by_subject_id"] != "subject-writer" || record["content"] != "draft soul v1" {
+		t.Fatalf("agent_soul record = %+v", record)
+	}
+	if strings.Contains(result.Content[0].Text, "draft soul v1") {
+		t.Fatalf("text content duplicated provisional soul content: %s", result.Content[0].Text)
+	}
+}
+
+func TestAgentSoulArchiveUsesStoreAndReportsIdempotentReplay(t *testing.T) {
+	store := &fakeAgentContentStore{
+		getRecord:     agentSoulRecord("drone-ada", "agent-123", "draft soul", 4, agentcontent.LifecycleStateArchived, "subject-prev"),
+		archiveRecord: agentSoulRecord("drone-ada", "agent-123", "draft soul", 4, agentcontent.LifecycleStateArchived, "subject-archive"),
+	}
+	registry := mcpruntime.NewToolRegistry()
+	if err := RegisterTools(registry, WithAgentContentStore(store)); err != nil {
+		t.Fatalf("RegisterTools: %v", err)
+	}
+
+	result, err := registry.Call(toolContextWithSubject("Drone-Ada", []string{"write"}, "owner-oauth-token", "subject-archive"), toolAgentSoulArchive, json.RawMessage(`{"agent_id":"agent-123","actor_username":"drone-ada"}`))
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if result == nil || result.IsError {
+		t.Fatalf("result = %+v", result)
+	}
+	if store.getCalls != 1 || store.archiveCalls != 1 {
+		t.Fatalf("Get/Archive calls = %d/%d, want 1/1", store.getCalls, store.archiveCalls)
+	}
+	if store.archiveIn.Account != "drone-ada" || store.archiveIn.AgentID != "agent-123" || store.archiveIn.Type != agentcontent.ContentTypeAgentSoul || store.archiveIn.UpdatedBySubjectID != "subject-archive" {
+		t.Fatalf("Archive input = %+v, want account-scoped agent_soul with subject", store.archiveIn)
+	}
+	data := structuredData(t, result)
+	if data["already_archived"] != true || data["idempotent"] != true {
+		t.Fatalf("archive idempotency metadata = %+v", data)
+	}
+	record, _ := data["agent_soul"].(map[string]any)
+	if record["lifecycle_state"] != string(agentcontent.LifecycleStateArchived) || record["version"] != int64(4) {
+		t.Fatalf("archived record = %+v", record)
+	}
+}
+
+func TestAgentSoulRejectsInvalidInputAndPrincipalsBeforeContentStoreWrite(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		tool      string
+		ctx       context.Context
+		args      string
+		wantCode  string
+		wantState int
+	}{
+		{
+			name:      "upsert insufficient scope",
+			tool:      toolAgentSoulUpsert,
+			ctx:       toolContextWithSubject("drone-ada", []string{"read"}, "owner-oauth-token", "subject-writer"),
+			args:      `{"agent_id":"agent-123","content":"draft"}`,
+			wantCode:  "insufficient_scope",
+			wantState: 403,
+		},
+		{
+			name:      "upsert agent principal",
+			tool:      toolAgentSoulUpsert,
+			ctx:       toolContextWithAgent("drone-ada", []string{"write"}, "agent-runtime-token", true),
+			args:      `{"agent_id":"agent-123","content":"draft"}`,
+			wantCode:  "forbidden",
+			wantState: 403,
+		},
+		{
+			name:      "upsert missing subject",
+			tool:      toolAgentSoulUpsert,
+			ctx:       toolContextWithSubject("drone-ada", []string{"write"}, "owner-oauth-token", ""),
+			args:      `{"agent_id":"agent-123","content":"draft"}`,
+			wantCode:  "forbidden",
+			wantState: 403,
+		},
+		{
+			name:      "upsert missing content",
+			tool:      toolAgentSoulUpsert,
+			ctx:       toolContextWithSubject("drone-ada", []string{"write"}, "owner-oauth-token", "subject-writer"),
+			args:      `{"agent_id":"agent-123"}`,
+			wantCode:  "invalid_request",
+			wantState: 400,
+		},
+		{
+			name:      "get caller-supplied account rejected",
+			tool:      toolAgentSoulGet,
+			ctx:       toolContextWithSubject("drone-ada", []string{"read"}, "owner-oauth-token", "subject-reader"),
+			args:      `{"agent_id":"agent-123","account":"other"}`,
+			wantCode:  "invalid_request",
+			wantState: 400,
+		},
+		{
+			name:      "archive mismatched actor username",
+			tool:      toolAgentSoulArchive,
+			ctx:       toolContextWithSubject("drone-ada", []string{"write"}, "owner-oauth-token", "subject-writer"),
+			args:      `{"agent_id":"agent-123","actor_username":"other"}`,
+			wantCode:  "forbidden",
+			wantState: 403,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := &fakeAgentContentStore{getRecord: agentSoulRecord("drone-ada", "agent-123", "draft", 1, agentcontent.LifecycleStateDraft, "subject")}
+			registry := mcpruntime.NewToolRegistry()
+			if err := RegisterTools(registry, WithAgentContentStore(store)); err != nil {
+				t.Fatalf("RegisterTools: %v", err)
+			}
+
+			result, err := registry.Call(tc.ctx, tc.tool, json.RawMessage(tc.args))
+			if err != nil {
+				t.Fatalf("Call: %v", err)
+			}
+			assertToolError(t, result, tc.wantCode, tc.wantState)
+			if store.getCalls != 0 || store.upsertCalls != 0 || store.archiveCalls != 0 {
+				t.Fatalf("content store side effects occurred before rejection: get=%d upsert=%d archive=%d", store.getCalls, store.upsertCalls, store.archiveCalls)
+			}
+		})
+	}
+}
+
+func TestAgentSoulMapsContentStoreErrorsWithoutLeakingScopeDetails(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		tool        string
+		store       *fakeAgentContentStore
+		ctx         context.Context
+		args        string
+		wantCode    string
+		wantStatus  int
+		forbidTerms []string
+	}{
+		{
+			name:       "get not found",
+			tool:       toolAgentSoulGet,
+			store:      &fakeAgentContentStore{getErr: fmt.Errorf("%w: hidden account agent-elsewhere", agentcontent.ErrContentNotFound)},
+			ctx:        toolContextWithSubject("drone-ada", []string{"read"}, "owner-oauth-token", "subject-reader"),
+			args:       `{"agent_id":"agent-elsewhere"}`,
+			wantCode:   "not_found",
+			wantStatus: 404,
+			forbidTerms: []string{
+				"hidden account",
+				"agent-elsewhere",
+				"drone-ada",
+			},
+		},
+		{
+			name:       "upsert too large",
+			tool:       toolAgentSoulUpsert,
+			store:      &fakeAgentContentStore{upsertErr: &agentcontent.SizeError{Type: agentcontent.ContentTypeAgentSoul, Limit: agentcontent.MaxAgentSoulBytes, Actual: agentcontent.MaxAgentSoulBytes + 1}},
+			ctx:        toolContextWithSubject("drone-ada", []string{"write"}, "owner-oauth-token", "subject-writer"),
+			args:       `{"agent_id":"agent-123","content":"too large"}`,
+			wantCode:   "invalid_request",
+			wantStatus: 400,
+		},
+		{
+			name:       "upsert conflict",
+			tool:       toolAgentSoulUpsert,
+			store:      &fakeAgentContentStore{upsertErr: fmt.Errorf("%w: conditional retry exhausted", agentcontent.ErrContentConflict)},
+			ctx:        toolContextWithSubject("drone-ada", []string{"write"}, "owner-oauth-token", "subject-writer"),
+			args:       `{"agent_id":"agent-123","content":"draft"}`,
+			wantCode:   "conflict",
+			wantStatus: 409,
+		},
+		{
+			name:       "archive invalid lifecycle",
+			tool:       toolAgentSoulArchive,
+			store:      &fakeAgentContentStore{getRecord: agentSoulRecord("drone-ada", "agent-123", "draft", 1, agentcontent.LifecycleStateDraft, "subject-prev"), archiveErr: fmt.Errorf("%w: corrupted", agentcontent.ErrInvalidLifecycleState)},
+			ctx:        toolContextWithSubject("drone-ada", []string{"write"}, "owner-oauth-token", "subject-writer"),
+			args:       `{"agent_id":"agent-123"}`,
+			wantCode:   "internal",
+			wantStatus: 500,
+			forbidTerms: []string{
+				"corrupted",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			registry := mcpruntime.NewToolRegistry()
+			if err := RegisterTools(registry, WithAgentContentStore(tc.store)); err != nil {
+				t.Fatalf("RegisterTools: %v", err)
+			}
+			result, err := registry.Call(tc.ctx, tc.tool, json.RawMessage(tc.args))
+			if err != nil {
+				t.Fatalf("Call: %v", err)
+			}
+			payload := assertToolError(t, result, tc.wantCode, tc.wantStatus)
+			encoded, _ := json.Marshal(payload)
+			for _, term := range tc.forbidTerms {
+				if strings.Contains(string(encoded), term) {
+					t.Fatalf("error payload leaked %q: %s", term, string(encoded))
+				}
+			}
+		})
+	}
+}
+
 type fakeSoulBindingClient struct {
 	calls             int
 	integrationBearer string
@@ -782,6 +1100,25 @@ type fakeAgentRegistry struct {
 	listErr    error
 }
 
+type fakeAgentContentStore struct {
+	getCalls   int
+	getAccount string
+	getAgentID string
+	getType    agentcontent.ContentType
+	getRecord  *agentcontent.Record
+	getErr     error
+
+	upsertCalls  int
+	upsertIn     agentcontent.UpsertInput
+	upsertRecord *agentcontent.Record
+	upsertErr    error
+
+	archiveCalls  int
+	archiveIn     agentcontent.ArchiveInput
+	archiveRecord *agentcontent.Record
+	archiveErr    error
+}
+
 func (f *fakeAgentRegistry) Create(_ context.Context, in agentregistry.CreateInput) (*agentregistry.Agent, error) {
 	f.calls++
 	f.in = in
@@ -816,20 +1153,82 @@ func (f *fakeAgentRegistry) List(_ context.Context, in agentregistry.ListInput) 
 	return &agentregistry.ListResult{}, nil
 }
 
+func (f *fakeAgentContentStore) Get(_ context.Context, account string, agentID string, contentType agentcontent.ContentType) (*agentcontent.Record, error) {
+	f.getCalls++
+	f.getAccount = account
+	f.getAgentID = agentID
+	f.getType = contentType
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	return f.getRecord, nil
+}
+
+func (f *fakeAgentContentStore) Upsert(_ context.Context, in agentcontent.UpsertInput) (*agentcontent.Record, error) {
+	f.upsertCalls++
+	f.upsertIn = in
+	if f.upsertErr != nil {
+		return nil, f.upsertErr
+	}
+	if f.upsertRecord != nil {
+		return f.upsertRecord, nil
+	}
+	return agentSoulRecord(in.Account, in.AgentID, in.Content, 1, agentcontent.LifecycleStateDraft, in.UpdatedBySubjectID), nil
+}
+
+func (f *fakeAgentContentStore) Archive(_ context.Context, in agentcontent.ArchiveInput) (*agentcontent.Record, error) {
+	f.archiveCalls++
+	f.archiveIn = in
+	if f.archiveErr != nil {
+		return nil, f.archiveErr
+	}
+	if f.archiveRecord != nil {
+		return f.archiveRecord, nil
+	}
+	return agentSoulRecord(in.Account, in.AgentID, "", 1, agentcontent.LifecycleStateArchived, in.UpdatedBySubjectID), nil
+}
+
 func toolContext(username string, scopes []string, bearer string) context.Context {
-	return toolContextWithAgent(username, scopes, bearer, false)
+	return toolContextWithSubject(username, scopes, bearer, username)
 }
 
 func toolContextWithAgent(username string, scopes []string, bearer string, isAgent bool) context.Context {
+	subject := username
+	if isAgent {
+		subject = "agent-subject-" + strings.ToLower(strings.TrimSpace(username))
+	}
+	return toolContextWithSubjectAndAgent(username, scopes, bearer, subject, isAgent)
+}
+
+func toolContextWithSubject(username string, scopes []string, bearer string, subject string) context.Context {
+	return toolContextWithSubjectAndAgent(username, scopes, bearer, subject, false)
+}
+
+func toolContextWithSubjectAndAgent(username string, scopes []string, bearer string, subject string, isAgent bool) context.Context {
 	return auth.InjectToolContext(context.Background(), &auth.Principal{
 		Type:     auth.PrincipalTypeOAuthToken,
 		Identity: username,
 		Claims: &auth.Claims{
-			Username: username,
-			Scopes:   scopes,
-			IsAgent:  isAgent,
+			RegisteredClaims: jwt.RegisteredClaims{Subject: subject},
+			Username:         username,
+			Scopes:           scopes,
+			IsAgent:          isAgent,
 		},
 	}, bearer)
+}
+
+func agentSoulRecord(account, agentID, content string, version int64, state agentcontent.LifecycleState, updatedBySubjectID string) *agentcontent.Record {
+	return &agentcontent.Record{
+		Account:            account,
+		AgentID:            agentID,
+		Type:               agentcontent.ContentTypeAgentSoul,
+		Content:            content,
+		Version:            version,
+		LifecycleState:     state,
+		CreatedAt:          time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC),
+		UpdatedAt:          time.Date(2026, 7, 15, 12, 30, 0, 0, time.UTC),
+		UpdatedBySubjectID: updatedBySubjectID,
+	}
 }
 
 func successfulBindingResponse(replayed bool) *lesserapi.SoulBindingResponse {
@@ -941,5 +1340,28 @@ func assertReadOnlyToolDef(t testing.TB, def mcpruntime.ToolDef) {
 	}
 	if def.Annotations.IdempotentHint == nil || !*def.Annotations.IdempotentHint {
 		t.Fatalf("%s should advertise idempotentHint=true: %+v", def.Name, def.Annotations)
+	}
+}
+
+func assertMutationToolDef(t testing.TB, def mcpruntime.ToolDef, idempotent bool) {
+	t.Helper()
+	if def.Annotations == nil {
+		t.Fatalf("%s annotations missing", def.Name)
+	}
+	if def.Annotations.ReadOnlyHint == nil || *def.Annotations.ReadOnlyHint {
+		t.Fatalf("%s should advertise readOnlyHint=false: %+v", def.Name, def.Annotations)
+	}
+	if def.Annotations.DestructiveHint == nil || *def.Annotations.DestructiveHint {
+		t.Fatalf("%s should advertise destructiveHint=false: %+v", def.Name, def.Annotations)
+	}
+	if def.Annotations.IdempotentHint == nil || *def.Annotations.IdempotentHint != idempotent {
+		t.Fatalf("%s idempotentHint = %+v want %v", def.Name, def.Annotations.IdempotentHint, idempotent)
+	}
+}
+
+func assertContains(t testing.TB, got string, want string) {
+	t.Helper()
+	if !strings.Contains(got, want) {
+		t.Fatalf("expected %q to contain %q", got, want)
 	}
 }


### PR DESCRIPTION
## Milestone
Project 48 M5/B10 — Ptah authoring, `agent_soul` tools

## Classification
tool-surface / MCP-contract-additive / test-coverage / docs

## Surfaces affected
- `internal/ptahserver`: registers `agent_soul_get`, `agent_soul_upsert`, and `agent_soul_archive` on the Ptah instance-plane MCP registry only.
- `internal/instanceapp` tests: updates Ptah `tools/list` expectations for the additive surface.
- `docs/mcp.md`: documents the provisional `agent_soul` schema marker and account-scoped semantics.

## Specialist walks referenced
- Tool surface: additive Ptah-only tool surface; read/write/write scope split; account-holder-only principal gate retained; no dynamic registration.
- MCP contract: additive `tools/list` surface on `/instance/ptah/mcp`; public actor-scoped `/.well-known/mcp.json` remains unchanged.
- Lesser integration: none; no Lesser API, SSM, DynamoDB Lesser table, or deploy changes.
- Host delegation: none.
- Framework/store: uses the existing TableTheory-backed `internal/agentcontent.Store` API; no custom persistence layer or framework bypass.

## Consumer impact
Ptah clients can now draft/read/archive provisional `agent_soul` content using the instance-plane MCP endpoint. Ka actor-scoped MCP clients and Ba are unaffected.

## Tasks
- [x] Register `agent_soul_get` with read scope semantics and structured not_found handling.
- [x] Register `agent_soul_upsert` with write scope semantics, `agentcontent.Store.Upsert`, and authenticated subject audit capture.
- [x] Register `agent_soul_archive` with write scope semantics, `agentcontent.Store.Archive`, and idempotent archive reporting.
- [x] Document provisional schema marker pending lesser-soul S1 governance unblock.

## Validation
- [x] `gofmt -l .` (empty)
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `bash scripts/build.sh`
- [x] Targeted: `go test ./internal/ptahserver ./internal/agentcontent`

## Stage rollout plan (handoff to deploy-body)
- [ ] Merged to staging
- [ ] Deployed to lab / dev
- [ ] Lab soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
No sibling repo edits. The `agent_soul` payload remains explicitly provisional until lesser-soul S1/Panonomous schema governance unblocks finalization.

Closes #351
