### PR TITLE
feat(ba): add one-time download grant store with atomic consume

### DIFF
--- a/internal/downloadgrant/doc.go
+++ b/internal/downloadgrant/doc.go
@@ -1,0 +1,7 @@
+// Package downloadgrant stores short-lived Ba install/download grants.
+//
+// It is an internal instance-plane data layer over the body-owned
+// INSTANCE_GRANT_TABLE table. Raw grant tokens are returned to callers only at
+// issuance time; persisted state stores only a deterministic token hash and the
+// binding fields required by later Ba redemption/install-plan steps.
+package downloadgrant

--- a/internal/downloadgrant/store.go
+++ b/internal/downloadgrant/store.go
@@ -1,0 +1,508 @@
+package downloadgrant
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/theory-cloud/tabletheory/v2"
+	tablecore "github.com/theory-cloud/tabletheory/v2/pkg/core"
+	tableerrors "github.com/theory-cloud/tabletheory/v2/pkg/errors"
+	"github.com/theory-cloud/tabletheory/v2/pkg/session"
+)
+
+const (
+	// EnvInstanceGrantTable is the body-owned instance-plane grant table. It is
+	// provisioned by this repo's CDK stack as INSTANCE_GRANT_TABLE and must not
+	// be confused with Lesser's LESSER_TABLE_NAME actor data table.
+	EnvInstanceGrantTable = "INSTANCE_GRANT_TABLE"
+
+	envAWSRegion = "AWS_REGION"
+
+	DefaultTTL = 10 * time.Minute
+
+	grantPKPrefix = "DOWNLOAD_GRANT#"
+	grantSK       = "GRANT"
+
+	grantIDPrefix        = "dg_"
+	grantIDRandomBytes   = 16
+	rawTokenRandomBytes  = 32
+	tokenHashDomainBytes = "lesser-body/downloadgrant/token/v1\x00"
+)
+
+type GrantStatus string
+
+const (
+	GrantStatusActive   GrantStatus = "active"
+	GrantStatusConsumed GrantStatus = "consumed"
+)
+
+type ConsumeOutcome string
+
+const (
+	ConsumeOutcomeConsumed        ConsumeOutcome = "consumed"
+	ConsumeOutcomeReplay          ConsumeOutcome = "replay"
+	ConsumeOutcomeNotFound        ConsumeOutcome = "not_found"
+	ConsumeOutcomeExpired         ConsumeOutcome = "expired"
+	ConsumeOutcomeTokenMismatch   ConsumeOutcome = "token_mismatch"
+	ConsumeOutcomeBindingMismatch ConsumeOutcome = "binding_mismatch"
+)
+
+var (
+	ErrGrantNotFound      = errors.New("download grant not found")
+	ErrGrantIDRequired    = errors.New("download grant id is required")
+	ErrRawTokenRequired   = errors.New("download grant token is required")
+	ErrInvalidBinding     = errors.New("download grant binding is invalid")
+	ErrInvalidGrantStatus = errors.New("download grant status is invalid")
+)
+
+// Binding describes the context a one-time Ba download/install grant is bound
+// to. Later redemption and local-install planning must supply the same binding
+// before a grant can be consumed.
+type Binding struct {
+	Account    string
+	Actor      string
+	Namespace  string
+	Route      string
+	Client     string
+	Profile    string
+	PackID     string
+	PackDigest string
+}
+
+// IssueInput describes a new one-time download grant. TTL defaults to
+// DefaultTTL when left unset.
+type IssueInput struct {
+	Binding Binding
+	TTL     time.Duration
+}
+
+// IssuedGrant is returned exactly once to the service layer that creates a
+// grant. Token is intentionally absent from persisted records.
+type IssuedGrant struct {
+	Binding        Binding
+	GrantID        string
+	Token          string
+	ExpiresAt      time.Time
+	ExpiresAtEpoch int64
+}
+
+// ConsumeInput describes an attempted one-time grant consume.
+type ConsumeInput struct {
+	Binding Binding
+	GrantID string
+	Token   string
+}
+
+// ConsumeResult classifies a consume attempt without exposing token hashes or
+// raw token material. GrantID is safe for diagnostics; Token is never included.
+type ConsumeResult struct {
+	Grant   *Grant
+	GrantID string
+	Outcome ConsumeOutcome
+}
+
+// Grant is the sanitized domain view returned by the store. It intentionally
+// omits the persisted tokenHash.
+type Grant struct {
+	CreatedAt      time.Time
+	ConsumedAt     time.Time
+	ExpiresAt      time.Time
+	Binding        Binding
+	GrantID        string
+	Status         GrantStatus
+	ExpiresAtEpoch int64
+}
+
+// Store persists short-lived Ba download grants in a body-owned instance table.
+type Store struct {
+	db        tablecore.DB
+	tableName string
+	now       func() time.Time
+}
+
+// NewStore constructs a Store over an injected TableTheory DB. tableName should
+// be the configured INSTANCE_GRANT_TABLE value.
+func NewStore(db tablecore.DB, tableName string) (*Store, error) {
+	if db == nil {
+		return nil, fmt.Errorf("download grant db is required")
+	}
+	tableName = strings.TrimSpace(tableName)
+	if tableName == "" {
+		return nil, fmt.Errorf("%s is required", EnvInstanceGrantTable)
+	}
+	return &Store{db: db, tableName: tableName, now: func() time.Time { return time.Now().UTC() }}, nil
+}
+
+// Default creates the production TableTheory-backed grant store from process
+// configuration.
+func Default() (*Store, error) {
+	tableName := strings.TrimSpace(os.Getenv(EnvInstanceGrantTable))
+	if tableName == "" {
+		return nil, fmt.Errorf("%s is required", EnvInstanceGrantTable)
+	}
+
+	db, err := tabletheory.NewBasic(session.Config{Region: os.Getenv(envAWSRegion)})
+	if err != nil {
+		return nil, fmt.Errorf("create tabletheory client: %w", err)
+	}
+	return NewStore(db, tableName)
+}
+
+// Issue creates a short-lived active grant and returns the raw opaque token once.
+// The raw token is never stored by this package.
+func (s *Store) Issue(ctx context.Context, in IssueInput) (*IssuedGrant, error) {
+	if s == nil {
+		return nil, fmt.Errorf("download grant store is nil")
+	}
+	binding, err := normalizeBinding(in.Binding)
+	if err != nil {
+		return nil, err
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	ttl := in.TTL
+	if ttl <= 0 {
+		ttl = DefaultTTL
+	}
+	now := s.clock()
+	expiresAt := now.Add(ttl).UTC()
+	rawToken, err := GenerateToken()
+	if err != nil {
+		return nil, fmt.Errorf("generate download grant token: %w", err)
+	}
+	tokenHash, err := HashToken(rawToken)
+	if err != nil {
+		return nil, err
+	}
+	grantID, err := GenerateGrantID()
+	if err != nil {
+		return nil, fmt.Errorf("generate download grant id: %w", err)
+	}
+
+	record := s.recordFor(grantID)
+	record.GrantID = grantID
+	record.Status = string(GrantStatusActive)
+	record.TokenHash = tokenHash
+	record.Account = binding.Account
+	record.Actor = binding.Actor
+	record.Namespace = binding.Namespace
+	record.Route = binding.Route
+	record.Client = binding.Client
+	record.Profile = binding.Profile
+	record.PackID = binding.PackID
+	record.PackDigest = binding.PackDigest
+	record.GrantCreatedAt = now
+	record.ExpiresAt = expiresAt.Unix()
+
+	if err := s.db.Model(record).WithContext(ctx).IfNotExists().Create(); err != nil {
+		return nil, fmt.Errorf("create download grant %s: %w", grantID, err)
+	}
+
+	return &IssuedGrant{
+		Binding:        binding,
+		GrantID:        grantID,
+		Token:          rawToken,
+		ExpiresAt:      expiresAt,
+		ExpiresAtEpoch: expiresAt.Unix(),
+	}, nil
+}
+
+// Consume atomically transitions a matching active grant to consumed. The
+// TableTheory conditional update requires status=active, matching token hash,
+// matching binding, and a future expiresAt epoch.
+func (s *Store) Consume(ctx context.Context, in ConsumeInput) (*ConsumeResult, error) {
+	if s == nil {
+		return nil, fmt.Errorf("download grant store is nil")
+	}
+	grantID := strings.TrimSpace(in.GrantID)
+	if grantID == "" {
+		return nil, ErrGrantIDRequired
+	}
+	binding, err := normalizeBinding(in.Binding)
+	if err != nil {
+		return nil, err
+	}
+	tokenHash, err := HashToken(in.Token)
+	if err != nil {
+		return nil, err
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	now := s.clock()
+	updated := s.emptyRecord()
+	err = s.db.Model(s.emptyRecord()).
+		WithContext(ctx).
+		Where("PK", "=", grantPartitionKey(grantID)).
+		Where("SK", "=", grantSK).
+		UpdateBuilder().
+		Set("Status", string(GrantStatusConsumed)).
+		Set("GrantConsumedAt", now).
+		Condition("Status", "=", string(GrantStatusActive)).
+		Condition("TokenHash", "=", tokenHash).
+		Condition("Account", "=", binding.Account).
+		Condition("Actor", "=", binding.Actor).
+		Condition("Namespace", "=", binding.Namespace).
+		Condition("Route", "=", binding.Route).
+		Condition("Client", "=", binding.Client).
+		Condition("Profile", "=", binding.Profile).
+		Condition("PackID", "=", binding.PackID).
+		Condition("PackDigest", "=", binding.PackDigest).
+		Condition("ExpiresAt", ">", now.Unix()).
+		ReturnValues("ALL_NEW").
+		ExecuteWithResult(updated)
+	switch {
+	case err == nil:
+		grant, err := updated.toGrant()
+		if err != nil {
+			return nil, err
+		}
+		return &ConsumeResult{GrantID: grantID, Outcome: ConsumeOutcomeConsumed, Grant: grant}, nil
+	case !tableerrors.IsConditionFailed(err):
+		return nil, fmt.Errorf("consume download grant %s: %w", grantID, err)
+	}
+
+	return s.classifyFailedConsume(ctx, grantID, tokenHash, binding, now)
+}
+
+func (s *Store) classifyFailedConsume(ctx context.Context, grantID string, tokenHash string, binding Binding, now time.Time) (*ConsumeResult, error) {
+	record, err := s.loadRecord(ctx, grantID)
+	switch {
+	case err == nil:
+		// Continue below.
+	case errors.Is(err, ErrGrantNotFound):
+		return &ConsumeResult{GrantID: grantID, Outcome: ConsumeOutcomeNotFound}, nil
+	default:
+		return nil, err
+	}
+
+	if !hashEqual(record.TokenHash, tokenHash) {
+		return &ConsumeResult{GrantID: grantID, Outcome: ConsumeOutcomeTokenMismatch}, nil
+	}
+	if !record.bindingEqual(binding) {
+		return &ConsumeResult{GrantID: grantID, Outcome: ConsumeOutcomeBindingMismatch}, nil
+	}
+	status := GrantStatus(record.Status)
+	if status == GrantStatusConsumed {
+		grant, err := record.toGrant()
+		if err != nil {
+			return nil, err
+		}
+		return &ConsumeResult{GrantID: grantID, Outcome: ConsumeOutcomeReplay, Grant: grant}, nil
+	}
+	if now.Unix() >= record.ExpiresAt {
+		grant, err := record.toGrant()
+		if err != nil {
+			return nil, err
+		}
+		return &ConsumeResult{GrantID: grantID, Outcome: ConsumeOutcomeExpired, Grant: grant}, nil
+	}
+	return &ConsumeResult{GrantID: grantID, Outcome: ConsumeOutcomeBindingMismatch}, nil
+}
+
+func (s *Store) loadRecord(ctx context.Context, grantID string) (*grantRecord, error) {
+	record := s.emptyRecord()
+	err := s.db.Model(s.emptyRecord()).
+		WithContext(ctx).
+		Where("PK", "=", grantPartitionKey(grantID)).
+		Where("SK", "=", grantSK).
+		First(record)
+	switch {
+	case err == nil:
+		return record, nil
+	case tableerrors.IsNotFound(err):
+		return nil, ErrGrantNotFound
+	default:
+		return nil, fmt.Errorf("get download grant %s: %w", grantID, err)
+	}
+}
+
+func (s *Store) clock() time.Time {
+	if s != nil && s.now != nil {
+		return s.now().UTC()
+	}
+	return time.Now().UTC()
+}
+
+func (s *Store) emptyRecord() *grantRecord {
+	return &grantRecord{tableName: s.tableName}
+}
+
+func (s *Store) recordFor(grantID string) *grantRecord {
+	grantID = strings.TrimSpace(grantID)
+	return &grantRecord{
+		tableName: s.tableName,
+		PK:        grantPartitionKey(grantID),
+		SK:        grantSK,
+		GrantID:   grantID,
+	}
+}
+
+type grantRecord struct {
+	tableName string
+
+	PK string `theorydb:"pk,attr:pk" json:"pk"`
+	SK string `theorydb:"sk,attr:sk" json:"sk"`
+
+	GrantCreatedAt  time.Time `theorydb:"attr:createdAt" json:"created_at"`
+	GrantConsumedAt time.Time `theorydb:"attr:consumedAt" json:"consumed_at"`
+	GrantID         string    `theorydb:"attr:grantId" json:"grant_id"`
+	Status          string    `theorydb:"attr:status" json:"status"`
+	TokenHash       string    `theorydb:"attr:tokenHash" json:"token_hash"`
+	Account         string    `theorydb:"attr:account" json:"account"`
+	Actor           string    `theorydb:"attr:actor" json:"actor"`
+	Namespace       string    `theorydb:"attr:namespace" json:"namespace"`
+	Route           string    `theorydb:"attr:route" json:"route"`
+	Client          string    `theorydb:"attr:client" json:"client"`
+	Profile         string    `theorydb:"attr:profile" json:"profile"`
+	PackID          string    `theorydb:"attr:packId" json:"pack_id"`
+	PackDigest      string    `theorydb:"attr:packDigest" json:"pack_digest"`
+	ExpiresAt       int64     `theorydb:"attr:expiresAt" json:"expires_at"`
+}
+
+func (r grantRecord) TableName() string {
+	if tableName := strings.TrimSpace(r.tableName); tableName != "" {
+		return tableName
+	}
+	return strings.TrimSpace(os.Getenv(EnvInstanceGrantTable))
+}
+
+func (r *grantRecord) toGrant() (*Grant, error) {
+	if r == nil {
+		return nil, nil
+	}
+	binding, err := normalizeBinding(Binding{
+		Account:    r.Account,
+		Actor:      r.Actor,
+		Namespace:  r.Namespace,
+		Route:      r.Route,
+		Client:     r.Client,
+		Profile:    r.Profile,
+		PackID:     r.PackID,
+		PackDigest: r.PackDigest,
+	})
+	if err != nil {
+		return nil, err
+	}
+	status, err := normalizeStatus(GrantStatus(r.Status))
+	if err != nil {
+		return nil, err
+	}
+	return &Grant{
+		Binding:        binding,
+		GrantID:        strings.TrimSpace(r.GrantID),
+		Status:         status,
+		CreatedAt:      r.GrantCreatedAt.UTC(),
+		ConsumedAt:     r.GrantConsumedAt.UTC(),
+		ExpiresAt:      time.Unix(r.ExpiresAt, 0).UTC(),
+		ExpiresAtEpoch: r.ExpiresAt,
+	}, nil
+}
+
+func (r *grantRecord) bindingEqual(binding Binding) bool {
+	if r == nil {
+		return false
+	}
+	return r.Account == binding.Account &&
+		r.Actor == binding.Actor &&
+		r.Namespace == binding.Namespace &&
+		r.Route == binding.Route &&
+		r.Client == binding.Client &&
+		r.Profile == binding.Profile &&
+		r.PackID == binding.PackID &&
+		r.PackDigest == binding.PackDigest
+}
+
+func normalizeBinding(binding Binding) (Binding, error) {
+	out := Binding{
+		Account:    strings.ToLower(strings.TrimSpace(binding.Account)),
+		Actor:      strings.ToLower(strings.TrimSpace(binding.Actor)),
+		Namespace:  strings.ToLower(strings.TrimSpace(binding.Namespace)),
+		Route:      strings.TrimSpace(binding.Route),
+		Client:     strings.ToLower(strings.TrimSpace(binding.Client)),
+		Profile:    strings.ToLower(strings.TrimSpace(binding.Profile)),
+		PackID:     strings.TrimSpace(binding.PackID),
+		PackDigest: strings.ToLower(strings.TrimSpace(binding.PackDigest)),
+	}
+	if out.Account == "" || out.Actor == "" || out.Namespace == "" || out.Route == "" || out.Client == "" || out.Profile == "" || out.PackID == "" || out.PackDigest == "" {
+		return Binding{}, ErrInvalidBinding
+	}
+	return out, nil
+}
+
+func normalizeStatus(status GrantStatus) (GrantStatus, error) {
+	switch GrantStatus(strings.ToLower(strings.TrimSpace(string(status)))) {
+	case GrantStatusActive:
+		return GrantStatusActive, nil
+	case GrantStatusConsumed:
+		return GrantStatusConsumed, nil
+	default:
+		return "", ErrInvalidGrantStatus
+	}
+}
+
+func grantPartitionKey(grantID string) string {
+	grantID = strings.TrimSpace(grantID)
+	if grantID == "" {
+		return ""
+	}
+	return grantPKPrefix + grantID
+}
+
+// HashToken returns a deterministic, domain-separated SHA-256 hash for an
+// opaque raw grant token. The raw token itself must never be stored or logged.
+func HashToken(rawToken string) (string, error) {
+	rawToken = strings.TrimSpace(rawToken)
+	if rawToken == "" {
+		return "", ErrRawTokenRequired
+	}
+	h := sha256.New()
+	_, _ = h.Write([]byte(tokenHashDomainBytes))
+	_, _ = h.Write([]byte(rawToken))
+	return "sha256:" + base64.RawURLEncoding.EncodeToString(h.Sum(nil)), nil
+}
+
+// GenerateToken returns a high-entropy opaque token suitable for one-time
+// return to a caller.
+func GenerateToken() (string, error) {
+	return randomBase64(rawTokenRandomBytes)
+}
+
+// GenerateGrantID returns an opaque grant identifier. Grant IDs are safe to
+// include in sanitized diagnostics.
+func GenerateGrantID() (string, error) {
+	random, err := randomBase64(grantIDRandomBytes)
+	if err != nil {
+		return "", err
+	}
+	return grantIDPrefix + random, nil
+}
+
+func randomBase64(size int) (string, error) {
+	buf := make([]byte, size)
+	if _, err := io.ReadFull(rand.Reader, buf); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(buf), nil
+}
+
+func hashEqual(a string, b string) bool {
+	a = strings.TrimSpace(a)
+	b = strings.TrimSpace(b)
+	if len(a) != len(b) {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
+}

--- a/internal/downloadgrant/store_test.go
+++ b/internal/downloadgrant/store_test.go
@@ -1,0 +1,376 @@
+package downloadgrant
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/theory-cloud/tabletheory/v2"
+	"github.com/theory-cloud/tabletheory/v2/pkg/session"
+	"github.com/theory-cloud/tabletheory/v2/pkg/testing/fakedb"
+)
+
+func TestIssuePersistsTokenHashOnlyAndTTL(t *testing.T) {
+	store, fake := newTestStore(t)
+	fixedNow := time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)
+	store.now = func() time.Time { return fixedNow }
+
+	issued, err := store.Issue(context.Background(), IssueInput{Binding: testBinding()})
+	if err != nil {
+		t.Fatalf("Issue() error = %v", err)
+	}
+	if issued.GrantID == "" || !strings.HasPrefix(issued.GrantID, grantIDPrefix) {
+		t.Fatalf("GrantID = %q, want generated %s*", issued.GrantID, grantIDPrefix)
+	}
+	if issued.Token == "" {
+		t.Fatal("Issue() returned empty raw token")
+	}
+	tokenBytes, err := base64.RawURLEncoding.DecodeString(issued.Token)
+	if err != nil {
+		t.Fatalf("raw token is not base64url: %v", err)
+	}
+	if len(tokenBytes) != rawTokenRandomBytes {
+		t.Fatalf("raw token entropy bytes = %d, want %d", len(tokenBytes), rawTokenRandomBytes)
+	}
+	wantExpiry := fixedNow.Add(DefaultTTL).Unix()
+	if issued.ExpiresAtEpoch != wantExpiry || issued.ExpiresAt.Unix() != wantExpiry {
+		t.Fatalf("expiry = %d/%s, want epoch %d", issued.ExpiresAtEpoch, issued.ExpiresAt, wantExpiry)
+	}
+	if issued.Binding != mustNormalizeBinding(t, testBinding()) {
+		t.Fatalf("issued binding = %+v, want normalized %+v", issued.Binding, mustNormalizeBinding(t, testBinding()))
+	}
+
+	items := fake.Items(os.Getenv(EnvInstanceGrantTable))
+	if len(items) != 1 {
+		t.Fatalf("grant table items = %d, want 1", len(items))
+	}
+	item := items[0]
+	if _, ok := item["tokenHash"]; !ok {
+		t.Fatalf("persisted item missing tokenHash: keys=%v", sortedKeys(item))
+	}
+	for _, forbidden := range []string{"token", "rawToken", "plainToken", "plaintextToken"} {
+		if _, ok := item[forbidden]; ok {
+			t.Fatalf("persisted item contains forbidden raw token field %q: keys=%v", forbidden, sortedKeys(item))
+		}
+	}
+	if got := attrString(t, item, "tokenHash"); got == issued.Token || !strings.HasPrefix(got, "sha256:") {
+		t.Fatalf("tokenHash = %q, want sha256 hash distinct from raw token", got)
+	}
+	if attrNumber(t, item, "expiresAt") != wantExpiry {
+		t.Fatalf("persisted expiresAt = %d, want %d", attrNumber(t, item, "expiresAt"), wantExpiry)
+	}
+	if rawValuePresent(item, issued.Token) {
+		t.Fatalf("persisted item leaked raw token value")
+	}
+}
+
+func TestHashTokenIsDeterministicAndDomainSeparated(t *testing.T) {
+	first, err := HashToken("opaque-token")
+	if err != nil {
+		t.Fatalf("HashToken() error = %v", err)
+	}
+	second, err := HashToken("opaque-token")
+	if err != nil {
+		t.Fatalf("HashToken() second error = %v", err)
+	}
+	other, err := HashToken("opaque-token-2")
+	if err != nil {
+		t.Fatalf("HashToken() other error = %v", err)
+	}
+	if first != second {
+		t.Fatalf("HashToken deterministic mismatch: %q != %q", first, second)
+	}
+	if first == other || first == "opaque-token" || !strings.HasPrefix(first, "sha256:") {
+		t.Fatalf("HashToken = %q other=%q, want sha256 hash distinct from token and other tokens", first, other)
+	}
+	if _, err := HashToken(" "); !errors.Is(err, ErrRawTokenRequired) {
+		t.Fatalf("HashToken(blank) error = %v, want ErrRawTokenRequired", err)
+	}
+}
+
+func TestConsumeTransitionsOnceAndReplayClassifies(t *testing.T) {
+	store, _ := newTestStore(t)
+	issuedAt := time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)
+	store.now = func() time.Time { return issuedAt }
+	issued, err := store.Issue(context.Background(), IssueInput{Binding: testBinding()})
+	if err != nil {
+		t.Fatalf("Issue() error = %v", err)
+	}
+
+	consumeAt := issuedAt.Add(2 * time.Minute)
+	store.now = func() time.Time { return consumeAt }
+	first, err := store.Consume(context.Background(), ConsumeInput{GrantID: issued.GrantID, Token: issued.Token, Binding: testBinding()})
+	if err != nil {
+		t.Fatalf("Consume(first) error = %v", err)
+	}
+	if first.Outcome != ConsumeOutcomeConsumed || first.Grant == nil || first.Grant.Status != GrantStatusConsumed {
+		t.Fatalf("Consume(first) = %+v, want consumed grant", first)
+	}
+	if !first.Grant.ConsumedAt.Equal(consumeAt) {
+		t.Fatalf("ConsumedAt = %s, want %s", first.Grant.ConsumedAt, consumeAt)
+	}
+
+	replay, err := store.Consume(context.Background(), ConsumeInput{GrantID: issued.GrantID, Token: issued.Token, Binding: testBinding()})
+	if err != nil {
+		t.Fatalf("Consume(replay) error = %v", err)
+	}
+	if replay.Outcome != ConsumeOutcomeReplay || replay.Grant == nil || replay.Grant.Status != GrantStatusConsumed {
+		t.Fatalf("Consume(replay) = %+v, want replay consumed classification", replay)
+	}
+	if strings.Contains(fmt.Sprintf("%+v", replay), issued.Token) || strings.Contains(fmt.Sprintf("%+v", replay), "sha256:") {
+		t.Fatalf("replay result leaked raw token or token hash: %+v", replay)
+	}
+}
+
+func TestConsumeFailsClosedForUnknownTokenBindingAndExpiry(t *testing.T) {
+	store, fake := newTestStore(t)
+	issuedAt := time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)
+	store.now = func() time.Time { return issuedAt }
+	issued, err := store.Issue(context.Background(), IssueInput{Binding: testBinding()})
+	if err != nil {
+		t.Fatalf("Issue() error = %v", err)
+	}
+
+	unknown, err := store.Consume(context.Background(), ConsumeInput{GrantID: "missing-grant", Token: issued.Token, Binding: testBinding()})
+	if err != nil {
+		t.Fatalf("Consume(unknown) error = %v", err)
+	}
+	if unknown.Outcome != ConsumeOutcomeNotFound {
+		t.Fatalf("Consume(unknown) = %+v, want not_found", unknown)
+	}
+
+	wrongToken := issued.Token[:len(issued.Token)-1] + "x"
+	tokenMismatch, err := store.Consume(context.Background(), ConsumeInput{GrantID: issued.GrantID, Token: wrongToken, Binding: testBinding()})
+	if err != nil {
+		t.Fatalf("Consume(wrong token) error = %v", err)
+	}
+	if tokenMismatch.Outcome != ConsumeOutcomeTokenMismatch || tokenMismatch.Grant != nil {
+		t.Fatalf("Consume(wrong token) = %+v, want token_mismatch without grant details", tokenMismatch)
+	}
+	if strings.Contains(fmt.Sprintf("%+v", tokenMismatch), wrongToken) || strings.Contains(fmt.Sprintf("%+v", tokenMismatch), "sha256:") {
+		t.Fatalf("token mismatch result leaked token material: %+v", tokenMismatch)
+	}
+	assertRecordStatus(t, store, issued.GrantID, GrantStatusActive)
+
+	wrongBinding := testBinding()
+	wrongBinding.Client = "claude_code"
+	bindingMismatch, err := store.Consume(context.Background(), ConsumeInput{GrantID: issued.GrantID, Token: issued.Token, Binding: wrongBinding})
+	if err != nil {
+		t.Fatalf("Consume(wrong binding) error = %v", err)
+	}
+	if bindingMismatch.Outcome != ConsumeOutcomeBindingMismatch || bindingMismatch.Grant != nil {
+		t.Fatalf("Consume(wrong binding) = %+v, want binding_mismatch without grant details", bindingMismatch)
+	}
+	assertRecordStatus(t, store, issued.GrantID, GrantStatusActive)
+
+	store.now = func() time.Time { return issuedAt.Add(DefaultTTL + time.Second) }
+	expired, err := store.Consume(context.Background(), ConsumeInput{GrantID: issued.GrantID, Token: issued.Token, Binding: testBinding()})
+	if err != nil {
+		t.Fatalf("Consume(expired) error = %v", err)
+	}
+	if expired.Outcome != ConsumeOutcomeExpired || expired.Grant == nil || expired.Grant.Status != GrantStatusActive {
+		t.Fatalf("Consume(expired) = %+v, want expired active grant classification", expired)
+	}
+	assertRecordStatus(t, store, issued.GrantID, GrantStatusActive)
+
+	items := fake.Items(os.Getenv(EnvInstanceGrantTable))
+	if rawValuePresent(items[0], issued.Token) || rawValuePresent(items[0], wrongToken) {
+		t.Fatalf("grant table leaked raw token after failed consumes")
+	}
+}
+
+func TestConcurrentConsumeExactlyOneWinner(t *testing.T) {
+	store, _ := newTestStore(t)
+	issuedAt := time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)
+	store.now = func() time.Time { return issuedAt }
+	issued, err := store.Issue(context.Background(), IssueInput{Binding: testBinding()})
+	if err != nil {
+		t.Fatalf("Issue() error = %v", err)
+	}
+	store.now = func() time.Time { return issuedAt.Add(time.Minute) }
+
+	const attempts = 32
+	start := make(chan struct{})
+	outcomes := make(chan ConsumeOutcome, attempts)
+	errs := make(chan error, attempts)
+	var wg sync.WaitGroup
+	wg.Add(attempts)
+	for i := 0; i < attempts; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			result, err := store.Consume(context.Background(), ConsumeInput{GrantID: issued.GrantID, Token: issued.Token, Binding: testBinding()})
+			if err != nil {
+				errs <- err
+				return
+			}
+			outcomes <- result.Outcome
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(outcomes)
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent Consume() error = %v", err)
+		}
+	}
+
+	counts := map[ConsumeOutcome]int{}
+	for outcome := range outcomes {
+		counts[outcome]++
+	}
+	if counts[ConsumeOutcomeConsumed] != 1 {
+		t.Fatalf("consumed winners = %d outcomes=%v, want exactly 1", counts[ConsumeOutcomeConsumed], counts)
+	}
+	if counts[ConsumeOutcomeReplay] != attempts-1 {
+		t.Fatalf("replay losers = %d outcomes=%v, want %d", counts[ConsumeOutcomeReplay], counts, attempts-1)
+	}
+	assertRecordStatus(t, store, issued.GrantID, GrantStatusConsumed)
+}
+
+func TestInvalidInputsAreSanitized(t *testing.T) {
+	store, _ := newTestStore(t)
+	if _, err := store.Issue(context.Background(), IssueInput{}); !errors.Is(err, ErrInvalidBinding) {
+		t.Fatalf("Issue(empty binding) error = %v, want ErrInvalidBinding", err)
+	}
+	if _, err := store.Consume(context.Background(), ConsumeInput{GrantID: " grant-1 ", Token: " raw-secret-token ", Binding: Binding{Account: "account"}}); !errors.Is(err, ErrInvalidBinding) {
+		t.Fatalf("Consume(invalid binding) error = %v, want ErrInvalidBinding", err)
+	} else if strings.Contains(err.Error(), "raw-secret-token") || strings.Contains(err.Error(), "sha256:") {
+		t.Fatalf("Consume(invalid binding) leaked token material in error: %v", err)
+	}
+	if _, err := store.Consume(context.Background(), ConsumeInput{Binding: testBinding(), Token: "raw-secret-token"}); !errors.Is(err, ErrGrantIDRequired) {
+		t.Fatalf("Consume(missing grant id) error = %v, want ErrGrantIDRequired", err)
+	} else if strings.Contains(err.Error(), "raw-secret-token") || strings.Contains(err.Error(), "sha256:") {
+		t.Fatalf("Consume(missing grant id) leaked token material in error: %v", err)
+	}
+}
+
+func newTestStore(t *testing.T) (*Store, *fakedb.Fake) {
+	t.Helper()
+	t.Setenv(EnvInstanceGrantTable, "body-instance-grants-test")
+	t.Setenv("LESSER_TABLE_NAME", "lesser-stage-table-test")
+
+	fake := fakedb.New()
+	db, err := tabletheory.NewWithClient(session.Config{Region: "us-east-1"}, fake)
+	if err != nil {
+		t.Fatalf("NewWithClient() error = %v", err)
+	}
+	store, err := NewStore(db, os.Getenv(EnvInstanceGrantTable))
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	if err := db.CreateTable(store.emptyRecord()); err != nil {
+		t.Fatalf("CreateTable() error = %v", err)
+	}
+	return store, fake
+}
+
+func testBinding() Binding {
+	return Binding{
+		Account:    " Account-A ",
+		Actor:      " Agent-One ",
+		Namespace:  " EqualToAI ",
+		Route:      " /instance/ba/mcp ",
+		Client:     " Codex ",
+		Profile:    " Dev ",
+		PackID:     "ba-install-pack-codex",
+		PackDigest: "SHA256:ABC123",
+	}
+}
+
+func mustNormalizeBinding(t *testing.T, binding Binding) Binding {
+	t.Helper()
+	out, err := normalizeBinding(binding)
+	if err != nil {
+		t.Fatalf("normalizeBinding() error = %v", err)
+	}
+	return out
+}
+
+func assertRecordStatus(t *testing.T, store *Store, grantID string, want GrantStatus) {
+	t.Helper()
+	record, err := store.loadRecord(context.Background(), grantID)
+	if err != nil {
+		t.Fatalf("loadRecord(%s) error = %v", grantID, err)
+	}
+	if record.Status != string(want) {
+		t.Fatalf("record status = %q, want %q", record.Status, want)
+	}
+}
+
+func attrString(t *testing.T, item map[string]types.AttributeValue, name string) string {
+	t.Helper()
+	member, ok := item[name].(*types.AttributeValueMemberS)
+	if !ok {
+		t.Fatalf("attribute %s = %#v, want string", name, item[name])
+	}
+	return member.Value
+}
+
+func attrNumber(t *testing.T, item map[string]types.AttributeValue, name string) int64 {
+	t.Helper()
+	member, ok := item[name].(*types.AttributeValueMemberN)
+	if !ok {
+		t.Fatalf("attribute %s = %#v, want number", name, item[name])
+	}
+	value, err := strconv.ParseInt(member.Value, 10, 64)
+	if err != nil {
+		t.Fatalf("parse number %s=%q: %v", name, member.Value, err)
+	}
+	return value
+}
+
+func rawValuePresent(item map[string]types.AttributeValue, raw string) bool {
+	for _, value := range item {
+		if attributeContainsRaw(value, raw) {
+			return true
+		}
+	}
+	return false
+}
+
+func attributeContainsRaw(value types.AttributeValue, raw string) bool {
+	switch v := value.(type) {
+	case *types.AttributeValueMemberS:
+		return v.Value == raw
+	case *types.AttributeValueMemberSS:
+		for _, s := range v.Value {
+			if s == raw {
+				return true
+			}
+		}
+	case *types.AttributeValueMemberM:
+		return rawValuePresent(v.Value, raw)
+	case *types.AttributeValueMemberL:
+		for _, child := range v.Value {
+			if attributeContainsRaw(child, raw) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func sortedKeys(item map[string]types.AttributeValue) []string {
+	keys := make([]string, 0, len(item))
+	for key := range item {
+		keys = append(keys, key)
+	}
+	// Tiny insertion sort avoids pulling in another helper just for test failure output.
+	for i := 1; i < len(keys); i++ {
+		for j := i; j > 0 && keys[j] < keys[j-1]; j-- {
+			keys[j], keys[j-1] = keys[j-1], keys[j]
+		}
+	}
+	return keys
+}


### PR DESCRIPTION
## Milestone
Project 48 M6/B12 — Ba one-time download grant store foundation.

Refs #353
Closes #354

## Classification
security / internal data layer / TableTheory persistence

## Surfaces affected
- `internal/downloadgrant/` new internal package only
- No handler, tool registration, MCP contract, CDK, deploy, or sibling-repo changes

## Specialist walks referenced
- Tool surface: data-layer foundation only; no registered Ba tool yet
- MCP contract: not touched
- Lesser integration: not touched
- Host delegation: not touched
- Framework: idiomatic TableTheory v2.0.3 `UpdateBuilder` conditional update APIs

## Consumer impact
No public MCP behavior changes yet. This creates the internal grant-store dependency for later Ba redemption/install-pack work.

## Implementation notes
- Issues high-entropy opaque raw tokens and returns them once.
- Persists only `tokenHash` plus grant/binding fields in `INSTANCE_GRANT_TABLE`; no raw/plaintext token fields.
- Stores DynamoDB TTL-compatible `expiresAt` epoch seconds with a default ~10 minute TTL.
- Consumes with a single TableTheory conditional update requiring active status, matching token hash, matching account/actor/namespace/route/client/profile/pack binding, and non-expiry.
- Classifies replay, unknown, expired, token mismatch, and binding mismatch without returning token/hash material.

## Validation
- `gofmt -l .` (empty)
- `go build ./...`
- `go test ./...`
- `go vet ./...`
- `bash scripts/build.sh`
- Targeted: `go test ./internal/downloadgrant -v`

## Evidence
- Concurrent race proof: `TestConcurrentConsumeExactlyOneWinner` launches 32 simultaneous consumes and asserts exactly one `consumed` winner and 31 `replay` losers.
- Raw-token non-persistence proof: `TestIssuePersistsTokenHashOnlyAndTTL` asserts stored item has `tokenHash`, no `token`/`rawToken`/plaintext-token fields, and no stored value equals the returned raw token.

## Stage rollout plan (handoff to deploy-body)
- [ ] Merged to staging
- [ ] Deployed to lab / dev
- [ ] Lab soak complete
- [ ] Deployed to staging deploy-stage (if used)
- [ ] Staging deploy-stage soak complete
- [ ] Deployed to live

## Cross-repo coordination
None for this internal package. Later #355/#356/#357 will wire route/render/plan behavior.
