### PR TITLE
feat(ptah): register agent_instructions tools

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -436,6 +436,9 @@ surface or Ba's `/instance/ba/mcp` surface. Clients discover them with an authen
 | `agent_soul_get` | Read | Read the current account-scoped Ptah `agent_soul` draft/archived record. Schema marker: `provisional_agent_soul_schema_pending_lesser_soul_s1`. |
 | `agent_soul_upsert` | Write | Create or update account-scoped Ptah `agent_soul` draft content through `internal/agentcontent.Store`. Schema marker: `provisional_agent_soul_schema_pending_lesser_soul_s1`. |
 | `agent_soul_archive` | Write | Idempotently archive the current account-scoped Ptah `agent_soul` record through `internal/agentcontent.Store`. Schema marker: `provisional_agent_soul_schema_pending_lesser_soul_s1`. |
+| `agent_instructions_get` | Read | Read the current account-scoped Ptah `agent_instructions` draft/archived record. |
+| `agent_instructions_upsert` | Write | Create or update account-scoped Ptah `agent_instructions` draft content through `internal/agentcontent.Store`. |
+| `agent_instructions_archive` | Write | Idempotently archive the current account-scoped Ptah `agent_instructions` record through `internal/agentcontent.Store`. |
 
 `agent_get` input:
 
@@ -568,6 +571,74 @@ returned `agent_soul` record keeps the store-owned version and has `lifecycle_st
 For all `agent_soul_*` tools, malformed input returns `invalid_request`; agent-delegated or mismatched principals return
 `forbidden`; missing content records return `not_found`; optimistic write races return `conflict`; and unexpected
 content-store failures return `internal` with sanitized `source:"agent_content"` details.
+
+`agent_instructions_get` input:
+
+- Required: `agent_id`.
+- Derived: the account scope is always the authenticated account-holder OAuth principal. Callers cannot supply an
+  account override. Optional `actor_username`, when supplied, must match the authenticated principal after normalization
+  or the tool fails closed.
+
+`agent_instructions_get` requires an account-holder OAuth principal with read-capable scope. It calls only the
+Body-owned `internal/agentcontent.Store.Get` path with content type `agent_instructions`; it does not call Lesser, read
+`LESSER_TABLE_NAME`, or accept cross-account selectors. Missing records and cross-account lookups return structured tool
+error code `not_found` without account/agent detail leakage.
+
+Successful output has `structuredContent.data.agent_instructions`:
+
+```json
+{
+  "account": "<authenticated account username>",
+  "agent_id": "<agent id>",
+  "type": "agent_instructions",
+  "content": "<draft instructions content>",
+  "content_bytes": 123,
+  "version": 1,
+  "lifecycle_state": "draft",
+  "created_at": "<RFC3339 timestamp>",
+  "updated_at": "<RFC3339 timestamp>",
+  "updated_by_subject_id": "<authenticated JWT subject>"
+}
+```
+
+The text content stays concise and points to `structuredContent.data.agent_instructions.content` instead of duplicating
+the draft body. `agent_instructions` has its own `internal/agentcontent` record and version counter, independent of
+`agent_soul`.
+
+`agent_instructions_upsert` input:
+
+- Required: `agent_id`, `content`.
+- Derived: account scope is the authenticated account-holder OAuth principal; `updated_by_subject_id` is the
+  authenticated JWT subject. Optional `actor_username`, when supplied, must match that principal.
+
+`agent_instructions_upsert` requires write scope. It stores draft instructions through
+`internal/agentcontent.Store.Upsert` with content type `agent_instructions`, so the TableTheory-backed instance content
+store owns version increments, lifecycle state, and size bounds. It does not introduce a separate persistence layer,
+DynamoDB client, or Lesser-table write. Successful upserts return the same `agent_instructions` record shape with
+`lifecycle_state:"draft"` and the incremented version.
+
+`agent_instructions_archive` input:
+
+- Required: `agent_id`.
+- Derived: account scope is the authenticated account-holder OAuth principal; `updated_by_subject_id` is the
+  authenticated JWT subject. Optional `actor_username`, when supplied, must match that principal.
+
+`agent_instructions_archive` requires write scope. It archives through `internal/agentcontent.Store.Archive`, preserves
+the store's idempotent archive behavior, and reports:
+
+```json
+{
+  "already_archived": false,
+  "idempotent": true
+}
+```
+
+`already_archived` is true when the current account-scoped record was already archived before the archive call. The
+returned `agent_instructions` record keeps the store-owned version and has `lifecycle_state:"archived"`.
+
+For all `agent_instructions_*` tools, malformed input returns `invalid_request`; agent-delegated or mismatched
+principals return `forbidden`; missing content records return `not_found`; optimistic write races return `conflict`; and
+unexpected content-store failures return `internal` with sanitized `source:"agent_content"` details.
 
 `agent_create` input:
 

--- a/internal/instanceapp/app_test.go
+++ b/internal/instanceapp/app_test.go
@@ -44,7 +44,7 @@ func TestInstancePlaneMCP_InitializeAndToolsList(t *testing.T) {
 		serverName string
 		wantTools  []string
 	}{
-		{name: "ptah", path: "/instance/ptah/mcp", serverName: "lesser-body-instance-ptah", wantTools: []string{"agent_bind_soul", "agent_create", "agent_get", "agent_list", "agent_soul_get", "agent_soul_upsert", "agent_soul_archive"}},
+		{name: "ptah", path: "/instance/ptah/mcp", serverName: "lesser-body-instance-ptah", wantTools: []string{"agent_bind_soul", "agent_create", "agent_get", "agent_list", "agent_soul_get", "agent_soul_upsert", "agent_soul_archive", "agent_instructions_get", "agent_instructions_upsert", "agent_instructions_archive"}},
 		{name: "ba", path: "/instance/ba/mcp", serverName: "lesser-body-instance-ba", wantTools: []string{}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -133,6 +133,18 @@ func TestInstancePlaneMCP_InitializeAndToolsList(t *testing.T) {
 				soulArchiveDef := listBody.Result.Tools[6]
 				if soulArchiveDef.Name != "agent_soul_archive" || soulArchiveDef.Annotations == nil || soulArchiveDef.Annotations.ReadOnlyHint == nil || *soulArchiveDef.Annotations.ReadOnlyHint || soulArchiveDef.Annotations.IdempotentHint == nil || !*soulArchiveDef.Annotations.IdempotentHint {
 					t.Fatalf("agent_soul_archive annotations invalid: %+v", soulArchiveDef)
+				}
+				instructionsGetDef := listBody.Result.Tools[7]
+				if instructionsGetDef.Name != "agent_instructions_get" || instructionsGetDef.Annotations == nil || instructionsGetDef.Annotations.ReadOnlyHint == nil || !*instructionsGetDef.Annotations.ReadOnlyHint || strings.Contains(instructionsGetDef.Description, "provisional_agent_soul_schema_pending_lesser_soul_s1") {
+					t.Fatalf("agent_instructions_get annotations/description invalid: %+v", instructionsGetDef)
+				}
+				instructionsUpsertDef := listBody.Result.Tools[8]
+				if instructionsUpsertDef.Name != "agent_instructions_upsert" || instructionsUpsertDef.Annotations == nil || instructionsUpsertDef.Annotations.ReadOnlyHint == nil || *instructionsUpsertDef.Annotations.ReadOnlyHint || instructionsUpsertDef.Annotations.IdempotentHint == nil || *instructionsUpsertDef.Annotations.IdempotentHint {
+					t.Fatalf("agent_instructions_upsert annotations invalid: %+v", instructionsUpsertDef)
+				}
+				instructionsArchiveDef := listBody.Result.Tools[9]
+				if instructionsArchiveDef.Name != "agent_instructions_archive" || instructionsArchiveDef.Annotations == nil || instructionsArchiveDef.Annotations.ReadOnlyHint == nil || *instructionsArchiveDef.Annotations.ReadOnlyHint || instructionsArchiveDef.Annotations.IdempotentHint == nil || !*instructionsArchiveDef.Annotations.IdempotentHint {
+					t.Fatalf("agent_instructions_archive annotations invalid: %+v", instructionsArchiveDef)
 				}
 			}
 		})

--- a/internal/ptahserver/ptahserver.go
+++ b/internal/ptahserver/ptahserver.go
@@ -36,6 +36,10 @@ const (
 	toolAgentSoulUpsert  = "agent_soul_upsert"
 	toolAgentSoulArchive = "agent_soul_archive"
 
+	toolAgentInstructionsGet     = "agent_instructions_get"
+	toolAgentInstructionsUpsert  = "agent_instructions_upsert"
+	toolAgentInstructionsArchive = "agent_instructions_archive"
+
 	agentSoulProvisionalMarker = "provisional_agent_soul_schema_pending_lesser_soul_s1"
 	agentSoulProvisionalText   = "Provisional schema marker " + agentSoulProvisionalMarker + ": agent_soul content is an opaque Ptah-authored draft string pending lesser-soul S1 governance-policy unblock; clients must not treat it as the final Panonomous soul contract."
 )
@@ -180,7 +184,16 @@ func RegisterTools(r *mcpruntime.ToolRegistry, opts ...Option) error {
 	if err := r.RegisterTool(agentSoulUpsertDef(), cfg.handleAgentSoulUpsert); err != nil {
 		return err
 	}
-	return r.RegisterTool(agentSoulArchiveDef(), cfg.handleAgentSoulArchive)
+	if err := r.RegisterTool(agentSoulArchiveDef(), cfg.handleAgentSoulArchive); err != nil {
+		return err
+	}
+	if err := r.RegisterTool(agentInstructionsGetDef(), cfg.handleAgentInstructionsGet); err != nil {
+		return err
+	}
+	if err := r.RegisterTool(agentInstructionsUpsertDef(), cfg.handleAgentInstructionsUpsert); err != nil {
+		return err
+	}
+	return r.RegisterTool(agentInstructionsArchiveDef(), cfg.handleAgentInstructionsArchive)
 }
 
 func defaultConfig() config {
@@ -394,6 +407,74 @@ func agentSoulOutputSchema() json.RawMessage {
 	}`)
 }
 
