### PR TITLE
feat(ba): add one-time installer grant redemption route

### DIFF
--- a/internal/instanceapp/app.go
+++ b/internal/instanceapp/app.go
@@ -22,7 +22,9 @@ const (
 // New builds the instance-plane Lambda app. Ptah and Ba are intentionally
 // separate AppTheory MCP server instances so each plane can grow its own static
 // registry without affecting Ka's actor-scoped /mcp/{actor} runtime.
-func New(name, version string) (*apptheory.App, error) {
+func New(name, version string, custom ...Option) (*apptheory.App, error) {
+	opts := applyOptions(custom)
+
 	name = strings.TrimSpace(name)
 	if name == "" {
 		name = "lesser-body-instance"
@@ -40,6 +42,7 @@ func New(name, version string) (*apptheory.App, error) {
 
 	app.Post("/instance/ptah/mcp", rejectX402Headers(requireInstancePrincipal(withToolContext(ptah.Handler()))), apptheory.RequireAuth())
 	app.Post("/instance/ba/mcp", rejectX402Headers(requireInstancePrincipal(withToolContext(ba.Handler()))), apptheory.RequireAuth())
+	app.Get(installerGrantPathPattern, installerGrantHandler(opts))
 	app.Get("/.well-known/oauth-protected-resource/instance/ptah/mcp", wellKnownStubHandler(SurfacePtah))
 	app.Get("/.well-known/oauth-protected-resource/instance/ba/mcp", wellKnownStubHandler(SurfaceBa))
 

--- a/internal/instanceapp/installer_grants.go
+++ b/internal/instanceapp/installer_grants.go
@@ -1,0 +1,247 @@
+package instanceapp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/equaltoai/lesser-body/internal/downloadgrant"
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+)
+
+const (
+	installerGrantPathPattern = "/instance/downloads/installer-grants/{grantId}"
+	installerGrantBoundRoute  = "/instance/ba/mcp"
+
+	// AWS Lambda's synchronous response payload ceiling is 6 MB. Keep the
+	// installer-pack body below that ceiling before the Lambda adapters serialize
+	// the response envelope.
+	lambdaResponsePayloadCeilingBytes = 6 * 1024 * 1024
+)
+
+// DownloadGrantStore is the minimal Store.Consume seam used by the public Ba
+// installer grant redemption route. Production supplies internal/downloadgrant.Store;
+// tests may inject a TableTheory-backed test store.
+type DownloadGrantStore interface {
+	Consume(context.Context, downloadgrant.ConsumeInput) (*downloadgrant.ConsumeResult, error)
+}
+
+// InstallerPackProvider is the minimal pack-rendering seam for the grant route.
+// The real install-pack renderer lands in #356; this route consumes grants and
+// returns the ZIP bytes supplied by this seam without implementing renderer
+// layout, manifest, or client-specific pack generation here.
+type InstallerPackProvider interface {
+	BuildInstallerPack(context.Context, InstallerPackRequest) (*InstallerPack, error)
+}
+
+// InstallerPackRequest identifies the consumed grant and normalized binding for
+// an install-pack render.
+type InstallerPackRequest struct {
+	GrantID string
+	Binding downloadgrant.Binding
+}
+
+// InstallerPack is the binary ZIP payload returned for a consumed grant.
+type InstallerPack struct {
+	ZIPBytes []byte
+}
+
+type downloadGrantStoreFactory func() (DownloadGrantStore, error)
+
+type options struct {
+	downloadGrantStoreFactory downloadGrantStoreFactory
+	installerPackProvider     InstallerPackProvider
+}
+
+// Option customizes the instance-plane app composition.
+type Option func(*options)
+
+// WithDownloadGrantStore injects a concrete download grant store. It is intended
+// for tests and tightly-scoped composition; production uses downloadgrant.Default.
+func WithDownloadGrantStore(store DownloadGrantStore) Option {
+	return func(opts *options) {
+		if opts == nil {
+			return
+		}
+		opts.downloadGrantStoreFactory = func() (DownloadGrantStore, error) {
+			if store == nil {
+				return nil, fmt.Errorf("download grant store is required")
+			}
+			return store, nil
+		}
+	}
+}
+
+// WithDownloadGrantStoreFactory injects a lazy store factory for tests or
+// alternate instanceapp composition while preserving the Store.Consume contract.
+func WithDownloadGrantStoreFactory(factory func() (DownloadGrantStore, error)) Option {
+	return func(opts *options) {
+		if opts == nil {
+			return
+		}
+		opts.downloadGrantStoreFactory = factory
+	}
+}
+
+// WithInstallerPackProvider injects the install-pack ZIP provider used after a
+// grant is consumed. The #356 renderer will provide the production implementation.
+func WithInstallerPackProvider(provider InstallerPackProvider) Option {
+	return func(opts *options) {
+		if opts == nil {
+			return
+		}
+		opts.installerPackProvider = provider
+	}
+}
+
+func defaultOptions() options {
+	return options{
+		downloadGrantStoreFactory: func() (DownloadGrantStore, error) {
+			return downloadgrant.Default()
+		},
+	}
+}
+
+func applyOptions(custom []Option) options {
+	opts := defaultOptions()
+	for _, opt := range custom {
+		if opt != nil {
+			opt(&opts)
+		}
+	}
+	return opts
+}
+
+func installerGrantHandler(opts options) apptheory.Handler {
+	return func(ctx *apptheory.Context) (*apptheory.Response, error) {
+		provider := opts.installerPackProvider
+		if provider == nil {
+			return noStoreJSON(http.StatusNotImplemented, "installer_pack_provider_not_configured", "installer pack rendering is not configured"), nil
+		}
+		if opts.downloadGrantStoreFactory == nil {
+			return noStoreJSON(http.StatusServiceUnavailable, "download_grant_store_unavailable", "download grant store is unavailable"), nil
+		}
+
+		grantID := strings.TrimSpace(ctx.Param("grantId"))
+		binding := installerGrantBindingFromQuery(ctx)
+		token := strings.TrimSpace(ctx.Query("token"))
+
+		store, err := opts.downloadGrantStoreFactory()
+		if err != nil || store == nil {
+			return noStoreJSON(http.StatusServiceUnavailable, "download_grant_store_unavailable", "download grant store is unavailable"), nil
+		}
+
+		consume, err := store.Consume(ctx.Context(), downloadgrant.ConsumeInput{
+			GrantID: grantID,
+			Token:   token,
+			Binding: binding,
+		})
+		if err != nil {
+			if errors.Is(err, downloadgrant.ErrGrantIDRequired) || errors.Is(err, downloadgrant.ErrRawTokenRequired) || errors.Is(err, downloadgrant.ErrInvalidBinding) {
+				return downloadGrantNotFoundResponse(), nil
+			}
+			return noStoreJSON(http.StatusInternalServerError, "download_grant_consume_failed", "download grant could not be consumed"), nil
+		}
+		if consume == nil {
+			return downloadGrantNotFoundResponse(), nil
+		}
+
+		switch consume.Outcome {
+		case downloadgrant.ConsumeOutcomeConsumed:
+			// Continue below.
+		case downloadgrant.ConsumeOutcomeReplay:
+			return noStoreJSON(http.StatusGone, "download_grant_consumed", "download grant has already been consumed"), nil
+		case downloadgrant.ConsumeOutcomeNotFound, downloadgrant.ConsumeOutcomeExpired, downloadgrant.ConsumeOutcomeTokenMismatch, downloadgrant.ConsumeOutcomeBindingMismatch:
+			return downloadGrantNotFoundResponse(), nil
+		default:
+			return downloadGrantNotFoundResponse(), nil
+		}
+		if consume.Grant == nil {
+			return noStoreJSON(http.StatusInternalServerError, "download_grant_consume_failed", "download grant could not be consumed"), nil
+		}
+
+		pack, err := provider.BuildInstallerPack(ctx.Context(), InstallerPackRequest{
+			GrantID: consume.GrantID,
+			Binding: consume.Grant.Binding,
+		})
+		if err != nil || pack == nil || len(pack.ZIPBytes) == 0 {
+			return noStoreJSON(http.StatusInternalServerError, "installer_pack_render_failed", "installer pack could not be rendered"), nil
+		}
+		if len(pack.ZIPBytes) >= lambdaResponsePayloadCeilingBytes {
+			return noStoreJSON(http.StatusInternalServerError, "installer_pack_too_large", "installer pack exceeds the response payload limit"), nil
+		}
+
+		resp := apptheory.Binary(http.StatusOK, pack.ZIPBytes, "application/zip")
+		resp.SetHeader("Cache-Control", "no-store")
+		resp.SetHeader("Content-Disposition", "attachment; filename=\""+safeInstallerFilename(consume.Grant.Binding.PackID)+"\"")
+		return resp, nil
+	}
+}
+
+func installerGrantBindingFromQuery(ctx *apptheory.Context) downloadgrant.Binding {
+	if ctx == nil {
+		return downloadgrant.Binding{}
+	}
+	return downloadgrant.Binding{
+		Account:    ctx.Query("account"),
+		Actor:      ctx.Query("actor"),
+		Namespace:  ctx.Query("namespace"),
+		Route:      installerGrantBoundRoute,
+		Client:     ctx.Query("client"),
+		Profile:    ctx.Query("profile"),
+		PackID:     ctx.Query("pack_id"),
+		PackDigest: ctx.Query("pack_digest"),
+	}
+}
+
+func downloadGrantNotFoundResponse() *apptheory.Response {
+	return noStoreJSON(http.StatusNotFound, "download_grant_not_found", "download grant is not available")
+}
+
+func noStoreJSON(status int, code string, message string) *apptheory.Response {
+	resp := apptheory.MustJSON(status, map[string]any{
+		"error": map[string]any{
+			"code":    strings.TrimSpace(code),
+			"message": strings.TrimSpace(message),
+		},
+	})
+	resp.SetHeader("Cache-Control", "no-store")
+	return resp
+}
+
+func safeInstallerFilename(packID string) string {
+	stem := sanitizeFilenameStem(packID)
+	if stem == "" {
+		stem = "installer-pack"
+	}
+	return "installer-" + stem + ".zip"
+}
+
+func sanitizeFilenameStem(in string) string {
+	in = strings.TrimSpace(in)
+	if in == "" {
+		return ""
+	}
+
+	var b strings.Builder
+	lastDash := false
+	for _, r := range in {
+		keep := (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '.' || r == '_' || r == '-'
+		if keep {
+			b.WriteRune(r)
+			lastDash = false
+			continue
+		}
+		if !lastDash {
+			b.WriteByte('-')
+			lastDash = true
+		}
+	}
+	out := strings.Trim(b.String(), ".-_")
+	if len(out) > 96 {
+		out = strings.Trim(out[:96], ".-_")
+	}
+	return out
+}

--- a/internal/instanceapp/installer_grants_test.go
+++ b/internal/instanceapp/installer_grants_test.go
@@ -1,0 +1,306 @@
+package instanceapp_test
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/equaltoai/lesser-body/internal/downloadgrant"
+	"github.com/equaltoai/lesser-body/internal/instanceapp"
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+	"github.com/theory-cloud/apptheory/testkit"
+	"github.com/theory-cloud/tabletheory/v2"
+	"github.com/theory-cloud/tabletheory/v2/pkg/session"
+	"github.com/theory-cloud/tabletheory/v2/pkg/testing/fakedb"
+)
+
+func TestInstallerGrantDownload_HeaderFreeConsumeReturnsZipAndReplayGone(t *testing.T) {
+	store := newDownloadGrantStore(t)
+	binding := installerGrantTestBinding()
+	issued, err := store.Issue(context.Background(), downloadgrant.IssueInput{Binding: binding})
+	if err != nil {
+		t.Fatalf("Issue() error = %v", err)
+	}
+
+	zipBytes := fakeZipBytes(t)
+	provider := &fakeInstallerPackProvider{pack: &instanceapp.InstallerPack{ZIPBytes: zipBytes}}
+	app, err := instanceapp.New("lesser-body-instance", "dev",
+		instanceapp.WithDownloadGrantStore(store),
+		instanceapp.WithInstallerPackProvider(provider),
+	)
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+	env := testkit.New()
+
+	resp := invokeInstallerGrantDownload(t, env, app, issued.GrantID, installerGrantQuery(issued.Token, issued.Binding), nil)
+	if resp.Status != 200 {
+		t.Fatalf("status = %d, want 200; body=%s", resp.Status, string(resp.Body))
+	}
+	if got := firstHeader(resp.Headers, "cache-control"); got != "no-store" {
+		t.Fatalf("Cache-Control = %q, want no-store", got)
+	}
+	if got := firstHeader(resp.Headers, "content-type"); got != "application/zip" {
+		t.Fatalf("Content-Type = %q, want application/zip", got)
+	}
+	disposition := firstHeader(resp.Headers, "content-disposition")
+	if !strings.HasPrefix(disposition, `attachment; filename="`) || !strings.HasSuffix(disposition, `.zip"`) {
+		t.Fatalf("Content-Disposition = %q, want safe attachment zip filename", disposition)
+	}
+	filename := strings.TrimPrefix(disposition, `attachment; filename="`)
+	filename = strings.TrimSuffix(filename, `"`)
+	for _, unsafe := range []string{"/", "\\", "\n", "\r", ";", issued.Token, "sha256:"} {
+		if strings.Contains(filename, unsafe) {
+			t.Fatalf("Content-Disposition filename %q contains unsafe/token material %q", filename, unsafe)
+		}
+	}
+	if !resp.IsBase64 {
+		t.Fatalf("IsBase64 = false, want binary Lambda response")
+	}
+	if !bytes.Equal(resp.Body, zipBytes) {
+		t.Fatalf("body bytes mismatch: got %d bytes want %d", len(resp.Body), len(zipBytes))
+	}
+	if len(resp.Body) >= 6*1024*1024 {
+		t.Fatalf("body length = %d, want under 6 MB Lambda payload ceiling", len(resp.Body))
+	}
+	if provider.calls != 1 {
+		t.Fatalf("provider calls = %d, want 1", provider.calls)
+	}
+	if provider.requests[0].GrantID != issued.GrantID || provider.requests[0].Binding != issued.Binding {
+		t.Fatalf("provider request = %+v, want grantID %q binding %+v", provider.requests[0], issued.GrantID, issued.Binding)
+	}
+
+	replay := invokeInstallerGrantDownload(t, env, app, issued.GrantID, installerGrantQuery(issued.Token, issued.Binding), nil)
+	if replay.Status != 410 {
+		t.Fatalf("replay status = %d, want 410; body=%s", replay.Status, string(replay.Body))
+	}
+	if provider.calls != 1 {
+		t.Fatalf("provider calls after replay = %d, want still 1", provider.calls)
+	}
+	assertNoTokenMaterial(t, replay.Body, issued.Token)
+}
+
+func TestInstallerGrantDownload_FailedConsumesReturn404WithoutRendering(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		setup func(t *testing.T, store *downloadgrant.Store) (grantID string, token string, binding downloadgrant.Binding, rawSecrets []string)
+	}{
+		{
+			name: "unknown grant",
+			setup: func(t *testing.T, store *downloadgrant.Store) (string, string, downloadgrant.Binding, []string) {
+				t.Helper()
+				issued := issueInstallerGrant(t, store, downloadgrant.DefaultTTL)
+				return "dg_missing", issued.Token, issued.Binding, []string{issued.Token}
+			},
+		},
+		{
+			name: "expired grant",
+			setup: func(t *testing.T, store *downloadgrant.Store) (string, string, downloadgrant.Binding, []string) {
+				t.Helper()
+				issued := issueInstallerGrant(t, store, time.Millisecond)
+				time.Sleep(5 * time.Millisecond)
+				return issued.GrantID, issued.Token, issued.Binding, []string{issued.Token}
+			},
+		},
+		{
+			name: "token mismatch",
+			setup: func(t *testing.T, store *downloadgrant.Store) (string, string, downloadgrant.Binding, []string) {
+				t.Helper()
+				issued := issueInstallerGrant(t, store, downloadgrant.DefaultTTL)
+				wrongToken := issued.Token + "x"
+				return issued.GrantID, wrongToken, issued.Binding, []string{issued.Token, wrongToken}
+			},
+		},
+		{
+			name: "binding mismatch",
+			setup: func(t *testing.T, store *downloadgrant.Store) (string, string, downloadgrant.Binding, []string) {
+				t.Helper()
+				issued := issueInstallerGrant(t, store, downloadgrant.DefaultTTL)
+				binding := issued.Binding
+				binding.Profile = "live"
+				return issued.GrantID, issued.Token, binding, []string{issued.Token}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := newDownloadGrantStore(t)
+			grantID, token, binding, rawSecrets := tc.setup(t, store)
+			provider := &fakeInstallerPackProvider{pack: &instanceapp.InstallerPack{ZIPBytes: fakeZipBytes(t)}}
+			app, err := instanceapp.New("lesser-body-instance", "dev",
+				instanceapp.WithDownloadGrantStore(store),
+				instanceapp.WithInstallerPackProvider(provider),
+			)
+			if err != nil {
+				t.Fatalf("new app: %v", err)
+			}
+
+			resp := invokeInstallerGrantDownload(t, testkit.New(), app, grantID, installerGrantQuery(token, binding), nil)
+			if resp.Status != 404 {
+				t.Fatalf("status = %d, want 404; body=%s", resp.Status, string(resp.Body))
+			}
+			if provider.calls != 0 {
+				t.Fatalf("provider calls = %d, want 0", provider.calls)
+			}
+			if got := firstHeader(resp.Headers, "cache-control"); got != "no-store" {
+				t.Fatalf("Cache-Control = %q, want no-store", got)
+			}
+			for _, secret := range rawSecrets {
+				assertNoTokenMaterial(t, resp.Body, secret)
+			}
+		})
+	}
+}
+
+func TestInstallerGrantDownload_OversizePackFailsBelowLambdaCeiling(t *testing.T) {
+	store := newDownloadGrantStore(t)
+	issued := issueInstallerGrant(t, store, downloadgrant.DefaultTTL)
+	provider := &fakeInstallerPackProvider{pack: &instanceapp.InstallerPack{ZIPBytes: bytes.Repeat([]byte{'x'}, 6*1024*1024)}}
+	app, err := instanceapp.New("lesser-body-instance", "dev",
+		instanceapp.WithDownloadGrantStore(store),
+		instanceapp.WithInstallerPackProvider(provider),
+	)
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+
+	resp := invokeInstallerGrantDownload(t, testkit.New(), app, issued.GrantID, installerGrantQuery(issued.Token, issued.Binding), nil)
+	if resp.Status != 500 {
+		t.Fatalf("status = %d, want 500; body=%s", resp.Status, string(resp.Body))
+	}
+	if len(resp.Body) >= 6*1024*1024 {
+		t.Fatalf("error body length = %d, want under Lambda ceiling", len(resp.Body))
+	}
+	assertNoTokenMaterial(t, resp.Body, issued.Token)
+}
+
+type fakeInstallerPackProvider struct {
+	pack     *instanceapp.InstallerPack
+	calls    int
+	requests []instanceapp.InstallerPackRequest
+}
+
+func (p *fakeInstallerPackProvider) BuildInstallerPack(_ context.Context, req instanceapp.InstallerPackRequest) (*instanceapp.InstallerPack, error) {
+	p.calls++
+	p.requests = append(p.requests, req)
+	return p.pack, nil
+}
+
+func invokeInstallerGrantDownload(t testing.TB, env *testkit.Env, app *apptheory.App, grantID string, query map[string][]string, headers map[string][]string) apptheory.Response {
+	t.Helper()
+	return env.Invoke(context.Background(), app, apptheory.Request{
+		Method:  "GET",
+		Path:    "/instance/downloads/installer-grants/" + grantID,
+		Query:   query,
+		Headers: headers,
+	})
+}
+
+func installerGrantQuery(token string, binding downloadgrant.Binding) map[string][]string {
+	return map[string][]string{
+		"token":       {token},
+		"account":     {binding.Account},
+		"actor":       {binding.Actor},
+		"namespace":   {binding.Namespace},
+		"client":      {binding.Client},
+		"profile":     {binding.Profile},
+		"pack_id":     {binding.PackID},
+		"pack_digest": {binding.PackDigest},
+	}
+}
+
+func issueInstallerGrant(t testing.TB, store *downloadgrant.Store, ttl time.Duration) *downloadgrant.IssuedGrant {
+	t.Helper()
+	issued, err := store.Issue(context.Background(), downloadgrant.IssueInput{Binding: installerGrantTestBinding(), TTL: ttl})
+	if err != nil {
+		t.Fatalf("Issue() error = %v", err)
+	}
+	return issued
+}
+
+func installerGrantTestBinding() downloadgrant.Binding {
+	return downloadgrant.Binding{
+		Account:    "account-a",
+		Actor:      "agent-one",
+		Namespace:  "equaltoai",
+		Route:      "/instance/ba/mcp",
+		Client:     "codex",
+		Profile:    "dev",
+		PackID:     "ba-install-pack/codex v1",
+		PackDigest: "sha256:abc123",
+	}
+}
+
+func newDownloadGrantStore(t testing.TB) *downloadgrant.Store {
+	t.Helper()
+	const tableName = "body-instance-grants-test"
+	t.Setenv(downloadgrant.EnvInstanceGrantTable, tableName)
+
+	fake := fakedb.New()
+	db, err := tabletheory.NewWithClient(session.Config{Region: "us-east-1"}, fake)
+	if err != nil {
+		t.Fatalf("NewWithClient() error = %v", err)
+	}
+	if err := db.CreateTable(instanceDownloadGrantRecord{}); err != nil {
+		t.Fatalf("CreateTable() error = %v", err)
+	}
+	store, err := downloadgrant.NewStore(db, tableName)
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	return store
+}
+
+type instanceDownloadGrantRecord struct {
+	PK string `theorydb:"pk,attr:pk" json:"pk"`
+	SK string `theorydb:"sk,attr:sk" json:"sk"`
+
+	GrantCreatedAt  time.Time `theorydb:"attr:createdAt" json:"created_at"`
+	GrantConsumedAt time.Time `theorydb:"attr:consumedAt" json:"consumed_at"`
+	GrantID         string    `theorydb:"attr:grantId" json:"grant_id"`
+	Status          string    `theorydb:"attr:status" json:"status"`
+	TokenHash       string    `theorydb:"attr:tokenHash" json:"token_hash"`
+	Account         string    `theorydb:"attr:account" json:"account"`
+	Actor           string    `theorydb:"attr:actor" json:"actor"`
+	Namespace       string    `theorydb:"attr:namespace" json:"namespace"`
+	Route           string    `theorydb:"attr:route" json:"route"`
+	Client          string    `theorydb:"attr:client" json:"client"`
+	Profile         string    `theorydb:"attr:profile" json:"profile"`
+	PackID          string    `theorydb:"attr:packId" json:"pack_id"`
+	PackDigest      string    `theorydb:"attr:packDigest" json:"pack_digest"`
+	ExpiresAt       int64     `theorydb:"attr:expiresAt" json:"expires_at"`
+}
+
+func (instanceDownloadGrantRecord) TableName() string {
+	return "body-instance-grants-test"
+}
+
+func fakeZipBytes(t testing.TB) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	w, err := zw.Create("README.txt")
+	if err != nil {
+		t.Fatalf("create fake zip entry: %v", err)
+	}
+	if _, err := w.Write([]byte("fake installer pack for route tests\n")); err != nil {
+		t.Fatalf("write fake zip entry: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("close fake zip: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func assertNoTokenMaterial(t testing.TB, body []byte, token string) {
+	t.Helper()
+	text := string(body)
+	if token != "" && strings.Contains(text, token) {
+		t.Fatalf("response body leaked raw token %q: %s", token, text)
+	}
+	if strings.Contains(text, "sha256:") {
+		t.Fatalf("response body leaked token hash material: %s", text)
+	}
+}


### PR DESCRIPTION
## Milestone
Project 48 — Legend of Lesser, M6/B13 Ba packs & grants: add the header-free one-time installer grant redemption route.

Closes #355.

## Classification
security / MCP-contract-adjacent additive HTTP contract / instance-plane Ba

## Surfaces affected
- `internal/instanceapp/app.go`
- `internal/instanceapp/installer_grants.go`
- `internal/instanceapp/installer_grants_test.go`

## Route contract
- `GET /instance/downloads/installer-grants/{grantId}` is public/header-free; no `Authorization` requirement.
- Opaque token is supplied as `?token=`.
- Because `internal/downloadgrant.Store.Consume` requires the full grant binding, the tests document the header-free query binding contract: `account`, `actor`, `namespace`, `client`, `profile`, `pack_id`, and `pack_digest`; the bound route is fixed to `/instance/ba/mcp`.
- First valid consume returns ZIP bytes with `Cache-Control: no-store` and `Content-Disposition: attachment; filename="...zip"`.
- Replay maps to 410; unknown/expired/token mismatch/binding mismatch map to 404.

## Framework/source evidence
- Confirmed `go.mod` uses `github.com/theory-cloud/apptheory v1.17.0` and `github.com/theory-cloud/tabletheory/v2 v2.0.3`.
- Inspected `internal/downloadgrant/` from #354: preserved `Store.Consume`, `Binding`, and consume outcomes; route calls `Store.Consume` through a minimal seam rather than reimplementing conditional consume.
- Inspected `internal/instanceapp/app.go` and existing tests for AppTheory route composition and testkit invocation.
- Inspected local AppTheory v1.17.0 request/response/testkit patterns (`App.Get`, `Context.Param`, `Context.Query`, `apptheory.Binary`, normalized headers, `testkit.Env.Invoke`).

## Implementation notes
- Adds minimal `DownloadGrantStore` and `InstallerPackProvider` injection seams in `instanceapp` only.
- Does not implement #356 renderer/layout/MANIFEST generation; tests use fake ZIP bytes.
- No #357 MCP tool registration, no sibling repo edits, no CDK/cloud/deploy mutation.
- Error responses are generic/no-store and do not include raw token or token hash material.

## Validation
Final gates run with `cdk/node_modules` temporarily moved outside the repo, per existing repo-local validation lesson, then restored.

```text
$ gofmt -l .
$ go test ./...
?   	github.com/equaltoai/lesser-body/cmd/lesser-body	[no test files]
?   	github.com/equaltoai/lesser-body/cmd/lesser-body-instance	[no test files]
ok  	github.com/equaltoai/lesser-body/internal/agentcontent	(cached)
ok  	github.com/equaltoai/lesser-body/internal/agentregistry	(cached)
ok  	github.com/equaltoai/lesser-body/internal/auth	(cached)
ok  	github.com/equaltoai/lesser-body/internal/cmsapi	(cached)
ok  	github.com/equaltoai/lesser-body/internal/downloadgrant	(cached)
ok  	github.com/equaltoai/lesser-body/internal/instanceapp	(cached)
ok  	github.com/equaltoai/lesser-body/internal/lesserapi	(cached)
ok  	github.com/equaltoai/lesser-body/internal/mcpapp	(cached)
ok  	github.com/equaltoai/lesser-body/internal/mcpserver	(cached)
?   	github.com/equaltoai/lesser-body/internal/memory	[no test files]
ok  	github.com/equaltoai/lesser-body/internal/ptahserver	(cached)
?   	github.com/equaltoai/lesser-body/internal/runtimepolicy	[no test files]
ok  	github.com/equaltoai/lesser-body/internal/soulapi	(cached)
ok  	github.com/equaltoai/lesser-body/internal/soulbinding	(cached)
ok  	github.com/equaltoai/lesser-body/internal/trustconfig	(cached)
$ go vet ./...
$ bash scripts/build.sh
Building lesser-body.zip bootstrap (linux/arm64)...
Packaging dist/lesser-body.zip...
OK: dist/lesser-body.zip
Building lesser-body-instance.zip bootstrap (linux/arm64)...
Packaging dist/lesser-body-instance.zip...
OK: dist/lesser-body-instance.zip
Writing dist/checksums.txt...
dist/lesser-body.zip: OK
dist/lesser-body-instance.zip: OK
OK: dist/checksums.txt
```

## Risks / follow-ups
- #356 must provide the production install-pack renderer/provider before real hosted-instance downloads can return rendered packs outside tests.
- #357 remains separate; no Ba MCP local-install-plan tool is registered here.