+func agentInstructionsGetDef() mcpruntime.ToolDef {
+	return mcpruntime.ToolDef{
+		Name:        toolAgentInstructionsGet,
+		Title:       "Get draft agent instructions",
+		Description: "Read the current account-scoped Ptah agent_instructions draft/archived record for the authenticated account-holder principal. Requires read scope.",
+		Annotations: readOnlyToolAnnotations(),
+		InputSchema: json.RawMessage(`{
+			"type":"object",
+			"properties":{
+				"agent_id":{"type":"string","description":"Agent id whose agent_instructions content is read from the authenticated account-holder's Ptah content partition."},
+				"actor_username":{"type":"string","description":"Optional explicit account-holder actor username. When supplied it must match the authenticated principal."}
+			},
+			"required":["agent_id"],
+			"additionalProperties":false
+		}`),
+		OutputSchema: agentInstructionsOutputSchema(),
+	}
+}
+
+func agentInstructionsUpsertDef() mcpruntime.ToolDef {
+	return mcpruntime.ToolDef{
+		Name:        toolAgentInstructionsUpsert,
+		Title:       "Upsert draft agent instructions",
+		Description: "Create or update an account-scoped Ptah agent_instructions draft through the canonical internal/agentcontent Store. Requires write scope and increments the per-content version via the store.",
+		Annotations: additiveMutationToolAnnotations(),
+		InputSchema: json.RawMessage(`{
+			"type":"object",
+			"properties":{
+				"agent_id":{"type":"string","description":"Agent id whose agent_instructions draft is written in the authenticated account-holder's Ptah content partition."},
+				"content":{"type":"string","description":"Agent instructions draft payload. Maximum 65536 bytes."},
+				"actor_username":{"type":"string","description":"Optional explicit account-holder actor username. When supplied it must match the authenticated principal."}
+			},
+			"required":["agent_id","content"],
+			"additionalProperties":false
+		}`),
+		OutputSchema: agentInstructionsOutputSchema(),
+	}
+}
+
+func agentInstructionsArchiveDef() mcpruntime.ToolDef {
+	return mcpruntime.ToolDef{
+		Name:        toolAgentInstructionsArchive,
+		Title:       "Archive draft agent instructions",
+		Description: "Idempotently archive the current account-scoped Ptah agent_instructions record through the canonical internal/agentcontent Store. Requires write scope.",
+		Annotations: idempotentMutationToolAnnotations(),
+		InputSchema: json.RawMessage(`{
+			"type":"object",
+			"properties":{
+				"agent_id":{"type":"string","description":"Agent id whose agent_instructions record is archived in the authenticated account-holder's Ptah content partition."},
+				"actor_username":{"type":"string","description":"Optional explicit account-holder actor username. When supplied it must match the authenticated principal."}
+			},
+			"required":["agent_id"],
+			"additionalProperties":false
+		}`),
+		OutputSchema: agentInstructionsOutputSchema(),
+	}
+}
+
+func agentInstructionsOutputSchema() json.RawMessage {
+	return json.RawMessage(`{
+		"type":"object",
+		"properties":{
+			"data":{"type":"object","description":"Structured account-scoped agent_instructions record and archive idempotency metadata when applicable."},
+			"error":{"type":"object","description":"Structured tool error when isError=true."}
+		}
+	}`)
+}
+
 type agentBindSoulInput struct {
 	SoulAgentID        string                  `json:"soul_agent_id"`
 	IdempotencyKey     string                  `json:"idempotency_key"`
@@ -444,6 +525,22 @@ type agentSoulUpsertInput struct {
 }
 
 type agentSoulArchiveInput struct {
+	AgentID       string `json:"agent_id"`
+	ActorUsername string `json:"actor_username"`
+}
+
+type agentInstructionsGetInput struct {
+	AgentID       string `json:"agent_id"`
+	ActorUsername string `json:"actor_username"`
+}
+
+type agentInstructionsUpsertInput struct {
+	AgentID       string  `json:"agent_id"`
+	Content       *string `json:"content"`
+	ActorUsername string  `json:"actor_username"`
+}
+
+type agentInstructionsArchiveInput struct {
 	AgentID       string `json:"agent_id"`
 	ActorUsername string `json:"actor_username"`
 }
@@ -779,7 +876,7 @@ func (cfg config) handleAgentSoulGet(ctx context.Context, args json.RawMessage) 
 
 	record, err := store.Get(ctx, actorUsername, in.AgentID, agentcontent.ContentTypeAgentSoul)
 	if err != nil {
-		return agentContentToolResultFromError(err)
+		return agentContentToolResultFromError(err, agentcontent.ContentTypeAgentSoul)
 	}
 	return agentSoulSuccessResult("Ptah agent_soul record read", actorUsername, record, nil)
 }
@@ -831,7 +928,7 @@ func (cfg config) handleAgentSoulUpsert(ctx context.Context, args json.RawMessag
 		UpdatedBySubjectID: subjectID,
 	})
 	if err != nil {
-		return agentContentToolResultFromError(err)
+		return agentContentToolResultFromError(err, agentcontent.ContentTypeAgentSoul)
 	}
 	return agentSoulSuccessResult("Ptah agent_soul draft upserted", actorUsername, record, nil)
 }
@@ -872,7 +969,7 @@ func (cfg config) handleAgentSoulArchive(ctx context.Context, args json.RawMessa
 
 	current, err := store.Get(ctx, actorUsername, in.AgentID, agentcontent.ContentTypeAgentSoul)
 	if err != nil {
-		return agentContentToolResultFromError(err)
+		return agentContentToolResultFromError(err, agentcontent.ContentTypeAgentSoul)
 	}
 	alreadyArchived := current != nil && current.LifecycleState == agentcontent.LifecycleStateArchived
 	record, err := store.Archive(ctx, agentcontent.ArchiveInput{
@@ -882,9 +979,152 @@ func (cfg config) handleAgentSoulArchive(ctx context.Context, args json.RawMessa
 		UpdatedBySubjectID: subjectID,
 	})
 	if err != nil {
-		return agentContentToolResultFromError(err)
+		return agentContentToolResultFromError(err, agentcontent.ContentTypeAgentSoul)
 	}
 	return agentSoulSuccessResult("Ptah agent_soul record archived", actorUsername, record, map[string]any{
+		"already_archived": alreadyArchived,
+		"idempotent":       true,
+	})
+}
+
+func (cfg config) handleAgentInstructionsGet(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
+	principal := auth.PrincipalFromToolContext(ctx)
+	actorUsername, errResult, err := authenticatedAccountHolderActor(principal, toolAgentInstructionsGet)
+	if errResult != nil || err != nil {
+		return errResult, err
+	}
+	if !principalHasReadScope(principal) {
+		return toolErrorResult("insufficient_scope", "agent_instructions_get requires read scope", http.StatusForbidden, map[string]any{
+			"requiredScopes": []string{"read"},
+			"grantedScopes":  normalizedScopes(principal.Claims.Scopes),
+		})
+	}
+
+	in, errResult, err := parseAgentInstructionsGetInput(args, actorUsername)
+	if errResult != nil || err != nil {
+		return errResult, err
+	}
+
+	store, err := cfg.content()
+	if err != nil {
+		return toolErrorResult("not_configured", err.Error(), http.StatusInternalServerError, map[string]any{
+			"source": "agent_content",
+		})
+	}
+
+	slog.InfoContext(ctx, "ptah tool invocation",
+		"tool", toolAgentInstructionsGet,
+		"actor_username", actorUsername,
+	)
+
+	record, err := store.Get(ctx, actorUsername, in.AgentID, agentcontent.ContentTypeAgentInstructions)
+	if err != nil {
+		return agentContentToolResultFromError(err, agentcontent.ContentTypeAgentInstructions)
+	}
+	return agentInstructionsSuccessResult("Ptah agent_instructions record read", actorUsername, record, nil)
+}
+
+func (cfg config) handleAgentInstructionsUpsert(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
+	principal := auth.PrincipalFromToolContext(ctx)
+	actorUsername, errResult, err := authenticatedAccountHolderActor(principal, toolAgentInstructionsUpsert)
+	if errResult != nil || err != nil {
+		return errResult, err
+	}
+	if !principalHasWriteScope(principal) {
+		return toolErrorResult("insufficient_scope", "agent_instructions_upsert requires write scope", http.StatusForbidden, map[string]any{
+			"requiredScopes": []string{"write"},
+			"grantedScopes":  normalizedScopes(principal.Claims.Scopes),
+		})
+	}
+	subjectID, errResult := authenticatedSubjectID(principal, toolAgentInstructionsUpsert)
+	if errResult != nil {
+		return errResult, nil
+	}
+
+	in, errResult, err := parseAgentInstructionsUpsertInput(args, actorUsername)
+	if errResult != nil || err != nil {
+		return errResult, err
+	}
+
+	store, err := cfg.content()
+	if err != nil {
+		return toolErrorResult("not_configured", err.Error(), http.StatusInternalServerError, map[string]any{
+			"source": "agent_content",
+		})
+	}
+
+	content := ""
+	if in.Content != nil {
+		content = *in.Content
+	}
+	slog.InfoContext(ctx, "ptah tool invocation",
+		"tool", toolAgentInstructionsUpsert,
+		"actor_username", actorUsername,
+		"content_bytes", len([]byte(content)),
+	)
+
+	record, err := store.Upsert(ctx, agentcontent.UpsertInput{
+		Account:            actorUsername,
+		AgentID:            in.AgentID,
+		Type:               agentcontent.ContentTypeAgentInstructions,
+		Content:            content,
+		UpdatedBySubjectID: subjectID,
+	})
+	if err != nil {
+		return agentContentToolResultFromError(err, agentcontent.ContentTypeAgentInstructions)
+	}
+	return agentInstructionsSuccessResult("Ptah agent_instructions draft upserted", actorUsername, record, nil)
+}
+
+func (cfg config) handleAgentInstructionsArchive(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
+	principal := auth.PrincipalFromToolContext(ctx)
+	actorUsername, errResult, err := authenticatedAccountHolderActor(principal, toolAgentInstructionsArchive)
+	if errResult != nil || err != nil {
+		return errResult, err
+	}
+	if !principalHasWriteScope(principal) {
+		return toolErrorResult("insufficient_scope", "agent_instructions_archive requires write scope", http.StatusForbidden, map[string]any{
+			"requiredScopes": []string{"write"},
+			"grantedScopes":  normalizedScopes(principal.Claims.Scopes),
+		})
+	}
+	subjectID, errResult := authenticatedSubjectID(principal, toolAgentInstructionsArchive)
+	if errResult != nil {
+		return errResult, nil
+	}
+
+	in, errResult, err := parseAgentInstructionsArchiveInput(args, actorUsername)
+	if errResult != nil || err != nil {
+		return errResult, err
+	}
+
+	store, err := cfg.content()
+	if err != nil {
+		return toolErrorResult("not_configured", err.Error(), http.StatusInternalServerError, map[string]any{
+			"source": "agent_content",
+		})
+	}
+
+	slog.InfoContext(ctx, "ptah tool invocation",
+		"tool", toolAgentInstructionsArchive,
+		"actor_username", actorUsername,
+	)
+
+	current, err := store.Get(ctx, actorUsername, in.AgentID, agentcontent.ContentTypeAgentInstructions)
+	if err != nil {
+		return agentContentToolResultFromError(err, agentcontent.ContentTypeAgentInstructions)
+	}
+	alreadyArchived := current != nil && current.LifecycleState == agentcontent.LifecycleStateArchived
+	record, err := store.Archive(ctx, agentcontent.ArchiveInput{
+		Account:            actorUsername,
+		AgentID:            in.AgentID,
+		Type:               agentcontent.ContentTypeAgentInstructions,
+		UpdatedBySubjectID: subjectID,
+	})
+	if err != nil {
+		return agentContentToolResultFromError(err, agentcontent.ContentTypeAgentInstructions)
+	}
+	return agentInstructionsSuccessResult("Ptah agent_instructions record archived", actorUsername, record, map[string]any{
 		"already_archived": alreadyArchived,
 		"idempotent":       true,
 	})
@@ -1117,6 +1357,84 @@ func parseAgentSoulArchiveInput(args json.RawMessage, actorUsername string) (age
 	}
 	if in.ActorUsername != "" && in.ActorUsername != actorUsername {
 		return agentSoulArchiveInput{}, mustToolErrorResult("forbidden", "actor_username must match authenticated principal", http.StatusForbidden, map[string]any{
+			"source": "lesser_body_ptah",
+		}), nil
+	}
+	return in, nil, nil
+}
+
+func parseAgentInstructionsGetInput(args json.RawMessage, actorUsername string) (agentInstructionsGetInput, *mcpruntime.ToolResult, error) {
+	raw := strings.TrimSpace(string(args))
+	if raw == "" || raw == "null" {
+		raw = "{}"
+	}
+
+	var in agentInstructionsGetInput
+	dec := json.NewDecoder(bytes.NewReader([]byte(raw)))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&in); err != nil {
+		return agentInstructionsGetInput{}, mustToolErrorResult("invalid_request", "invalid args: "+err.Error(), http.StatusBadRequest, nil), nil
+	}
+	in.AgentID = strings.TrimSpace(in.AgentID)
+	in.ActorUsername = normalizeActorUsername(in.ActorUsername)
+	if in.AgentID == "" {
+		return agentInstructionsGetInput{}, mustToolErrorResult("invalid_request", "agent_id is required", http.StatusBadRequest, nil), nil
+	}
+	if in.ActorUsername != "" && in.ActorUsername != actorUsername {
+		return agentInstructionsGetInput{}, mustToolErrorResult("forbidden", "actor_username must match authenticated principal", http.StatusForbidden, map[string]any{
+			"source": "lesser_body_ptah",
+		}), nil
+	}
+	return in, nil, nil
+}
+
+func parseAgentInstructionsUpsertInput(args json.RawMessage, actorUsername string) (agentInstructionsUpsertInput, *mcpruntime.ToolResult, error) {
+	raw := strings.TrimSpace(string(args))
+	if raw == "" || raw == "null" {
+		raw = "{}"
+	}
+
+	var in agentInstructionsUpsertInput
+	dec := json.NewDecoder(bytes.NewReader([]byte(raw)))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&in); err != nil {
+		return agentInstructionsUpsertInput{}, mustToolErrorResult("invalid_request", "invalid args: "+err.Error(), http.StatusBadRequest, nil), nil
+	}
+	in.AgentID = strings.TrimSpace(in.AgentID)
+	in.ActorUsername = normalizeActorUsername(in.ActorUsername)
+	if in.AgentID == "" {
+		return agentInstructionsUpsertInput{}, mustToolErrorResult("invalid_request", "agent_id is required", http.StatusBadRequest, nil), nil
+	}
+	if in.Content == nil {
+		return agentInstructionsUpsertInput{}, mustToolErrorResult("invalid_request", "content is required", http.StatusBadRequest, nil), nil
+	}
+	if in.ActorUsername != "" && in.ActorUsername != actorUsername {
+		return agentInstructionsUpsertInput{}, mustToolErrorResult("forbidden", "actor_username must match authenticated principal", http.StatusForbidden, map[string]any{
+			"source": "lesser_body_ptah",
+		}), nil
+	}
+	return in, nil, nil
+}
+
+func parseAgentInstructionsArchiveInput(args json.RawMessage, actorUsername string) (agentInstructionsArchiveInput, *mcpruntime.ToolResult, error) {
+	raw := strings.TrimSpace(string(args))
+	if raw == "" || raw == "null" {
+		raw = "{}"
+	}
+
+	var in agentInstructionsArchiveInput
+	dec := json.NewDecoder(bytes.NewReader([]byte(raw)))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&in); err != nil {
+		return agentInstructionsArchiveInput{}, mustToolErrorResult("invalid_request", "invalid args: "+err.Error(), http.StatusBadRequest, nil), nil
+	}
+	in.AgentID = strings.TrimSpace(in.AgentID)
+	in.ActorUsername = normalizeActorUsername(in.ActorUsername)
+	if in.AgentID == "" {
+		return agentInstructionsArchiveInput{}, mustToolErrorResult("invalid_request", "agent_id is required", http.StatusBadRequest, nil), nil
+	}
+	if in.ActorUsername != "" && in.ActorUsername != actorUsername {
+		return agentInstructionsArchiveInput{}, mustToolErrorResult("forbidden", "actor_username must match authenticated principal", http.StatusForbidden, map[string]any{
 			"source": "lesser_body_ptah",
 		}), nil
 	}
@@ -1359,7 +1677,7 @@ func agentListSuccessResult(actorUsername string, limit int, page *agentregistry
 }
 
 func agentSoulSuccessResult(summary string, actorUsername string, record *agentcontent.Record, extra map[string]any) (*mcpruntime.ToolResult, error) {
-	recordSummary := agentSoulRecordSummary(record)
+	recordSummary := agentContentRecordSummary(record)
 	data := map[string]any{
 		"actor_username": actorUsername,
 		"agent_soul":     recordSummary,
@@ -1382,6 +1700,34 @@ func agentSoulSuccessResult(summary string, actorUsername string, record *agentc
 		},
 		"schema": agentSoulSchemaMarker(),
 		"data":   map[string]any{"location": "structuredContent.data"},
+	}
+	if len(extra) > 0 {
+		text["metadata"] = extra
+	}
+	return toolJSONTextResult(text, map[string]any{"data": data})
+}
+
+func agentInstructionsSuccessResult(summary string, actorUsername string, record *agentcontent.Record, extra map[string]any) (*mcpruntime.ToolResult, error) {
+	recordSummary := agentContentRecordSummary(record)
+	data := map[string]any{
+		"actor_username":     actorUsername,
+		"agent_instructions": recordSummary,
+	}
+	for key, value := range extra {
+		data[key] = value
+	}
+
+	text := map[string]any{
+		"summary": summary,
+		"agent_instructions": map[string]any{
+			"account":          recordSummary["account"],
+			"agent_id":         recordSummary["agent_id"],
+			"version":          recordSummary["version"],
+			"lifecycle_state":  recordSummary["lifecycle_state"],
+			"content_bytes":    recordSummary["content_bytes"],
+			"content_location": "structuredContent.data.agent_instructions.content",
+		},
+		"data": map[string]any{"location": "structuredContent.data"},
 	}
 	if len(extra) > 0 {
 		text["metadata"] = extra
@@ -1436,33 +1782,37 @@ func agentDelegateToolResultFromError(err error) (*mcpruntime.ToolResult, error)
 	})
 }
 
-func agentContentToolResultFromError(err error) (*mcpruntime.ToolResult, error) {
+func agentContentToolResultFromError(err error, contentType agentcontent.ContentType) (*mcpruntime.ToolResult, error) {
 	if err == nil {
 		return nil, nil
 	}
 
+	contentName := string(contentType)
+	if contentName == "" {
+		contentName = "agent content"
+	}
 	details := map[string]any{
 		"source":       "agent_content",
-		"content_type": string(agentcontent.ContentTypeAgentSoul),
+		"content_type": contentName,
 	}
 	var sizeErr *agentcontent.SizeError
 	switch {
 	case errors.Is(err, agentcontent.ErrContentNotFound):
-		return toolErrorResult("not_found", "agent_soul record not found in this account-scoped Ptah content store", http.StatusNotFound, details)
+		return toolErrorResult("not_found", contentName+" record not found in this account-scoped Ptah content store", http.StatusNotFound, details)
 	case errors.As(err, &sizeErr):
 		details["limit_bytes"] = sizeErr.Limit
 		details["actual_bytes"] = sizeErr.Actual
-		return toolErrorResult("invalid_request", "agent_soul content exceeds the per-record size limit", http.StatusBadRequest, details)
+		return toolErrorResult("invalid_request", contentName+" content exceeds the per-record size limit", http.StatusBadRequest, details)
 	case errors.Is(err, agentcontent.ErrInvalidContentType):
 		return toolErrorResult("invalid_request", "invalid agent content type", http.StatusBadRequest, details)
 	case errors.Is(err, agentcontent.ErrMissingUpdatedBySubjectID):
-		return toolErrorResult("forbidden", "agent_soul writes require an authenticated subject id", http.StatusForbidden, details)
+		return toolErrorResult("forbidden", contentName+" writes require an authenticated subject id", http.StatusForbidden, details)
 	case errors.Is(err, agentcontent.ErrContentConflict):
-		return toolErrorResult("conflict", "agent_soul content update conflict; retry the operation", http.StatusConflict, details)
+		return toolErrorResult("conflict", contentName+" content update conflict; retry the operation", http.StatusConflict, details)
 	case errors.Is(err, agentcontent.ErrInvalidLifecycleState):
-		return toolErrorResult("internal", "agent_soul content record has invalid lifecycle state", http.StatusInternalServerError, details)
+		return toolErrorResult("internal", contentName+" content record has invalid lifecycle state", http.StatusInternalServerError, details)
 	default:
-		return toolErrorResult("internal", "Body failed to access the Ptah agent_soul content record", http.StatusInternalServerError, details)
+		return toolErrorResult("internal", "Body failed to access the Ptah "+contentName+" content record", http.StatusInternalServerError, details)
 	}
 }
 
@@ -1656,7 +2006,7 @@ func unavailableContentSummary() map[string]any {
 	}
 }
 
-func agentSoulRecordSummary(record *agentcontent.Record) map[string]any {
+func agentContentRecordSummary(record *agentcontent.Record) map[string]any {
 	if record == nil {
 		return map[string]any{}
 	}

--- a/internal/ptahserver/ptahserver_test.go
+++ b/internal/ptahserver/ptahserver_test.go
@@ -25,7 +25,7 @@ func TestRegisterToolsRegistersPtahDefinitions(t *testing.T) {
 	}
 
 	tools := registry.List()
-	if got, want := toolDefNames(tools), []string{toolAgentBindSoul, toolAgentCreate, toolAgentGet, toolAgentList, toolAgentSoulGet, toolAgentSoulUpsert, toolAgentSoulArchive}; strings.Join(got, ",") != strings.Join(want, ",") {
+	if got, want := toolDefNames(tools), []string{toolAgentBindSoul, toolAgentCreate, toolAgentGet, toolAgentList, toolAgentSoulGet, toolAgentSoulUpsert, toolAgentSoulArchive, toolAgentInstructionsGet, toolAgentInstructionsUpsert, toolAgentInstructionsArchive}; strings.Join(got, ",") != strings.Join(want, ",") {
 		t.Fatalf("registered tool order = %v, want %v", got, want)
 	}
 	def := tools[0]
@@ -185,6 +185,70 @@ func TestRegisterToolsRegistersPtahDefinitions(t *testing.T) {
 	}
 	if _, ok := soulArchiveSchema.Props["actor_username"]; !ok {
 		t.Fatalf("agent_soul_archive schema should advertise optional actor_username mismatch guard")
+	}
+
+	instructionsGetDef := tools[7]
+	if instructionsGetDef.Name != toolAgentInstructionsGet {
+		t.Fatalf("eighth tool name = %q, want %q", instructionsGetDef.Name, toolAgentInstructionsGet)
+	}
+	assertReadOnlyToolDef(t, instructionsGetDef)
+	assertNotContains(t, instructionsGetDef.Description, agentSoulProvisionalMarker)
+	var instructionsGetSchema struct {
+		Required []string       `json:"required"`
+		Props    map[string]any `json:"properties"`
+	}
+	if err := json.Unmarshal(instructionsGetDef.InputSchema, &instructionsGetSchema); err != nil {
+		t.Fatalf("agent_instructions_get input schema invalid json: %v", err)
+	}
+	if !contains(instructionsGetSchema.Required, "agent_id") {
+		t.Fatalf("agent_instructions_get required = %v, missing agent_id", instructionsGetSchema.Required)
+	}
+	if _, ok := instructionsGetSchema.Props["actor_username"]; !ok {
+		t.Fatalf("agent_instructions_get schema should advertise optional actor_username mismatch guard")
+	}
+
+	instructionsUpsertDef := tools[8]
+	if instructionsUpsertDef.Name != toolAgentInstructionsUpsert {
+		t.Fatalf("ninth tool name = %q, want %q", instructionsUpsertDef.Name, toolAgentInstructionsUpsert)
+	}
+	assertMutationToolDef(t, instructionsUpsertDef, false)
+	assertNotContains(t, instructionsUpsertDef.Description, agentSoulProvisionalMarker)
+	var instructionsUpsertSchema struct {
+		Required []string       `json:"required"`
+		Props    map[string]any `json:"properties"`
+	}
+	if err := json.Unmarshal(instructionsUpsertDef.InputSchema, &instructionsUpsertSchema); err != nil {
+		t.Fatalf("agent_instructions_upsert input schema invalid json: %v", err)
+	}
+	for _, required := range []string{"agent_id", "content"} {
+		if !contains(instructionsUpsertSchema.Required, required) {
+			t.Fatalf("agent_instructions_upsert required = %v, missing %s", instructionsUpsertSchema.Required, required)
+		}
+	}
+	for _, prop := range []string{"actor_username", "content"} {
+		if _, ok := instructionsUpsertSchema.Props[prop]; !ok {
+			t.Fatalf("agent_instructions_upsert schema missing %s", prop)
+		}
+	}
+
+	instructionsArchiveDef := tools[9]
+	if instructionsArchiveDef.Name != toolAgentInstructionsArchive {
+		t.Fatalf("tenth tool name = %q, want %q", instructionsArchiveDef.Name, toolAgentInstructionsArchive)
+	}
+	assertMutationToolDef(t, instructionsArchiveDef, true)
+	assertNotContains(t, instructionsArchiveDef.Description, agentSoulProvisionalMarker)
+	var instructionsArchiveSchema struct {
+		Required []string       `json:"required"`
+		Props    map[string]any `json:"properties"`
+	}
+	if err := json.Unmarshal(instructionsArchiveDef.InputSchema, &instructionsArchiveSchema); err != nil {
+		t.Fatalf("agent_instructions_archive input schema invalid json: %v", err)
+	}
+	if !contains(instructionsArchiveSchema.Required, "agent_id") {
+		t.Fatalf("agent_instructions_archive required = %v, missing agent_id", instructionsArchiveSchema.Required)
+	}
+	if _, ok := instructionsArchiveSchema.Props["actor_username"]; !ok {
+		t.Fatalf("agent_instructions_archive schema should advertise optional actor_username mismatch guard")
 	}
 }
 
@@ -1044,6 +1108,241 @@ func TestAgentSoulMapsContentStoreErrorsWithoutLeakingScopeDetails(t *testing.T)
 	}
 }
 
+func TestAgentInstructionsGetReadsAccountScopedContentWithReadCapableScopes(t *testing.T) {
+	for _, scope := range []string{"read", "write", "admin"} {
+		t.Run(scope, func(t *testing.T) {
+			store := &fakeAgentContentStore{getRecord: agentInstructionsRecord("drone-ada", "agent-123", "follow the operator", 2, agentcontent.LifecycleStateDraft, "subject-prev")}
+			registry := mcpruntime.NewToolRegistry()
+			if err := RegisterTools(registry, WithAgentContentStore(store)); err != nil {
+				t.Fatalf("RegisterTools: %v", err)
+			}
+
+			result, err := registry.Call(toolContextWithSubject("Drone-Ada", []string{scope}, "owner-oauth-token", "subject-reader"), toolAgentInstructionsGet, json.RawMessage(`{"agent_id":" agent-123 ","actor_username":"drone-ada"}`))
+			if err != nil {
+				t.Fatalf("Call: %v", err)
+			}
+			if result == nil || result.IsError {
+				t.Fatalf("result = %+v", result)
+			}
+			if store.getCalls != 1 || store.getAccount != "drone-ada" || store.getAgentID != "agent-123" || store.getType != agentcontent.ContentTypeAgentInstructions {
+				t.Fatalf("content Get calls/account/id/type = %d/%q/%q/%q, want account-scoped agent_instructions", store.getCalls, store.getAccount, store.getAgentID, store.getType)
+			}
+			data := structuredData(t, result)
+			record, _ := data["agent_instructions"].(map[string]any)
+			if record["account"] != "drone-ada" || record["agent_id"] != "agent-123" || record["type"] != string(agentcontent.ContentTypeAgentInstructions) || record["content"] != "follow the operator" || record["version"] != int64(2) {
+				t.Fatalf("agent_instructions record = %+v", record)
+			}
+			if _, ok := data["schema"]; ok {
+				t.Fatalf("agent_instructions should not carry agent_soul provisional schema marker: %+v", data["schema"])
+			}
+		})
+	}
+}
+
+func TestAgentInstructionsUpsertUsesAgentContentStoreWithSubject(t *testing.T) {
+	store := &fakeAgentContentStore{upsertRecord: agentInstructionsRecord("drone-ada", "agent-123", "instructions v1", 1, agentcontent.LifecycleStateDraft, "subject-writer")}
+	registry := mcpruntime.NewToolRegistry()
+	if err := RegisterTools(registry, WithAgentContentStore(store)); err != nil {
+		t.Fatalf("RegisterTools: %v", err)
+	}
+
+	result, err := registry.Call(toolContextWithSubject("Drone-Ada", []string{"write"}, "owner-oauth-token", "subject-writer"), toolAgentInstructionsUpsert, json.RawMessage(`{
+		"agent_id":" agent-123 ",
+		"actor_username":"drone-ada",
+		"content":"instructions v1"
+	}`))
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if result == nil || result.IsError {
+		t.Fatalf("result = %+v", result)
+	}
+	if store.upsertCalls != 1 {
+		t.Fatalf("Upsert calls = %d, want 1", store.upsertCalls)
+	}
+	if store.upsertIn.Account != "drone-ada" || store.upsertIn.AgentID != "agent-123" || store.upsertIn.Type != agentcontent.ContentTypeAgentInstructions || store.upsertIn.Content != "instructions v1" || store.upsertIn.UpdatedBySubjectID != "subject-writer" {
+		t.Fatalf("Upsert input = %+v, want account-scoped agent_instructions with subject", store.upsertIn)
+	}
+	data := structuredData(t, result)
+	record, _ := data["agent_instructions"].(map[string]any)
+	if record["updated_by_subject_id"] != "subject-writer" || record["content"] != "instructions v1" {
+		t.Fatalf("agent_instructions record = %+v", record)
+	}
+	if strings.Contains(result.Content[0].Text, "instructions v1") {
+		t.Fatalf("text content duplicated instructions content: %s", result.Content[0].Text)
+	}
+}
+
+func TestAgentInstructionsArchiveUsesStoreAndReportsIdempotentReplay(t *testing.T) {
+	store := &fakeAgentContentStore{
+		getRecord:     agentInstructionsRecord("drone-ada", "agent-123", "instructions", 4, agentcontent.LifecycleStateArchived, "subject-prev"),
+		archiveRecord: agentInstructionsRecord("drone-ada", "agent-123", "instructions", 4, agentcontent.LifecycleStateArchived, "subject-archive"),
+	}
+	registry := mcpruntime.NewToolRegistry()
+	if err := RegisterTools(registry, WithAgentContentStore(store)); err != nil {
+		t.Fatalf("RegisterTools: %v", err)
+	}
+
+	result, err := registry.Call(toolContextWithSubject("Drone-Ada", []string{"write"}, "owner-oauth-token", "subject-archive"), toolAgentInstructionsArchive, json.RawMessage(`{"agent_id":"agent-123","actor_username":"drone-ada"}`))
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if result == nil || result.IsError {
+		t.Fatalf("result = %+v", result)
+	}
+	if store.getCalls != 1 || store.archiveCalls != 1 {
+		t.Fatalf("Get/Archive calls = %d/%d, want 1/1", store.getCalls, store.archiveCalls)
+	}
+	if store.archiveIn.Account != "drone-ada" || store.archiveIn.AgentID != "agent-123" || store.archiveIn.Type != agentcontent.ContentTypeAgentInstructions || store.archiveIn.UpdatedBySubjectID != "subject-archive" {
+		t.Fatalf("Archive input = %+v, want account-scoped agent_instructions with subject", store.archiveIn)
+	}
+	data := structuredData(t, result)
+	if data["already_archived"] != true || data["idempotent"] != true {
+		t.Fatalf("archive idempotency metadata = %+v", data)
+	}
+	record, _ := data["agent_instructions"].(map[string]any)
+	if record["lifecycle_state"] != string(agentcontent.LifecycleStateArchived) || record["version"] != int64(4) {
+		t.Fatalf("archived record = %+v", record)
+	}
+}
+
+func TestAgentInstructionsRejectsInvalidInputAndPrincipalsBeforeContentStoreWrite(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		tool      string
+		ctx       context.Context
+		args      string
+		wantCode  string
+		wantState int
+	}{
+		{
+			name:      "get insufficient scope",
+			tool:      toolAgentInstructionsGet,
+			ctx:       toolContextWithSubject("drone-ada", []string{"follow"}, "owner-oauth-token", "subject-reader"),
+			args:      `{"agent_id":"agent-123"}`,
+			wantCode:  "insufficient_scope",
+			wantState: 403,
+		},
+		{
+			name:      "upsert insufficient scope",
+			tool:      toolAgentInstructionsUpsert,
+			ctx:       toolContextWithSubject("drone-ada", []string{"read"}, "owner-oauth-token", "subject-writer"),
+			args:      `{"agent_id":"agent-123","content":"instructions"}`,
+			wantCode:  "insufficient_scope",
+			wantState: 403,
+		},
+		{
+			name:      "upsert agent principal",
+			tool:      toolAgentInstructionsUpsert,
+			ctx:       toolContextWithAgent("drone-ada", []string{"write"}, "agent-runtime-token", true),
+			args:      `{"agent_id":"agent-123","content":"instructions"}`,
+			wantCode:  "forbidden",
+			wantState: 403,
+		},
+		{
+			name:      "upsert missing subject",
+			tool:      toolAgentInstructionsUpsert,
+			ctx:       toolContextWithSubject("drone-ada", []string{"write"}, "owner-oauth-token", ""),
+			args:      `{"agent_id":"agent-123","content":"instructions"}`,
+			wantCode:  "forbidden",
+			wantState: 403,
+		},
+		{
+			name:      "get caller-supplied account rejected",
+			tool:      toolAgentInstructionsGet,
+			ctx:       toolContextWithSubject("drone-ada", []string{"read"}, "owner-oauth-token", "subject-reader"),
+			args:      `{"agent_id":"agent-123","account":"other"}`,
+			wantCode:  "invalid_request",
+			wantState: 400,
+		},
+		{
+			name:      "archive mismatched actor username",
+			tool:      toolAgentInstructionsArchive,
+			ctx:       toolContextWithSubject("drone-ada", []string{"write"}, "owner-oauth-token", "subject-writer"),
+			args:      `{"agent_id":"agent-123","actor_username":"other"}`,
+			wantCode:  "forbidden",
+			wantState: 403,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := &fakeAgentContentStore{getRecord: agentInstructionsRecord("drone-ada", "agent-123", "instructions", 1, agentcontent.LifecycleStateDraft, "subject")}
+			registry := mcpruntime.NewToolRegistry()
+			if err := RegisterTools(registry, WithAgentContentStore(store)); err != nil {
+				t.Fatalf("RegisterTools: %v", err)
+			}
+
+			result, err := registry.Call(tc.ctx, tc.tool, json.RawMessage(tc.args))
+			if err != nil {
+				t.Fatalf("Call: %v", err)
+			}
+			assertToolError(t, result, tc.wantCode, tc.wantState)
+			if store.getCalls != 0 || store.upsertCalls != 0 || store.archiveCalls != 0 {
+				t.Fatalf("content store side effects occurred before rejection: get=%d upsert=%d archive=%d", store.getCalls, store.upsertCalls, store.archiveCalls)
+			}
+		})
+	}
+}
+
+func TestAgentInstructionsMapsContentStoreErrorsWithoutLeakingScopeDetails(t *testing.T) {
+	store := &fakeAgentContentStore{getErr: fmt.Errorf("%w: hidden account agent-elsewhere", agentcontent.ErrContentNotFound)}
+	registry := mcpruntime.NewToolRegistry()
+	if err := RegisterTools(registry, WithAgentContentStore(store)); err != nil {
+		t.Fatalf("RegisterTools: %v", err)
+	}
+
+	result, err := registry.Call(toolContextWithSubject("drone-ada", []string{"read"}, "owner-oauth-token", "subject-reader"), toolAgentInstructionsGet, json.RawMessage(`{"agent_id":"agent-elsewhere"}`))
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	payload := assertToolError(t, result, "not_found", 404)
+	details, _ := payload["details"].(map[string]any)
+	if details["content_type"] != string(agentcontent.ContentTypeAgentInstructions) {
+		t.Fatalf("content error details = %+v, want agent_instructions content_type", details)
+	}
+	encoded, _ := json.Marshal(payload)
+	for _, term := range []string{"hidden account", "agent-elsewhere", "drone-ada"} {
+		if strings.Contains(string(encoded), term) {
+			t.Fatalf("error payload leaked %q: %s", term, string(encoded))
+		}
+	}
+}
+
+func TestAgentInstructionsAndSoulUseIndependentContentTypeCounters(t *testing.T) {
+	store := newVersionedFakeAgentContentStore()
+	registry := mcpruntime.NewToolRegistry()
+	if err := RegisterTools(registry, WithAgentContentStore(store)); err != nil {
+		t.Fatalf("RegisterTools: %v", err)
+	}
+	ctx := toolContextWithSubject("Drone-Ada", []string{"read", "write"}, "owner-oauth-token", "subject-writer")
+
+	soulV1 := callToolData(t, registry, ctx, toolAgentSoulUpsert, `{"agent_id":"agent-123","content":"soul v1"}`)
+	instructionsV1 := callToolData(t, registry, ctx, toolAgentInstructionsUpsert, `{"agent_id":"agent-123","content":"instructions v1"}`)
+	soulV2 := callToolData(t, registry, ctx, toolAgentSoulUpsert, `{"agent_id":"agent-123","content":"soul v2"}`)
+	instructionsGot := callToolData(t, registry, ctx, toolAgentInstructionsGet, `{"agent_id":"agent-123"}`)
+
+	if got := soulV1["agent_soul"].(map[string]any)["version"]; got != int64(1) {
+		t.Fatalf("soul v1 version = %v, want 1", got)
+	}
+	if got := instructionsV1["agent_instructions"].(map[string]any)["version"]; got != int64(1) {
+		t.Fatalf("instructions v1 version = %v, want 1", got)
+	}
+	if got := soulV2["agent_soul"].(map[string]any)["version"]; got != int64(2) {
+		t.Fatalf("soul v2 version = %v, want 2", got)
+	}
+	instructionsRecord := instructionsGot["agent_instructions"].(map[string]any)
+	if instructionsRecord["version"] != int64(1) || instructionsRecord["content"] != "instructions v1" {
+		t.Fatalf("instructions after soul update = %+v, want unchanged independent version 1", instructionsRecord)
+	}
+	if len(store.records) != 2 {
+		t.Fatalf("fake store records = %d, want separate agent_soul and agent_instructions records", len(store.records))
+	}
+	for _, typ := range []agentcontent.ContentType{agentcontent.ContentTypeAgentSoul, agentcontent.ContentTypeAgentInstructions} {
+		if _, ok := store.records[agentContentTestKey{account: "drone-ada", agentID: "agent-123", typ: typ}]; !ok {
+			t.Fatalf("missing fake store record for content type %s; records = %+v", typ, store.records)
+		}
+	}
+}
+
 type fakeSoulBindingClient struct {
 	calls             int
 	integrationBearer string
@@ -1173,7 +1472,7 @@ func (f *fakeAgentContentStore) Upsert(_ context.Context, in agentcontent.Upsert
 	if f.upsertRecord != nil {
 		return f.upsertRecord, nil
 	}
-	return agentSoulRecord(in.Account, in.AgentID, in.Content, 1, agentcontent.LifecycleStateDraft, in.UpdatedBySubjectID), nil
+	return agentContentRecord(in.Type, in.Account, in.AgentID, in.Content, 1, agentcontent.LifecycleStateDraft, in.UpdatedBySubjectID), nil
 }
 
 func (f *fakeAgentContentStore) Archive(_ context.Context, in agentcontent.ArchiveInput) (*agentcontent.Record, error) {
@@ -1185,7 +1484,59 @@ func (f *fakeAgentContentStore) Archive(_ context.Context, in agentcontent.Archi
 	if f.archiveRecord != nil {
 		return f.archiveRecord, nil
 	}
-	return agentSoulRecord(in.Account, in.AgentID, "", 1, agentcontent.LifecycleStateArchived, in.UpdatedBySubjectID), nil
+	return agentContentRecord(in.Type, in.Account, in.AgentID, "", 1, agentcontent.LifecycleStateArchived, in.UpdatedBySubjectID), nil
+}
+
+type agentContentTestKey struct {
+	account string
+	agentID string
+	typ     agentcontent.ContentType
+}
+
+type versionedFakeAgentContentStore struct {
+	records map[agentContentTestKey]*agentcontent.Record
+}
+
+func newVersionedFakeAgentContentStore() *versionedFakeAgentContentStore {
+	return &versionedFakeAgentContentStore{records: map[agentContentTestKey]*agentcontent.Record{}}
+}
+
+func (f *versionedFakeAgentContentStore) Get(_ context.Context, account string, agentID string, contentType agentcontent.ContentType) (*agentcontent.Record, error) {
+	key := agentContentTestKey{account: account, agentID: agentID, typ: contentType}
+	record := f.records[key]
+	if record == nil {
+		return nil, agentcontent.ErrContentNotFound
+	}
+	return cloneAgentContentRecord(record), nil
+}
+
+func (f *versionedFakeAgentContentStore) Upsert(_ context.Context, in agentcontent.UpsertInput) (*agentcontent.Record, error) {
+	key := agentContentTestKey{account: in.Account, agentID: in.AgentID, typ: in.Type}
+	version := int64(1)
+	createdAt := time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)
+	if existing := f.records[key]; existing != nil {
+		version = existing.Version + 1
+		createdAt = existing.CreatedAt
+	}
+	record := agentContentRecord(in.Type, in.Account, in.AgentID, in.Content, version, agentcontent.LifecycleStateDraft, in.UpdatedBySubjectID)
+	record.CreatedAt = createdAt
+	record.UpdatedAt = createdAt.Add(time.Duration(version) * time.Minute)
+	f.records[key] = cloneAgentContentRecord(record)
+	return record, nil
+}
+
+func (f *versionedFakeAgentContentStore) Archive(_ context.Context, in agentcontent.ArchiveInput) (*agentcontent.Record, error) {
+	key := agentContentTestKey{account: in.Account, agentID: in.AgentID, typ: in.Type}
+	record := f.records[key]
+	if record == nil {
+		return nil, agentcontent.ErrContentNotFound
+	}
+	archived := cloneAgentContentRecord(record)
+	archived.LifecycleState = agentcontent.LifecycleStateArchived
+	archived.UpdatedBySubjectID = in.UpdatedBySubjectID
+	archived.UpdatedAt = archived.UpdatedAt.Add(time.Minute)
+	f.records[key] = cloneAgentContentRecord(archived)
+	return archived, nil
 }
 
 func toolContext(username string, scopes []string, bearer string) context.Context {
@@ -1218,10 +1569,18 @@ func toolContextWithSubjectAndAgent(username string, scopes []string, bearer str
 }
 
 func agentSoulRecord(account, agentID, content string, version int64, state agentcontent.LifecycleState, updatedBySubjectID string) *agentcontent.Record {
+	return agentContentRecord(agentcontent.ContentTypeAgentSoul, account, agentID, content, version, state, updatedBySubjectID)
+}
+
+func agentInstructionsRecord(account, agentID, content string, version int64, state agentcontent.LifecycleState, updatedBySubjectID string) *agentcontent.Record {
+	return agentContentRecord(agentcontent.ContentTypeAgentInstructions, account, agentID, content, version, state, updatedBySubjectID)
+}
+
+func agentContentRecord(contentType agentcontent.ContentType, account, agentID, content string, version int64, state agentcontent.LifecycleState, updatedBySubjectID string) *agentcontent.Record {
 	return &agentcontent.Record{
 		Account:            account,
 		AgentID:            agentID,
-		Type:               agentcontent.ContentTypeAgentSoul,
+		Type:               contentType,
 		Content:            content,
 		Version:            version,
 		LifecycleState:     state,
@@ -1229,6 +1588,14 @@ func agentSoulRecord(account, agentID, content string, version int64, state agen
 		UpdatedAt:          time.Date(2026, 7, 15, 12, 30, 0, 0, time.UTC),
 		UpdatedBySubjectID: updatedBySubjectID,
 	}
+}
+
+func cloneAgentContentRecord(record *agentcontent.Record) *agentcontent.Record {
+	if record == nil {
+		return nil
+	}
+	clone := *record
+	return &clone
 }
 
 func successfulBindingResponse(replayed bool) *lesserapi.SoulBindingResponse {
@@ -1293,6 +1660,18 @@ func structuredData(t *testing.T, result *mcpruntime.ToolResult) map[string]any 
 		t.Fatalf("structuredContent.data missing: %+v", result.StructuredContent)
 	}
 	return data
+}
+
+func callToolData(t *testing.T, registry *mcpruntime.ToolRegistry, ctx context.Context, toolName string, args string) map[string]any {
+	t.Helper()
+	result, err := registry.Call(ctx, toolName, json.RawMessage(args))
+	if err != nil {
+		t.Fatalf("%s Call: %v", toolName, err)
+	}
+	if result == nil || result.IsError {
+		t.Fatalf("%s result = %+v", toolName, result)
+	}
+	return structuredData(t, result)
 }
 
 func assertToolError(t *testing.T, result *mcpruntime.ToolResult, wantCode string, wantStatus int) map[string]any {
@@ -1363,5 +1742,12 @@ func assertContains(t testing.TB, got string, want string) {
 	t.Helper()
 	if !strings.Contains(got, want) {
 		t.Fatalf("expected %q to contain %q", got, want)
+	}
+}
+
+func assertNotContains(t testing.TB, got string, forbidden string) {
+	t.Helper()
+	if strings.Contains(got, forbidden) {
+		t.Fatalf("expected %q not to contain %q", got, forbidden)
 	}
 }


### PR DESCRIPTION
## Milestone
Project 48 M5/B11 — Ptah authoring, agent_instructions tools.

## Classification
tool-surface / MCP-contract additive (Ptah instance-plane tools/list only) / test-coverage / docs

## Surfaces affected
- `internal/ptahserver`: statically registers `agent_instructions_get`, `agent_instructions_upsert`, `agent_instructions_archive`.
- `internal/ptahserver` tests: account scoping, read/write scope split, subject audit, sanitized errors, idempotent archive, and independent counters.
- `internal/instanceapp` listing test: Ptah tools/list includes the new trio; Ba remains empty.
- `docs/mcp.md`: documents the new Ptah-only tools and `internal/agentcontent.Store` persistence path.

## Specialist walks referenced
- Tool surface: additive Ptah-only tools; read/write scopes enforced in handlers; no dynamic registration.
- MCP contract: additive authenticated Ptah `tools/list` change; no actor-scoped `/.well-known/mcp.json`, OAuth metadata, or JSON-RPC envelope changes.
- Lesser integration: no Lesser API/table writes and no direct DynamoDB client; uses existing TableTheory-backed `internal/agentcontent.Store` abstraction.
- Host delegation: not applicable.
- Framework: idiomatic AppTheory ToolRegistry use; no AppTheory/TableTheory patch.

## Consumer impact
Ptah clients gain an account-scoped instructions authoring trio. Ka actor-scoped clients and Ba see no new public discovery surface.

## Tasks
- [x] Register `agent_instructions_get` (read) using account-holder scope and `agentcontent.Store.Get` with type `agent_instructions`.
- [x] Register `agent_instructions_upsert` (write) using `agentcontent.Store.Upsert`, type `agent_instructions`, and JWT subject audit.
- [x] Register `agent_instructions_archive` (write) using `agentcontent.Store.Archive`, preserving/reporting idempotent archive behavior.
- [x] Prove `agent_soul` and `agent_instructions` use independent content-type records/counters.
- [x] Update Ptah docs and tools/list expectations.

## Validation
- `go build ./...` ✅
- `gofmt -l .` ✅ empty
- `go test ./...` ✅
- `go vet ./...` ✅
- `bash scripts/build.sh` ✅
- Targeted: `go test ./internal/ptahserver -run 'TestAgentInstructions|TestRegisterToolsRegistersPtahDefinitions'` ✅

Note: local raw Go gates were run with ignored `cdk/node_modules` temporarily moved outside the repo, matching clean-checkout semantics for AWS CDK Go templates.

## Stage rollout plan (handoff to deploy-body)
- [ ] Merged to staging
- [ ] Deployed to lab / dev
- [ ] Lab soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
None required for this PR. It reuses the existing body-owned TableTheory-backed content store from #350 and Ptah patterns from #351.

Closes #352
Part of #349
