### PR TITLE
feat(ba): register agent_local_install_plan tool

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -15,7 +15,7 @@
 - Instance-plane Ptah MCP (authenticated): `POST /instance/ptah/mcp`
   - Uses a separate AppTheory MCP server instance for account-holder orchestration tools.
 - Instance-plane Ba MCP (authenticated): `POST /instance/ba/mcp`
-  - Uses a separate AppTheory MCP server instance. The foundation surface currently has no registered tools.
+  - Uses a separate AppTheory MCP server instance for account-holder install-pack/grant tooling.
 
 Canonical base URL for a Lesser stage:
 
@@ -81,8 +81,9 @@ Deprecated bearer-token/runtime-credential flows should be migrated to OAuth con
 Instance-plane MCP endpoints (`/instance/ptah/mcp` and `/instance/ba/mcp`) also require Lesser OAuth JWT bearer
 authentication, but they are not actor-delegated Ka surfaces. They fail closed unless the authenticated principal is an
 account-holder OAuth token, not an agent-delegated token and not the legacy managed instance key. The token audience
-must match the exact instance MCP resource URL, for example `https://api.<stageDomain>/instance/ptah/mcp`. Ptah write
-tools still enforce their own write-scope requirement before invoking downstream Lesser integration APIs.
+must match the exact instance MCP resource URL, for example `https://api.<stageDomain>/instance/ptah/mcp` or
+`https://api.<stageDomain>/instance/ba/mcp`. Ptah and Ba write tools still enforce their own write-scope
+requirements before side effects such as Lesser integration calls or one-time grant minting.
 
 Scoped public x402 invocation grants:
 
@@ -688,6 +689,85 @@ structured MCP content containing Lesser's response, idempotency/replay metadata
 Lesser remains the sole writer of soul/body binding state. `agent_bind_soul` does not create, update, delete, or store
 `SOUL_BODY_BINDING` records in Body. After Lesser-owned binding state appears in the Lesser table, Ka resolves the actor
 as `souled` through the existing `internal/soulbinding` read path.
+
+### Instance-plane Ba tools
+
+Ba tools are served only from `POST /instance/ba/mcp` and are not registered on Ka's actor-scoped `/mcp/{actor}`
+surface or Ptah's `/instance/ptah/mcp` surface. Clients discover them with an authenticated Ba `tools/list` request
+after `initialize`; the public actor-scoped `/.well-known/mcp.json` discovery document remains the Ka contract.
+
+| Tool | Scope | Description |
+|------|-------|-------------|
+| `agent_local_install_plan` | Write | Render a deterministic local install pack for an account-scoped agent and mint a one-time header-free download grant. |
+
+`agent_local_install_plan` input:
+
+- Required: `agent_id`, `client`.
+- `client` must be `claude_code` or `codex`; optional `profile`, when supplied, must match `client`.
+- Derived: account scope is the authenticated account-holder OAuth principal. Optional `actor_username`, when supplied,
+  must match that principal after normalization. Callers cannot supply an account override.
+- Derived: the stage domain and download origin come from the CDK-provided `INSTANCE_MCP_ENDPOINT` template
+  (`https://api.<stageDomain>/instance/{surface}/mcp`), not from caller input or unvalidated `Host` headers. Rendered
+  packs still target the canonical actor MCP endpoint `https://api.<stageDomain>/mcp/{actor}`.
+
+`agent_local_install_plan` requires an account-holder OAuth principal with `write` scope because it mints a one-time
+installer grant. Agent-delegated principals, legacy managed-instance-key principals, read-only principals, missing actor
+usernames, and `actor_username` mismatches are rejected before Body reads content, renders a pack, or mints a grant.
+The instance-plane x402 seam remains fail-closed in this foundation slice: x402 headers on `/instance/ba/mcp` are
+rejected before tool dispatch.
+
+The tool reads current account-scoped `agent_soul` and `agent_instructions` records through
+`internal/agentcontent.Store.Get`, renders a deterministic ZIP through `internal/installpack`, then mints a short-lived
+one-time grant through `internal/downloadgrant.Store.Issue`. The grant binding is fixed to:
+
+```json
+{
+  "account": "<authenticated account username>",
+  "actor": "<safe local actor segment derived from agent_id>",
+  "namespace": "equaltoai",
+  "route": "/instance/ba/mcp",
+  "client": "codex",
+  "profile": "codex",
+  "pack_id": "<deterministic Ba pack id>",
+  "pack_digest": "sha256:<input/content digest>"
+}
+```
+
+The successful response is a TheoryMCP-compatible install-plan envelope under `structuredContent.data`. Text content is
+only a concise locator and does not duplicate the raw download URL, raw token, `agent_soul`, or `agent_instructions`
+content. The data envelope includes at least:
+
+- `schema` (`lesserbody.agent_local_install_plan.v1`)
+- `grant_id` and `expires_at`
+- `download_url` and `install_pack_resource.uri`
+- `pack_id`, `pack_digest`, and `pack_checksum`
+- `resource_metadata` / `install_pack_resource` with `method: "GET"`, `media_type: "application/zip"`,
+  `requires_authorization_header: false`, and the safe grant binding query metadata
+- `manifest`, `manifest_entries`, `marker_metadata` / `install_marker`
+- `mcp_server_name` and `mcp_endpoint_url`
+- `merge_instructions`, `update_guidance`, and `verification_steps`
+
+The download URL is intentionally header-free for local installer clients and uses the public grant route:
+
+```text
+GET https://api.<stageDomain>/instance/downloads/installer-grants/{grantId}?token=<raw-token>&account=...&actor=...&namespace=...&client=...&profile=...&pack_id=...&pack_digest=...
+```
+
+The raw token is returned only inside that tool response URL at issue time. `internal/downloadgrant` persists only a
+domain-separated `TokenHash`, TTL-compatible `expiresAt`, grant id, status, and safe binding fields. Ba audit logging
+for successful plans records only safe metadata such as `grant_id`, account, actor, client/profile, `pack_id`,
+`pack_digest`, and `pack_checksum`; it must never log raw tokens, token hashes, grant URLs, `agent_soul` content, or
+`agent_instructions` content.
+
+The grant download route consumes matching active grants atomically and then renders the ZIP through the same
+`internal/installpack` provider path. Successful downloads return `application/zip` with `Cache-Control: no-store`.
+Replay of a consumed grant returns `410 Gone`; unknown, expired, mismatched-token, or mismatched-binding grants return
+`404 Not Found` without token material. Clients must verify `pack_checksum` against the downloaded ZIP bytes, read
+`MANIFEST.json`, and verify every `manifest_entries[].checksum` before writing or merging local files.
+
+Ba applies a bounded in-process per-account grant minting rate cap before content reads and grant issuance. This is a
+foundation-slice safety backstop only; it does not coordinate across Lambda execution environments and is not a durable
+quota system. Exceeded caps return structured tool error code `rate_limited` with HTTP-style status `429`.
 
 ### Shared read-tool shaping parameters
 

--- a/internal/baserver/baserver.go
+++ b/internal/baserver/baserver.go
@@ -1,0 +1,1031 @@
+package baserver
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/equaltoai/lesser-body/internal/agentcontent"
+	"github.com/equaltoai/lesser-body/internal/auth"
+	"github.com/equaltoai/lesser-body/internal/downloadgrant"
+	"github.com/equaltoai/lesser-body/internal/installpack"
+	mcpruntime "github.com/theory-cloud/apptheory/runtime/mcp"
+)
+
+const (
+	// ToolAgentLocalInstallPlan is the Ba instance-plane local install planning tool.
+	ToolAgentLocalInstallPlan = "agent_local_install_plan"
+
+	// InstallerGrantBoundRoute is the fixed instance-plane MCP route bound into
+	// Ba local-install download grants. It intentionally does not come from caller
+	// input or host headers.
+	InstallerGrantBoundRoute = "/instance/ba/mcp"
+
+	// EnvInstanceMCPEndpoint is injected by CDK as the canonical instance-plane
+	// endpoint template, for example https://api.dev.example.com/instance/{surface}/mcp.
+	EnvInstanceMCPEndpoint = "INSTANCE_MCP_ENDPOINT"
+
+	DefaultNamespace = "equaltoai"
+
+	planSchema       = "lesserbody.agent_local_install_plan.v1"
+	packIDPrefix     = "agent-local-install/v1/"
+	defaultRateLimit = 5
+)
+
+var defaultRateWindow = time.Minute
+
+// AgentContentStore is the body-owned Ba content read dependency. Production
+// uses internal/agentcontent.Store over INSTANCE_CONTENT_TABLE.
+type AgentContentStore interface {
+	Get(ctx context.Context, account string, agentID string, contentType agentcontent.ContentType) (*agentcontent.Record, error)
+}
+
+// DownloadGrantIssuer is the one-time download grant minting dependency used by
+// agent_local_install_plan. Production uses internal/downloadgrant.Store.
+type DownloadGrantIssuer interface {
+	Issue(ctx context.Context, in downloadgrant.IssueInput) (*downloadgrant.IssuedGrant, error)
+}
+
+// Renderer is the deterministic install-pack renderer dependency.
+type Renderer interface {
+	Render(ctx context.Context, req installpack.Request) (*installpack.Pack, error)
+}
+
+type config struct {
+	contentStore        AgentContentStore
+	contentStoreFactory func() (AgentContentStore, error)
+	grantIssuer         DownloadGrantIssuer
+	grantIssuerFactory  func() (DownloadGrantIssuer, error)
+	renderer            Renderer
+	instanceEndpoint    string
+	namespace           string
+	rateLimiter         GrantMintLimiter
+	now                 func() time.Time
+}
+
+// Option configures Ba tool registration.
+type Option func(*config)
+
+// WithAgentContentStore injects the content store used by Ba plan rendering.
+func WithAgentContentStore(store AgentContentStore) Option {
+	return func(cfg *config) {
+		cfg.contentStore = store
+	}
+}
+
+// WithDownloadGrantIssuer injects the grant issuer used by Ba plan rendering.
+func WithDownloadGrantIssuer(issuer DownloadGrantIssuer) Option {
+	return func(cfg *config) {
+		cfg.grantIssuer = issuer
+	}
+}
+
+// WithRenderer injects the deterministic install-pack renderer.
+func WithRenderer(renderer Renderer) Option {
+	return func(cfg *config) {
+		cfg.renderer = renderer
+	}
+}
+
+// WithInstanceEndpoint injects the canonical instance-plane endpoint template.
+func WithInstanceEndpoint(endpoint string) Option {
+	return func(cfg *config) {
+		cfg.instanceEndpoint = strings.TrimSpace(endpoint)
+	}
+}
+
+// WithNamespace injects the namespace recorded in Ba install-pack metadata and
+// download-grant bindings. Empty values fall back to DefaultNamespace.
+func WithNamespace(namespace string) Option {
+	return func(cfg *config) {
+		cfg.namespace = strings.TrimSpace(namespace)
+	}
+}
+
+// WithRateLimiter injects the process-local grant minting limiter.
+func WithRateLimiter(limiter GrantMintLimiter) Option {
+	return func(cfg *config) {
+		cfg.rateLimiter = limiter
+	}
+}
+
+// WithClock injects a clock for tests.
+func WithClock(now func() time.Time) Option {
+	return func(cfg *config) {
+		cfg.now = now
+	}
+}
+
+func defaultConfig() config {
+	return config{
+		contentStoreFactory: func() (AgentContentStore, error) {
+			return agentcontent.Default()
+		},
+		grantIssuerFactory: func() (DownloadGrantIssuer, error) {
+			return downloadgrant.Default()
+		},
+		renderer:         installpack.NewRenderer(),
+		instanceEndpoint: strings.TrimSpace(os.Getenv(EnvInstanceMCPEndpoint)),
+		namespace:        DefaultNamespace,
+		rateLimiter:      NewInMemoryGrantMintLimiter(defaultRateLimit, defaultRateWindow),
+		now:              func() time.Time { return time.Now().UTC() },
+	}
+}
+
+// RegisterTools statically registers the Ba instance-plane tool surface.
+func RegisterTools(r *mcpruntime.ToolRegistry, opts ...Option) error {
+	if r == nil {
+		return fmt.Errorf("tool registry is nil")
+	}
+	cfg := defaultConfig()
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&cfg)
+		}
+	}
+	return r.RegisterTool(agentLocalInstallPlanDef(), cfg.handleAgentLocalInstallPlan)
+}
+
+func agentLocalInstallPlanDef() mcpruntime.ToolDef {
+	return mcpruntime.ToolDef{
+		Name:        ToolAgentLocalInstallPlan,
+		Title:       "Plan local agent install pack",
+		Description: "Render a deterministic Ba local-install pack for an account-scoped agent, mint a one-time header-free download grant, and return a TheoryMCP-compatible install-plan envelope. Requires an account-holder OAuth principal with write scope.",
+		Annotations: additiveMutationToolAnnotations(),
+		InputSchema: json.RawMessage(`{
+			"type":"object",
+			"properties":{
+				"agent_id":{"type":"string","description":"Account-scoped agent id whose current agent_soul and agent_instructions records should be rendered into the local install pack."},
+				"client":{"type":"string","enum":["claude_code","codex"],"description":"Local MCP client profile to render."},
+				"profile":{"type":"string","enum":["claude_code","codex"],"description":"Optional profile alias. When supplied it must match client."},
+				"actor_username":{"type":"string","description":"Optional explicit account-holder username. When supplied it must match the authenticated OAuth principal."}
+			},
+			"required":["agent_id","client"],
+			"additionalProperties":false
+		}`),
+		OutputSchema: json.RawMessage(`{
+			"type":"object",
+			"properties":{
+				"data":{"type":"object","description":"Install-plan envelope containing grant id, header-free download URL, pack checksum/digest, resource metadata, manifest entries, mcp_server_name, merge/update guidance, expiration, and verification steps."},
+				"error":{"type":"object","description":"Structured tool error when isError=true."}
+			}
+		}`),
+	}
+}
+
+type agentLocalInstallPlanInput struct {
+	AgentID       string `json:"agent_id"`
+	Client        string `json:"client"`
+	Profile       string `json:"profile"`
+	ActorUsername string `json:"actor_username"`
+}
+
+func (cfg config) handleAgentLocalInstallPlan(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
+	principal := auth.PrincipalFromToolContext(ctx)
+	account, errResult, err := authenticatedAccountHolderActor(principal, ToolAgentLocalInstallPlan)
+	if errResult != nil || err != nil {
+		return errResult, err
+	}
+	if !principalHasWriteScope(principal) {
+		return toolErrorResult("insufficient_scope", "agent_local_install_plan requires write scope because it mints a one-time download grant", http.StatusForbidden, map[string]any{
+			"requiredScopes": []string{"write"},
+			"grantedScopes":  normalizedScopes(principal.Claims.Scopes),
+		})
+	}
+
+	in, errResult, err := parseAgentLocalInstallPlanInput(args, account)
+	if errResult != nil || err != nil {
+		return errResult, err
+	}
+
+	decision := cfg.rateLimit(account)
+	if !decision.Allowed {
+		return toolErrorResult("rate_limited", "agent_local_install_plan grant minting rate limit exceeded for this account", http.StatusTooManyRequests, map[string]any{
+			"source":      "ba_grant_mint_rate_limit",
+			"limit":       decision.Limit,
+			"window":      decision.Window.String(),
+			"reset_at":    formatTime(decision.ResetAt),
+			"retry_after": maxInt(0, int(time.Until(decision.ResetAt).Seconds())),
+		})
+	}
+
+	contentStore, err := cfg.content()
+	if err != nil {
+		return toolErrorResult("not_configured", err.Error(), http.StatusInternalServerError, map[string]any{
+			"source": "agent_content",
+		})
+	}
+	grantIssuer, err := cfg.grantIssuerStore()
+	if err != nil {
+		return toolErrorResult("not_configured", err.Error(), http.StatusInternalServerError, map[string]any{
+			"source": "download_grant",
+		})
+	}
+
+	actor, err := actorFromAgentID(in.AgentID)
+	if err != nil {
+		return toolErrorResult("invalid_request", err.Error(), http.StatusBadRequest, map[string]any{"source": "ba_install_plan"})
+	}
+	profile := installpack.Profile(in.Client)
+	packID, err := PackIDForAgent(in.AgentID, in.Client)
+	if err != nil {
+		return toolErrorResult("invalid_request", err.Error(), http.StatusBadRequest, map[string]any{"source": "ba_install_plan"})
+	}
+
+	packInput, err := BuildPackInput(ctx, PackInputRequest{
+		ContentStore:     contentStore,
+		InstanceEndpoint: cfg.instanceEndpoint,
+		Namespace:        cfg.normalizedNamespace(),
+		Account:          account,
+		AgentID:          in.AgentID,
+		Actor:            actor,
+		Client:           in.Client,
+		Profile:          profile,
+		PackID:           packID,
+	})
+	if err != nil {
+		return packBuildToolResultFromError(err)
+	}
+
+	pack, err := cfg.render(ctx, packInput.RenderRequest)
+	if err != nil {
+		return toolErrorResult("install_pack_render_failed", "Ba failed to render the local install pack", http.StatusInternalServerError, map[string]any{
+			"source": "installpack",
+		})
+	}
+	if pack == nil || len(pack.ZIPBytes) == 0 || pack.PackChecksum == "" {
+		return toolErrorResult("install_pack_render_failed", "Ba rendered an empty local install pack", http.StatusInternalServerError, map[string]any{
+			"source": "installpack",
+		})
+	}
+
+	binding := downloadgrant.Binding{
+		Account:    account,
+		Actor:      actor,
+		Namespace:  cfg.normalizedNamespace(),
+		Route:      InstallerGrantBoundRoute,
+		Client:     in.Client,
+		Profile:    string(profile),
+		PackID:     packInput.RenderRequest.PackID,
+		PackDigest: packInput.RenderRequest.PackDigest,
+	}
+	issued, err := grantIssuer.Issue(ctx, downloadgrant.IssueInput{Binding: binding})
+	if err != nil {
+		return toolErrorResult("download_grant_issue_failed", "Ba failed to mint the one-time download grant", http.StatusInternalServerError, map[string]any{
+			"source": "download_grant",
+		})
+	}
+	if issued == nil || issued.GrantID == "" || strings.TrimSpace(issued.Token) == "" {
+		return toolErrorResult("download_grant_issue_failed", "Ba minted an incomplete one-time download grant", http.StatusInternalServerError, map[string]any{
+			"source": "download_grant",
+		})
+	}
+	downloadURL, err := DownloadURLForGrant(cfg.instanceEndpoint, issued)
+	if err != nil {
+		return toolErrorResult("download_grant_issue_failed", "Ba failed to build the grant download URL", http.StatusInternalServerError, map[string]any{
+			"source": "download_grant",
+		})
+	}
+
+	slog.InfoContext(ctx, "ba agent_local_install_plan grant minted",
+		"tool", ToolAgentLocalInstallPlan,
+		"account", account,
+		"actor", actor,
+		"client", in.Client,
+		"profile", string(profile),
+		"grant_id", issued.GrantID,
+		"pack_id", packInput.RenderRequest.PackID,
+		"pack_digest", packInput.RenderRequest.PackDigest,
+		"pack_checksum", pack.PackChecksum,
+	)
+
+	return installPlanSuccessResult(account, in.AgentID, actor, in.Client, string(profile), issued, downloadURL, pack)
+}
+
+func (cfg config) content() (AgentContentStore, error) {
+	if cfg.contentStore != nil {
+		return cfg.contentStore, nil
+	}
+	if cfg.contentStoreFactory == nil {
+		return nil, fmt.Errorf("agent content store is not configured")
+	}
+	return cfg.contentStoreFactory()
+}
+
+func (cfg config) grantIssuerStore() (DownloadGrantIssuer, error) {
+	if cfg.grantIssuer != nil {
+		return cfg.grantIssuer, nil
+	}
+	if cfg.grantIssuerFactory == nil {
+		return nil, fmt.Errorf("download grant issuer is not configured")
+	}
+	return cfg.grantIssuerFactory()
+}
+
+func (cfg config) render(ctx context.Context, req installpack.Request) (*installpack.Pack, error) {
+	renderer := cfg.renderer
+	if renderer == nil {
+		renderer = installpack.NewRenderer()
+	}
+	return renderer.Render(ctx, req)
+}
+
+func (cfg config) normalizedNamespace() string {
+	if namespace := strings.ToLower(strings.TrimSpace(cfg.namespace)); namespace != "" {
+		return namespace
+	}
+	return DefaultNamespace
+}
+
+func (cfg config) rateLimit(account string) RateLimitDecision {
+	limiter := cfg.rateLimiter
+	if limiter == nil {
+		return RateLimitDecision{Allowed: true}
+	}
+	now := time.Now().UTC()
+	if cfg.now != nil {
+		now = cfg.now().UTC()
+	}
+	return limiter.Allow(account, now)
+}
+
+func parseAgentLocalInstallPlanInput(args json.RawMessage, account string) (agentLocalInstallPlanInput, *mcpruntime.ToolResult, error) {
+	raw := strings.TrimSpace(string(args))
+	if raw == "" || raw == "null" {
+		raw = "{}"
+	}
+
+	var in agentLocalInstallPlanInput
+	dec := json.NewDecoder(bytes.NewReader([]byte(raw)))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&in); err != nil {
+		return agentLocalInstallPlanInput{}, mustToolErrorResult("invalid_request", "invalid args: "+err.Error(), http.StatusBadRequest, nil), nil
+	}
+	in.AgentID = strings.TrimSpace(in.AgentID)
+	in.Client = normalizeClient(in.Client)
+	in.Profile = normalizeClient(in.Profile)
+	in.ActorUsername = normalizeActorUsername(in.ActorUsername)
+
+	if in.AgentID == "" {
+		return agentLocalInstallPlanInput{}, mustToolErrorResult("invalid_request", "agent_id is required", http.StatusBadRequest, nil), nil
+	}
+	if in.Client == "" {
+		return agentLocalInstallPlanInput{}, mustToolErrorResult("invalid_request", "client is required", http.StatusBadRequest, nil), nil
+	}
+	if !supportedClient(in.Client) {
+		return agentLocalInstallPlanInput{}, mustToolErrorResult("invalid_request", "client must be claude_code or codex", http.StatusBadRequest, nil), nil
+	}
+	if in.Profile != "" && in.Profile != in.Client {
+		return agentLocalInstallPlanInput{}, mustToolErrorResult("invalid_request", "profile must match client when supplied", http.StatusBadRequest, nil), nil
+	}
+	if in.ActorUsername != "" && in.ActorUsername != account {
+		return agentLocalInstallPlanInput{}, mustToolErrorResult("forbidden", "actor_username must match authenticated principal", http.StatusForbidden, map[string]any{
+			"source": "lesser_body_ba",
+		}), nil
+	}
+	return in, nil, nil
+}
+
+func normalizeClient(client string) string {
+	return strings.ToLower(strings.ReplaceAll(strings.TrimSpace(client), "-", "_"))
+}
+
+func supportedClient(client string) bool {
+	switch client {
+	case string(installpack.ProfileClaudeCode), string(installpack.ProfileCodex):
+		return true
+	default:
+		return false
+	}
+}
+
+func authenticatedAccountHolderActor(principal *auth.Principal, toolName string) (string, *mcpruntime.ToolResult, error) {
+	if principal == nil || principal.Type != auth.PrincipalTypeOAuthToken || principal.Claims == nil || principal.Claims.IsAgent {
+		return "", mustToolErrorResult("forbidden", toolName+" requires an account-holder OAuth principal", http.StatusForbidden, map[string]any{
+			"source": "lesser_body_ba",
+		}), nil
+	}
+	actorUsername := normalizeActorUsername(firstNonEmpty(principal.Claims.GetUsername(), principal.Identity))
+	if actorUsername == "" {
+		return "", mustToolErrorResult("forbidden", toolName+" requires an authenticated actor username", http.StatusForbidden, map[string]any{
+			"source": "lesser_body_ba",
+		}), nil
+	}
+	return actorUsername, nil, nil
+}
+
+func principalHasWriteScope(principal *auth.Principal) bool {
+	if principal == nil || principal.Claims == nil {
+		return false
+	}
+	for _, scope := range principal.Claims.Scopes {
+		switch strings.ToLower(strings.TrimSpace(scope)) {
+		case "write", "admin":
+			return true
+		}
+	}
+	return false
+}
+
+func normalizedScopes(scopes []string) []string {
+	out := make([]string, 0, len(scopes))
+	seen := map[string]struct{}{}
+	for _, scope := range scopes {
+		scope = strings.ToLower(strings.TrimSpace(scope))
+		if scope == "" {
+			continue
+		}
+		if _, ok := seen[scope]; ok {
+			continue
+		}
+		seen[scope] = struct{}{}
+		out = append(out, scope)
+	}
+	return out
+}
+
+func normalizeActorUsername(username string) string {
+	return strings.ToLower(strings.TrimSpace(username))
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func additiveMutationToolAnnotations() *mcpruntime.ToolAnnotations {
+	return &mcpruntime.ToolAnnotations{
+		ReadOnlyHint:    boolHint(false),
+		DestructiveHint: boolHint(false),
+		IdempotentHint:  boolHint(false),
+	}
+}
+
+func boolHint(value bool) *bool { return &value }
+
+// PackInputRequest describes a render request assembled from a plan or a
+// consumed download-grant binding.
+type PackInputRequest struct {
+	ContentStore     AgentContentStore
+	InstanceEndpoint string
+	Namespace        string
+	Account          string
+	AgentID          string
+	Actor            string
+	Client           string
+	Profile          installpack.Profile
+	PackID           string
+	PackDigest       string
+}
+
+// PackInput is the resolved deterministic install-pack render request.
+type PackInput struct {
+	RenderRequest installpack.Request
+	SoulRecord    *agentcontent.Record
+	Instructions  *agentcontent.Record
+}
+
+// BuildPackInput reads current account-scoped content and produces an explicit
+// installpack.Request. It never reads host headers or process global state.
+func BuildPackInput(ctx context.Context, in PackInputRequest) (*PackInput, error) {
+	if in.ContentStore == nil {
+		return nil, fmt.Errorf("agent content store is required")
+	}
+	account := normalizeActorUsername(in.Account)
+	if account == "" {
+		return nil, fmt.Errorf("account is required")
+	}
+	agentID := strings.TrimSpace(in.AgentID)
+	if agentID == "" {
+		return nil, fmt.Errorf("agent_id is required")
+	}
+	actor := strings.ToLower(strings.TrimSpace(in.Actor))
+	if actor == "" {
+		var err error
+		actor, err = actorFromAgentID(agentID)
+		if err != nil {
+			return nil, err
+		}
+	}
+	client := normalizeClient(in.Client)
+	if client == "" {
+		client = normalizeClient(string(in.Profile))
+	}
+	if !supportedClient(client) {
+		return nil, fmt.Errorf("client must be claude_code or codex")
+	}
+	profile := in.Profile
+	if profile == "" {
+		profile = installpack.Profile(client)
+	}
+	if normalizeClient(string(profile)) != client {
+		return nil, fmt.Errorf("profile must match client")
+	}
+	stageDomain, err := StageDomainFromInstanceEndpoint(in.InstanceEndpoint)
+	if err != nil {
+		return nil, err
+	}
+	namespace := strings.ToLower(strings.TrimSpace(in.Namespace))
+	if namespace == "" {
+		namespace = DefaultNamespace
+	}
+	packID := strings.TrimSpace(in.PackID)
+	if packID == "" {
+		packID, err = PackIDForAgent(agentID, client)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	soul, err := in.ContentStore.Get(ctx, account, agentID, agentcontent.ContentTypeAgentSoul)
+	if err != nil {
+		return nil, fmt.Errorf("read agent_soul: %w", err)
+	}
+	instructions, err := in.ContentStore.Get(ctx, account, agentID, agentcontent.ContentTypeAgentInstructions)
+	if err != nil {
+		return nil, fmt.Errorf("read agent_instructions: %w", err)
+	}
+	packDigest := strings.TrimSpace(in.PackDigest)
+	if packDigest == "" {
+		packDigest = packInputDigest(account, actor, namespace, agentID, client, soul, instructions)
+	}
+
+	return &PackInput{
+		RenderRequest: installpack.Request{
+			Profile:           profile,
+			StageDomain:       stageDomain,
+			Actor:             actor,
+			Namespace:         namespace,
+			Account:           account,
+			PackID:            packID,
+			PackDigest:        packDigest,
+			AgentSoul:         soul.Content,
+			AgentInstructions: instructions.Content,
+		},
+		SoulRecord:   soul,
+		Instructions: instructions,
+	}, nil
+}
+
+func packBuildToolResultFromError(err error) (*mcpruntime.ToolResult, error) {
+	if err == nil {
+		return nil, nil
+	}
+	details := map[string]any{"source": "ba_install_plan"}
+	switch {
+	case errors.Is(err, agentcontent.ErrContentNotFound):
+		return toolErrorResult("not_found", "required account-scoped agent_soul or agent_instructions content was not found", http.StatusNotFound, details)
+	default:
+		msg := err.Error()
+		if strings.Contains(msg, "stage domain") || strings.Contains(msg, "endpoint") || strings.Contains(msg, EnvInstanceMCPEndpoint) {
+			return toolErrorResult("not_configured", "Ba instance endpoint configuration is invalid", http.StatusInternalServerError, details)
+		}
+		return toolErrorResult("invalid_request", msg, http.StatusBadRequest, details)
+	}
+}
+
+func packInputDigest(account, actor, namespace, agentID, client string, soul *agentcontent.Record, instructions *agentcontent.Record) string {
+	payload := struct {
+		Schema                     string `json:"schema"`
+		Account                    string `json:"account"`
+		Actor                      string `json:"actor"`
+		Namespace                  string `json:"namespace"`
+		AgentID                    string `json:"agent_id"`
+		Client                     string `json:"client"`
+		AgentSoulVersion           int64  `json:"agent_soul_version"`
+		AgentSoulLifecycle         string `json:"agent_soul_lifecycle"`
+		AgentSoulContentHash       string `json:"agent_soul_content_hash"`
+		AgentInstructionsVersion   int64  `json:"agent_instructions_version"`
+		AgentInstructionsLifecycle string `json:"agent_instructions_lifecycle"`
+		AgentInstructionsHash      string `json:"agent_instructions_content_hash"`
+	}{
+		Schema:                     planSchema,
+		Account:                    account,
+		Actor:                      actor,
+		Namespace:                  namespace,
+		AgentID:                    agentID,
+		Client:                     client,
+		AgentSoulVersion:           recordVersion(soul),
+		AgentSoulLifecycle:         recordLifecycle(soul),
+		AgentSoulContentHash:       contentHash(recordContent(soul)),
+		AgentInstructionsVersion:   recordVersion(instructions),
+		AgentInstructionsLifecycle: recordLifecycle(instructions),
+		AgentInstructionsHash:      contentHash(recordContent(instructions)),
+	}
+	b, _ := json.Marshal(payload)
+	return contentHash(string(b))
+}
+
+func recordVersion(record *agentcontent.Record) int64 {
+	if record == nil {
+		return 0
+	}
+	return record.Version
+}
+
+func recordLifecycle(record *agentcontent.Record) string {
+	if record == nil {
+		return ""
+	}
+	return string(record.LifecycleState)
+}
+
+func recordContent(record *agentcontent.Record) string {
+	if record == nil {
+		return ""
+	}
+	return record.Content
+}
+
+func contentHash(content string) string {
+	sum := sha256.Sum256([]byte(content))
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+// PackIDForAgent returns a deterministic pack id that carries the source
+// agent_id needed by the later header-free download route provider.
+func PackIDForAgent(agentID string, client string) (string, error) {
+	agentID = strings.TrimSpace(agentID)
+	if agentID == "" {
+		return "", fmt.Errorf("agent_id is required")
+	}
+	client = normalizeClient(client)
+	if !supportedClient(client) {
+		return "", fmt.Errorf("client must be claude_code or codex")
+	}
+	encoded := base64.RawURLEncoding.EncodeToString([]byte(agentID))
+	return packIDPrefix + client + "/" + encoded, nil
+}
+
+// AgentIDFromPackID reverses PackIDForAgent for the download route provider.
+func AgentIDFromPackID(packID string) (string, error) {
+	packID = strings.TrimSpace(packID)
+	if !strings.HasPrefix(packID, packIDPrefix) {
+		return "", fmt.Errorf("pack_id is not a Ba local-install pack id")
+	}
+	rest := strings.TrimPrefix(packID, packIDPrefix)
+	parts := strings.Split(rest, "/")
+	if len(parts) != 2 || !supportedClient(parts[0]) || strings.TrimSpace(parts[1]) == "" {
+		return "", fmt.Errorf("pack_id is not a valid Ba local-install pack id")
+	}
+	decoded, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil || strings.TrimSpace(string(decoded)) == "" {
+		return "", fmt.Errorf("pack_id is not a valid Ba local-install pack id")
+	}
+	return strings.TrimSpace(string(decoded)), nil
+}
+
+func actorFromAgentID(agentID string) (string, error) {
+	agentID = strings.TrimSpace(agentID)
+	if agentID == "" {
+		return "", fmt.Errorf("agent_id is required")
+	}
+	candidate := agentID
+	if u, err := url.Parse(agentID); err == nil && u.Scheme != "" && u.Host != "" {
+		parts := strings.Split(strings.Trim(u.EscapedPath(), "/"), "/")
+		if len(parts) > 0 {
+			candidate, _ = url.PathUnescape(parts[len(parts)-1])
+		}
+	}
+	candidate = strings.ToLower(strings.TrimSpace(candidate))
+	if candidate == "" || strings.ContainsAny(candidate, "/\\?#") || strings.Contains(candidate, "..") {
+		return "", fmt.Errorf("agent_id must identify a single safe actor path segment or URL with a safe final path segment")
+	}
+	for _, r := range candidate {
+		if r <= 0x20 || r == 0x7f {
+			return "", fmt.Errorf("agent_id must identify a single safe actor path segment")
+		}
+	}
+	if url.PathEscape(candidate) != candidate {
+		return "", fmt.Errorf("agent_id must identify a single safe actor path segment")
+	}
+	return candidate, nil
+}
+
+// StageDomainFromInstanceEndpoint derives the stage domain from the CDK-injected
+// instance endpoint template. It intentionally does not inspect request Host or
+// forwarded headers.
+func StageDomainFromInstanceEndpoint(endpoint string) (string, error) {
+	u, err := parseInstanceEndpoint(endpoint)
+	if err != nil {
+		return "", err
+	}
+	host := strings.ToLower(strings.TrimSpace(u.Hostname()))
+	if !strings.HasPrefix(host, "api.") {
+		return "", fmt.Errorf("%s host must start with api.", EnvInstanceMCPEndpoint)
+	}
+	stageDomain := strings.TrimPrefix(host, "api.")
+	if stageDomain == "" || !strings.Contains(stageDomain, ".") {
+		return "", fmt.Errorf("%s host must include a stage domain", EnvInstanceMCPEndpoint)
+	}
+	return stageDomain, nil
+}
+
+func parseInstanceEndpoint(endpoint string) (*url.URL, error) {
+	endpoint = strings.TrimSpace(endpoint)
+	if endpoint == "" {
+		return nil, fmt.Errorf("%s is required", EnvInstanceMCPEndpoint)
+	}
+	u, err := url.Parse(endpoint)
+	if err != nil || u.Scheme != "https" || strings.TrimSpace(u.Host) == "" {
+		return nil, fmt.Errorf("%s must be an https URL", EnvInstanceMCPEndpoint)
+	}
+	return u, nil
+}
+
+// DownloadURLForGrant builds the header-free one-time download URL. The raw
+// grant token is included only in this returned URL and is never persisted by
+// internal/downloadgrant or logged by this package.
+func DownloadURLForGrant(instanceEndpoint string, issued *downloadgrant.IssuedGrant) (string, error) {
+	if issued == nil {
+		return "", fmt.Errorf("issued grant is required")
+	}
+	u, err := parseInstanceEndpoint(instanceEndpoint)
+	if err != nil {
+		return "", err
+	}
+	grantID := strings.TrimSpace(issued.GrantID)
+	token := strings.TrimSpace(issued.Token)
+	if grantID == "" || token == "" {
+		return "", fmt.Errorf("issued grant id and token are required")
+	}
+	u.Path = "/instance/downloads/installer-grants/" + url.PathEscape(grantID)
+	u.RawQuery = ""
+	u.Fragment = ""
+	q := u.Query()
+	q.Set("token", token)
+	q.Set("account", issued.Binding.Account)
+	q.Set("actor", issued.Binding.Actor)
+	q.Set("namespace", issued.Binding.Namespace)
+	q.Set("client", issued.Binding.Client)
+	q.Set("profile", issued.Binding.Profile)
+	q.Set("pack_id", issued.Binding.PackID)
+	q.Set("pack_digest", issued.Binding.PackDigest)
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}
+
+func installPlanSuccessResult(account string, agentID string, actor string, client string, profile string, issued *downloadgrant.IssuedGrant, downloadURL string, pack *installpack.Pack) (*mcpruntime.ToolResult, error) {
+	expiresAt := formatTime(issued.ExpiresAt)
+	manifestEntries, err := jsonMapSlice(pack.Manifest.ManifestEntries)
+	if err != nil {
+		return nil, err
+	}
+	mergeInstructions, err := jsonMapSlice(pack.Manifest.MergeInstructions)
+	if err != nil {
+		return nil, err
+	}
+	installMarker, err := jsonMap(pack.Manifest.InstallMarker)
+	if err != nil {
+		return nil, err
+	}
+	manifest, err := jsonMap(pack.Manifest)
+	if err != nil {
+		return nil, err
+	}
+
+	resource := map[string]any{
+		"uri":                           downloadURL,
+		"download_url":                  downloadURL,
+		"method":                        "GET",
+		"media_type":                    "application/zip",
+		"mime_type":                     "application/zip",
+		"resource_kind":                 "installer_grant_download",
+		"grant_id":                      issued.GrantID,
+		"expires_at":                    expiresAt,
+		"requires_authorization_header": false,
+		"query_binding": map[string]any{
+			"account":     issued.Binding.Account,
+			"actor":       issued.Binding.Actor,
+			"namespace":   issued.Binding.Namespace,
+			"route":       issued.Binding.Route,
+			"client":      issued.Binding.Client,
+			"profile":     issued.Binding.Profile,
+			"pack_id":     issued.Binding.PackID,
+			"pack_digest": issued.Binding.PackDigest,
+		},
+	}
+	verificationSteps := []string{
+		"Download the ZIP from install_pack_resource.uri before expires_at; do not add Authorization headers to the grant URL.",
+		"Compute SHA-256 over the downloaded ZIP bytes and compare it to pack_checksum.",
+		"Read MANIFEST.json from the ZIP and confirm schema, pack_id, pack_digest, mcp_server_name, and mcp_endpoint_url match this plan.",
+		"For every manifest_entries item, compute SHA-256 over that ZIP entry and compare it to checksum before writing local files.",
+		"Review merge_instructions and update_guidance locally; the server never writes to the caller filesystem.",
+	}
+	updateGuidance := []map[string]any{
+		{"action": "detect_existing_marker", "path": pack.Manifest.InstallMarker.Path, "description": "If an existing marker is present, compare mcp_server_name, pack_id, and pack_digest before replacing local files."},
+		{"action": "merge_not_overwrite", "path": ".mcp.json", "description": "Merge the server entry keyed by mcp_server_name rather than replacing unrelated MCP client configuration."},
+	}
+
+	data := map[string]any{
+		"schema":                planSchema,
+		"account":               account,
+		"agent_id":              agentID,
+		"actor":                 actor,
+		"client":                client,
+		"profile":               profile,
+		"grant_id":              issued.GrantID,
+		"expires_at":            expiresAt,
+		"download_url":          downloadURL,
+		"install_pack_resource": resource,
+		"resource_metadata":     resource,
+		"pack_id":               pack.Manifest.PackID,
+		"pack_digest":           pack.Manifest.PackDigest,
+		"pack_checksum":         pack.PackChecksum,
+		"mcp_server_name":       pack.MCPServerName,
+		"mcp_endpoint_url":      pack.MCPEndpointURL,
+		"manifest":              manifest,
+		"manifest_entries":      manifestEntries,
+		"marker_metadata":       installMarker,
+		"install_marker":        installMarker,
+		"merge_instructions":    mergeInstructions,
+		"update_guidance":       updateGuidance,
+		"verification_steps":    verificationSteps,
+	}
+	text := map[string]any{
+		"summary":           "Ba local-install plan prepared with a one-time installer grant",
+		"grant_id":          issued.GrantID,
+		"expires_at":        expiresAt,
+		"pack_checksum":     pack.PackChecksum,
+		"pack_digest":       pack.Manifest.PackDigest,
+		"mcp_server_name":   pack.MCPServerName,
+		"download_location": "structuredContent.data.install_pack_resource.uri",
+		"data":              map[string]any{"location": "structuredContent.data"},
+	}
+	return toolJSONTextResult(text, map[string]any{"data": data})
+}
+
+func jsonMap(value any) (map[string]any, error) {
+	b, err := json.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+	var out map[string]any
+	if err := json.Unmarshal(b, &out); err != nil {
+		return nil, err
+	}
+	if out == nil {
+		out = map[string]any{}
+	}
+	return out, nil
+}
+
+func jsonMapSlice(value any) ([]map[string]any, error) {
+	b, err := json.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+	var out []map[string]any
+	if err := json.Unmarshal(b, &out); err != nil {
+		return nil, err
+	}
+	if out == nil {
+		out = []map[string]any{}
+	}
+	return out, nil
+}
+
+func toolJSONTextResult(text any, structured map[string]any) (*mcpruntime.ToolResult, error) {
+	b, err := json.Marshal(text)
+	if err != nil {
+		return nil, fmt.Errorf("marshal tool result text: %w", err)
+	}
+	return &mcpruntime.ToolResult{
+		Content: []mcpruntime.ContentBlock{{
+			Type: "text",
+			Text: string(b),
+		}},
+		StructuredContent: structured,
+	}, nil
+}
+
+func toolErrorResult(code string, message string, status int, details map[string]any) (*mcpruntime.ToolResult, error) {
+	payload := map[string]any{
+		"code":    firstNonEmpty(strings.TrimSpace(code), "unknown_error"),
+		"message": firstNonEmpty(strings.TrimSpace(message), "error"),
+	}
+	if status != 0 {
+		payload["status"] = status
+	}
+	if len(details) > 0 {
+		payload["details"] = details
+	}
+	return toolErrorResultPayload(payload)
+}
+
+func mustToolErrorResult(code string, message string, status int, details map[string]any) *mcpruntime.ToolResult {
+	res, err := toolErrorResult(code, message, status, details)
+	if err != nil {
+		panic(err)
+	}
+	return res
+}
+
+func toolErrorResultPayload(payload map[string]any) (*mcpruntime.ToolResult, error) {
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("marshal tool error: %w", err)
+	}
+	return &mcpruntime.ToolResult{
+		Content: []mcpruntime.ContentBlock{{Type: "text", Text: string(b)}},
+		IsError: true,
+		StructuredContent: map[string]any{
+			"error": payload,
+		},
+	}, nil
+}
+
+func formatTime(value time.Time) string {
+	if value.IsZero() {
+		return ""
+	}
+	return value.UTC().Format(time.RFC3339Nano)
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+// RateLimitDecision describes a process-local grant minting rate decision.
+type RateLimitDecision struct {
+	Allowed   bool
+	Limit     int
+	Remaining int
+	Window    time.Duration
+	ResetAt   time.Time
+}
+
+// GrantMintLimiter guards account-scoped one-time grant minting.
+type GrantMintLimiter interface {
+	Allow(account string, now time.Time) RateLimitDecision
+}
+
+// InMemoryGrantMintLimiter is a bounded, process-local limiter for this
+// foundation slice. It does not coordinate across Lambda execution environments
+// and is therefore a safety backstop, not a durable quota system.
+type InMemoryGrantMintLimiter struct {
+	mu     sync.Mutex
+	limit  int
+	window time.Duration
+	hits   map[string][]time.Time
+}
+
+// NewInMemoryGrantMintLimiter creates a process-local per-account limiter.
+func NewInMemoryGrantMintLimiter(limit int, window time.Duration) *InMemoryGrantMintLimiter {
+	if limit <= 0 {
+		limit = defaultRateLimit
+	}
+	if window <= 0 {
+		window = defaultRateWindow
+	}
+	return &InMemoryGrantMintLimiter{limit: limit, window: window, hits: map[string][]time.Time{}}
+}
+
+func (l *InMemoryGrantMintLimiter) Allow(account string, now time.Time) RateLimitDecision {
+	if l == nil {
+		return RateLimitDecision{Allowed: true}
+	}
+	account = normalizeActorUsername(account)
+	if account == "" {
+		return RateLimitDecision{Allowed: false, Limit: l.limit, Window: l.window, ResetAt: now.Add(l.window)}
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	cutoff := now.Add(-l.window)
+	kept := l.hits[account][:0]
+	for _, hit := range l.hits[account] {
+		if hit.After(cutoff) {
+			kept = append(kept, hit)
+		}
+	}
+	l.hits[account] = kept
+	if len(kept) >= l.limit {
+		reset := kept[0].Add(l.window)
+		return RateLimitDecision{Allowed: false, Limit: l.limit, Remaining: 0, Window: l.window, ResetAt: reset}
+	}
+	l.hits[account] = append(kept, now)
+	return RateLimitDecision{Allowed: true, Limit: l.limit, Remaining: l.limit - len(l.hits[account]), Window: l.window, ResetAt: now.Add(l.window)}
+}

--- a/internal/baserver/baserver_test.go
+++ b/internal/baserver/baserver_test.go
@@ -1,0 +1,407 @@
+package baserver
+
+import (
+	"context"
+	"encoding/json"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/equaltoai/lesser-body/internal/agentcontent"
+	"github.com/equaltoai/lesser-body/internal/auth"
+	"github.com/equaltoai/lesser-body/internal/downloadgrant"
+	"github.com/golang-jwt/jwt/v5"
+	mcpruntime "github.com/theory-cloud/apptheory/runtime/mcp"
+)
+
+const testInstanceEndpoint = "https://api.dev.example.com/instance/{surface}/mcp"
+
+func TestRegisterToolsRegistersAgentLocalInstallPlan(t *testing.T) {
+	registry := mcpruntime.NewToolRegistry()
+	if err := RegisterTools(registry); err != nil {
+		t.Fatalf("RegisterTools: %v", err)
+	}
+	tools := registry.List()
+	if got, want := len(tools), 1; got != want {
+		t.Fatalf("tool count = %d, want %d", got, want)
+	}
+	def := tools[0]
+	if def.Name != ToolAgentLocalInstallPlan {
+		t.Fatalf("tool name = %q, want %q", def.Name, ToolAgentLocalInstallPlan)
+	}
+	if def.Annotations == nil || def.Annotations.ReadOnlyHint == nil || *def.Annotations.ReadOnlyHint {
+		t.Fatalf("agent_local_install_plan must be write/additive: %+v", def.Annotations)
+	}
+	if def.Annotations.DestructiveHint == nil || *def.Annotations.DestructiveHint {
+		t.Fatalf("agent_local_install_plan must be non-destructive grant minting: %+v", def.Annotations)
+	}
+	if def.Annotations.IdempotentHint == nil || *def.Annotations.IdempotentHint {
+		t.Fatalf("agent_local_install_plan is not idempotent because it mints grants: %+v", def.Annotations)
+	}
+
+	var schema struct {
+		Required []string                   `json:"required"`
+		Props    map[string]json.RawMessage `json:"properties"`
+	}
+	if err := json.Unmarshal(def.InputSchema, &schema); err != nil {
+		t.Fatalf("input schema invalid json: %v", err)
+	}
+	for _, required := range []string{"agent_id", "client"} {
+		if !contains(schema.Required, required) {
+			t.Fatalf("input schema required = %v, missing %s", schema.Required, required)
+		}
+	}
+	for _, prop := range []string{"actor_username", "profile"} {
+		if _, ok := schema.Props[prop]; !ok {
+			t.Fatalf("input schema missing %s", prop)
+		}
+	}
+	if !strings.Contains(string(schema.Props["client"]), "claude_code") || !strings.Contains(string(schema.Props["client"]), "codex") {
+		t.Fatalf("client schema does not advertise supported clients: %s", string(schema.Props["client"]))
+	}
+}
+
+func TestAgentLocalInstallPlanMintsGrantEnvelopeWithoutTextTokenLeak(t *testing.T) {
+	content := newFakeContentStore("owner", "agent-one")
+	issuer := &fakeGrantIssuer{expiresAt: time.Date(2026, 7, 15, 21, 0, 0, 0, time.UTC)}
+	registry := mcpruntime.NewToolRegistry()
+	if err := RegisterTools(registry,
+		WithAgentContentStore(content),
+		WithDownloadGrantIssuer(issuer),
+		WithInstanceEndpoint(testInstanceEndpoint),
+		WithNamespace("equaltoai"),
+		WithRateLimiter(NewInMemoryGrantMintLimiter(10, time.Minute)),
+	); err != nil {
+		t.Fatalf("RegisterTools: %v", err)
+	}
+
+	result, err := registry.Call(toolContext("Owner", []string{"write"}), ToolAgentLocalInstallPlan, json.RawMessage(`{
+		"agent_id":" agent-one ",
+		"client":"codex",
+		"profile":"codex",
+		"actor_username":"owner"
+	}`))
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if result == nil || result.IsError {
+		t.Fatalf("result = %+v", result)
+	}
+	if issuer.calls != 1 {
+		t.Fatalf("grant issuer calls = %d, want 1", issuer.calls)
+	}
+	binding := issuer.inputs[0].Binding
+	if binding.Account != "owner" || binding.Actor != "agent-one" || binding.Namespace != "equaltoai" || binding.Route != InstallerGrantBoundRoute || binding.Client != "codex" || binding.Profile != "codex" {
+		t.Fatalf("grant binding = %+v", binding)
+	}
+	if !strings.HasPrefix(binding.PackID, packIDPrefix+"codex/") {
+		t.Fatalf("pack id = %q, want Ba codex prefix", binding.PackID)
+	}
+	if gotAgentID, err := AgentIDFromPackID(binding.PackID); err != nil || gotAgentID != "agent-one" {
+		t.Fatalf("AgentIDFromPackID(%q) = %q/%v, want agent-one", binding.PackID, gotAgentID, err)
+	}
+	if !strings.HasPrefix(binding.PackDigest, "sha256:") {
+		t.Fatalf("pack digest = %q, want sha256", binding.PackDigest)
+	}
+
+	data := toolData(t, result)
+	if data["schema"] != planSchema || data["grant_id"] != "dg_test" || data["mcp_server_name"] == "" {
+		t.Fatalf("plan identity fields = %+v", data)
+	}
+	if data["pack_digest"] != binding.PackDigest {
+		t.Fatalf("pack_digest = %q, want binding digest %q", data["pack_digest"], binding.PackDigest)
+	}
+	packChecksum, _ := data["pack_checksum"].(string)
+	if !strings.HasPrefix(packChecksum, "sha256:") {
+		t.Fatalf("pack_checksum = %q, want sha256", packChecksum)
+	}
+	if data["mcp_endpoint_url"] != "https://api.dev.example.com/mcp/agent-one" {
+		t.Fatalf("mcp_endpoint_url = %q", data["mcp_endpoint_url"])
+	}
+	entries, _ := data["manifest_entries"].([]map[string]any)
+	if len(entries) == 0 {
+		t.Fatalf("manifest_entries empty: %+v", data["manifest_entries"])
+	}
+	merge, _ := data["merge_instructions"].([]map[string]any)
+	if len(merge) == 0 {
+		t.Fatalf("merge_instructions empty")
+	}
+	if steps, ok := data["verification_steps"].([]string); !ok || len(steps) == 0 {
+		t.Fatalf("verification_steps = %#v", data["verification_steps"])
+	}
+
+	downloadURL, _ := data["download_url"].(string)
+	parsed, err := url.Parse(downloadURL)
+	if err != nil {
+		t.Fatalf("download_url parse: %v", err)
+	}
+	if parsed.Scheme != "https" || parsed.Host != "api.dev.example.com" || parsed.Path != "/instance/downloads/installer-grants/dg_test" {
+		t.Fatalf("download_url = %s", downloadURL)
+	}
+	q := parsed.Query()
+	if q.Get("token") != "raw-plan-token" {
+		t.Fatalf("download token query = %q, want raw token", q.Get("token"))
+	}
+	for key, want := range map[string]string{
+		"account":     binding.Account,
+		"actor":       binding.Actor,
+		"namespace":   binding.Namespace,
+		"client":      binding.Client,
+		"profile":     binding.Profile,
+		"pack_id":     binding.PackID,
+		"pack_digest": binding.PackDigest,
+	} {
+		if got := q.Get(key); got != want {
+			t.Fatalf("download query %s = %q, want %q", key, got, want)
+		}
+	}
+	resource := data["install_pack_resource"].(map[string]any)
+	if resource["uri"] != downloadURL || resource["requires_authorization_header"] != false || resource["media_type"] != "application/zip" {
+		t.Fatalf("install_pack_resource = %+v", resource)
+	}
+
+	text := result.Content[0].Text
+	for _, forbidden := range []string{"raw-plan-token", "draft soul content", "follow the operator", "tokenHash", "sha256:token"} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("text result leaked forbidden material %q: %s", forbidden, text)
+		}
+	}
+}
+
+func TestAgentLocalInstallPlanRejectsUnauthorizedPrincipalsBeforeSideEffects(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		ctx  context.Context
+		code string
+	}{
+		{name: "read only", ctx: toolContext("owner", []string{"read"}), code: "insufficient_scope"},
+		{name: "agent principal", ctx: toolContextWithAgent("owner", []string{"write"}, true), code: "forbidden"},
+		{name: "legacy instance key", ctx: auth.InjectToolContext(context.Background(), &auth.Principal{Type: auth.PrincipalTypeInstanceKey, Identity: "instance"}, "legacy-key"), code: "forbidden"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			issuer := &fakeGrantIssuer{expiresAt: time.Date(2026, 7, 15, 21, 0, 0, 0, time.UTC)}
+			registry := mcpruntime.NewToolRegistry()
+			if err := RegisterTools(registry,
+				WithAgentContentStore(newFakeContentStore("owner", "agent-one")),
+				WithDownloadGrantIssuer(issuer),
+				WithInstanceEndpoint(testInstanceEndpoint),
+			); err != nil {
+				t.Fatalf("RegisterTools: %v", err)
+			}
+
+			result, err := registry.Call(tc.ctx, ToolAgentLocalInstallPlan, json.RawMessage(`{"agent_id":"agent-one","client":"codex"}`))
+			if err != nil {
+				t.Fatalf("Call: %v", err)
+			}
+			payload := toolError(t, result)
+			if payload["code"] != tc.code {
+				t.Fatalf("error code = %q, want %q payload=%+v", payload["code"], tc.code, payload)
+			}
+			if issuer.calls != 0 {
+				t.Fatalf("grant issuer calls = %d, want 0", issuer.calls)
+			}
+		})
+	}
+}
+
+func TestAgentLocalInstallPlanRejectsActorMismatchBeforeGrant(t *testing.T) {
+	issuer := &fakeGrantIssuer{expiresAt: time.Date(2026, 7, 15, 21, 0, 0, 0, time.UTC)}
+	registry := mcpruntime.NewToolRegistry()
+	if err := RegisterTools(registry,
+		WithAgentContentStore(newFakeContentStore("owner", "agent-one")),
+		WithDownloadGrantIssuer(issuer),
+		WithInstanceEndpoint(testInstanceEndpoint),
+	); err != nil {
+		t.Fatalf("RegisterTools: %v", err)
+	}
+
+	result, err := registry.Call(toolContext("owner", []string{"write"}), ToolAgentLocalInstallPlan, json.RawMessage(`{"agent_id":"agent-one","client":"codex","actor_username":"other"}`))
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	payload := toolError(t, result)
+	if payload["code"] != "forbidden" {
+		t.Fatalf("error payload = %+v", payload)
+	}
+	if issuer.calls != 0 {
+		t.Fatalf("grant issuer calls = %d, want 0", issuer.calls)
+	}
+}
+
+func TestAgentLocalInstallPlanEnforcesPerAccountInProcessRateCap(t *testing.T) {
+	issuer := &fakeGrantIssuer{expiresAt: time.Date(2026, 7, 15, 21, 0, 0, 0, time.UTC)}
+	registry := mcpruntime.NewToolRegistry()
+	if err := RegisterTools(registry,
+		WithAgentContentStore(newFakeContentStore("owner", "agent-one")),
+		WithDownloadGrantIssuer(issuer),
+		WithInstanceEndpoint(testInstanceEndpoint),
+		WithRateLimiter(NewInMemoryGrantMintLimiter(1, time.Minute)),
+	); err != nil {
+		t.Fatalf("RegisterTools: %v", err)
+	}
+	ctx := toolContext("owner", []string{"write"})
+	args := json.RawMessage(`{"agent_id":"agent-one","client":"codex"}`)
+	first, err := registry.Call(ctx, ToolAgentLocalInstallPlan, args)
+	if err != nil || first == nil || first.IsError {
+		t.Fatalf("first call result=%+v err=%v", first, err)
+	}
+	second, err := registry.Call(ctx, ToolAgentLocalInstallPlan, args)
+	if err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	payload := toolError(t, second)
+	if payload["code"] != "rate_limited" || statusValue(payload["status"]) != 429 {
+		t.Fatalf("rate limit payload = %+v", payload)
+	}
+	if issuer.calls != 1 {
+		t.Fatalf("grant issuer calls = %d, want 1", issuer.calls)
+	}
+}
+
+func TestPackIDEndpointAndActorDerivation(t *testing.T) {
+	packID, err := PackIDForAgent("https://lesser.example/users/Ptah_Agent", "claude-code")
+	if err != nil {
+		t.Fatalf("PackIDForAgent: %v", err)
+	}
+	agentID, err := AgentIDFromPackID(packID)
+	if err != nil || agentID != "https://lesser.example/users/Ptah_Agent" {
+		t.Fatalf("AgentIDFromPackID = %q/%v", agentID, err)
+	}
+	actor, err := actorFromAgentID(agentID)
+	if err != nil || actor != "ptah_agent" {
+		t.Fatalf("actorFromAgentID = %q/%v, want ptah_agent", actor, err)
+	}
+	stageDomain, err := StageDomainFromInstanceEndpoint(testInstanceEndpoint)
+	if err != nil || stageDomain != "dev.example.com" {
+		t.Fatalf("StageDomainFromInstanceEndpoint = %q/%v", stageDomain, err)
+	}
+}
+
+type fakeGrantIssuer struct {
+	calls     int
+	inputs    []downloadgrant.IssueInput
+	expiresAt time.Time
+}
+
+func (f *fakeGrantIssuer) Issue(_ context.Context, in downloadgrant.IssueInput) (*downloadgrant.IssuedGrant, error) {
+	f.calls++
+	f.inputs = append(f.inputs, in)
+	return &downloadgrant.IssuedGrant{
+		Binding:        in.Binding,
+		GrantID:        "dg_test",
+		Token:          "raw-plan-token",
+		ExpiresAt:      f.expiresAt,
+		ExpiresAtEpoch: f.expiresAt.Unix(),
+	}, nil
+}
+
+type fakeContentStore struct {
+	records map[string]*agentcontent.Record
+	calls   []string
+}
+
+func newFakeContentStore(account, agentID string) *fakeContentStore {
+	return &fakeContentStore{records: map[string]*agentcontent.Record{
+		key(account, agentID, agentcontent.ContentTypeAgentSoul): {
+			Account:            account,
+			AgentID:            agentID,
+			Type:               agentcontent.ContentTypeAgentSoul,
+			Content:            "draft soul content",
+			Version:            3,
+			LifecycleState:     agentcontent.LifecycleStateDraft,
+			CreatedAt:          time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC),
+			UpdatedAt:          time.Date(2026, 7, 15, 12, 30, 0, 0, time.UTC),
+			UpdatedBySubjectID: "subject-owner",
+		},
+		key(account, agentID, agentcontent.ContentTypeAgentInstructions): {
+			Account:            account,
+			AgentID:            agentID,
+			Type:               agentcontent.ContentTypeAgentInstructions,
+			Content:            "follow the operator",
+			Version:            4,
+			LifecycleState:     agentcontent.LifecycleStateDraft,
+			CreatedAt:          time.Date(2026, 7, 15, 12, 1, 0, 0, time.UTC),
+			UpdatedAt:          time.Date(2026, 7, 15, 12, 31, 0, 0, time.UTC),
+			UpdatedBySubjectID: "subject-owner",
+		},
+	}}
+}
+
+func (f *fakeContentStore) Get(_ context.Context, account string, agentID string, contentType agentcontent.ContentType) (*agentcontent.Record, error) {
+	f.calls = append(f.calls, key(account, agentID, contentType))
+	record := f.records[key(account, agentID, contentType)]
+	if record == nil {
+		return nil, agentcontent.ErrContentNotFound
+	}
+	clone := *record
+	return &clone, nil
+}
+
+func key(account, agentID string, contentType agentcontent.ContentType) string {
+	return strings.ToLower(strings.TrimSpace(account)) + "\x00" + strings.TrimSpace(agentID) + "\x00" + string(contentType)
+}
+
+func toolContext(username string, scopes []string) context.Context {
+	return toolContextWithAgent(username, scopes, false)
+}
+
+func toolContextWithAgent(username string, scopes []string, isAgent bool) context.Context {
+	subject := "subject-" + strings.ToLower(strings.TrimSpace(username))
+	return auth.InjectToolContext(context.Background(), &auth.Principal{
+		Type:     auth.PrincipalTypeOAuthToken,
+		Identity: username,
+		Claims: &auth.Claims{
+			RegisteredClaims: jwt.RegisteredClaims{Subject: subject},
+			Username:         username,
+			Scopes:           scopes,
+			IsAgent:          isAgent,
+		},
+	}, "owner-oauth-token")
+}
+
+func toolData(t *testing.T, result *mcpruntime.ToolResult) map[string]any {
+	t.Helper()
+	if result == nil || result.StructuredContent == nil {
+		t.Fatalf("missing structured content: %+v", result)
+	}
+	data, ok := result.StructuredContent["data"].(map[string]any)
+	if !ok {
+		t.Fatalf("structured data = %#v", result.StructuredContent["data"])
+	}
+	return data
+}
+
+func toolError(t *testing.T, result *mcpruntime.ToolResult) map[string]any {
+	t.Helper()
+	if result == nil || !result.IsError {
+		t.Fatalf("result IsError=false: %+v", result)
+	}
+	payload, ok := result.StructuredContent["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("error payload = %#v", result.StructuredContent["error"])
+	}
+	return payload
+}
+
+func contains(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}
+
+func statusValue(value any) int {
+	switch v := value.(type) {
+	case int:
+		return v
+	case int64:
+		return int(v)
+	case float64:
+		return int(v)
+	default:
+		return 0
+	}
+}

--- a/internal/instanceapp/app.go
+++ b/internal/instanceapp/app.go
@@ -9,6 +9,7 @@ import (
 	"unsafe"
 
 	"github.com/equaltoai/lesser-body/internal/auth"
+	"github.com/equaltoai/lesser-body/internal/baserver"
 	"github.com/equaltoai/lesser-body/internal/ptahserver"
 	apptheory "github.com/theory-cloud/apptheory/runtime"
 	mcpruntime "github.com/theory-cloud/apptheory/runtime/mcp"
@@ -35,6 +36,9 @@ func New(name, version string, custom ...Option) (*apptheory.App, error) {
 		return nil, err
 	}
 	ba := newPlaneServer(name, version, SurfaceBa)
+	if err := baserver.RegisterTools(ba.Registry(), opts.baToolOptions...); err != nil {
+		return nil, err
+	}
 
 	app := apptheory.New(
 		apptheory.WithAuthHook(auth.Hook(slog.Default())),

--- a/internal/instanceapp/app_test.go
+++ b/internal/instanceapp/app_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/equaltoai/lesser-body/internal/agentregistry"
 	"github.com/equaltoai/lesser-body/internal/auth"
+	"github.com/equaltoai/lesser-body/internal/baserver"
 	"github.com/equaltoai/lesser-body/internal/instanceapp"
 	"github.com/equaltoai/lesser-body/internal/lesserapi"
 	"github.com/equaltoai/lesser-body/internal/ptahserver"
@@ -45,7 +46,7 @@ func TestInstancePlaneMCP_InitializeAndToolsList(t *testing.T) {
 		wantTools  []string
 	}{
 		{name: "ptah", path: "/instance/ptah/mcp", serverName: "lesser-body-instance-ptah", wantTools: []string{"agent_bind_soul", "agent_create", "agent_get", "agent_list", "agent_soul_get", "agent_soul_upsert", "agent_soul_archive", "agent_instructions_get", "agent_instructions_upsert", "agent_instructions_archive"}},
-		{name: "ba", path: "/instance/ba/mcp", serverName: "lesser-body-instance-ba", wantTools: []string{}},
+		{name: "ba", path: "/instance/ba/mcp", serverName: "lesser-body-instance-ba", wantTools: []string{baserver.ToolAgentLocalInstallPlan}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			token := newTestTokenWithAudience(t, "test-secret", "agent1", []string{"read"}, audienceForPath(tc.path))
@@ -104,6 +105,12 @@ func TestInstancePlaneMCP_InitializeAndToolsList(t *testing.T) {
 			}
 			if got := toolNames(listBody.Result.Tools); !reflect.DeepEqual(got, tc.wantTools) {
 				t.Fatalf("tools/list names = %v, want %v", got, tc.wantTools)
+			}
+			if tc.name == "ba" {
+				def := listBody.Result.Tools[0]
+				if def.Name != baserver.ToolAgentLocalInstallPlan || def.Annotations == nil || def.Annotations.ReadOnlyHint == nil || *def.Annotations.ReadOnlyHint || def.Annotations.DestructiveHint == nil || *def.Annotations.DestructiveHint || def.Annotations.IdempotentHint == nil || *def.Annotations.IdempotentHint {
+					t.Fatalf("agent_local_install_plan annotations not write/additive: %+v", def)
+				}
 			}
 			if tc.name == "ptah" {
 				def := listBody.Result.Tools[0]
@@ -556,8 +563,38 @@ func TestInstancePlaneMCP_RejectsDisallowedPrincipals(t *testing.T) {
 			wantErr: "instance_principal_not_allowed",
 		},
 		{
+			name: "agent delegated OAuth token on ba",
+			path: "/instance/ba/mcp",
+			setup: func(t testing.TB) map[string][]string {
+				t.Helper()
+				t.Setenv("JWT_SECRET", "test-secret")
+				t.Setenv("JWT_SECRET_ARN", "")
+				auth.ResetForTests()
+				token := newTestTokenWithAudienceAndAgent(t, "test-secret", "agent1", []string{"write"}, audienceForPath("/instance/ba/mcp"), true)
+				return bearerHeaders(token)
+			},
+			want:    403,
+			wantErr: "instance_principal_not_allowed",
+		},
+		{
 			name: "legacy managed instance key despite compatibility flag",
 			path: "/instance/ptah/mcp",
+			setup: func(t testing.TB) map[string][]string {
+				t.Helper()
+				t.Setenv("JWT_SECRET", "")
+				t.Setenv("JWT_SECRET_ARN", "")
+				t.Setenv("LESSER_HOST_INSTANCE_KEY", "legacy-instance-key")
+				t.Setenv("LESSER_HOST_INSTANCE_KEY_ARN", "")
+				t.Setenv("MCP_ALLOW_LEGACY_INSTANCE_KEY", "true")
+				auth.ResetForTests()
+				return bearerHeaders("legacy-instance-key")
+			},
+			want:    403,
+			wantErr: "instance_principal_not_allowed",
+		},
+		{
+			name: "legacy managed instance key on ba despite compatibility flag",
+			path: "/instance/ba/mcp",
 			setup: func(t testing.TB) map[string][]string {
 				t.Helper()
 				t.Setenv("JWT_SECRET", "")

--- a/internal/instanceapp/ba_install_plan_test.go
+++ b/internal/instanceapp/ba_install_plan_test.go
@@ -1,0 +1,204 @@
+package instanceapp_test
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/equaltoai/lesser-body/internal/agentcontent"
+	"github.com/equaltoai/lesser-body/internal/auth"
+	"github.com/equaltoai/lesser-body/internal/baserver"
+	"github.com/equaltoai/lesser-body/internal/installpack"
+	"github.com/equaltoai/lesser-body/internal/instanceapp"
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+	"github.com/theory-cloud/apptheory/testkit"
+)
+
+func TestInstancePlaneMCP_BaAgentLocalInstallPlanDownloadVerifyReplay(t *testing.T) {
+	const endpoint = "https://api.dev.example.com/instance/{surface}/mcp"
+	t.Setenv("JWT_SECRET", "test-secret")
+	t.Setenv(baserver.EnvInstanceMCPEndpoint, endpoint)
+	auth.ResetForTests()
+
+	grantStore := newDownloadGrantStore(t)
+	content := newBaPlanContentStore("agent1", "agent-one")
+	app, err := instanceapp.New("lesser-body-instance", "dev",
+		instanceapp.WithDownloadGrantStore(grantStore),
+		instanceapp.WithBaContentStore(content),
+		instanceapp.WithBaInstanceEndpoint(endpoint),
+		instanceapp.WithBaNamespace("equaltoai"),
+		instanceapp.WithBaToolOptions(baserver.WithRateLimiter(baserver.NewInMemoryGrantMintLimiter(10, time.Minute))),
+	)
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+	env := testkit.New()
+	token := newTestTokenWithAudience(t, "test-secret", "agent1", []string{"write"}, audienceForPath("/instance/ba/mcp"))
+	headers := initializedMCPHeaders(t, env, app, "/instance/ba/mcp", token)
+
+	out := callMCPTool(t, env, app, "/instance/ba/mcp", headers, baserver.ToolAgentLocalInstallPlan, map[string]any{
+		"agent_id":       "agent-one",
+		"client":         "codex",
+		"actor_username": "agent1",
+	})
+	if out.Result == nil || out.Result.IsError {
+		t.Fatalf("plan result = %+v error=%+v", out.Result, out.Error)
+	}
+	data := toolResultData(t, out.Result)
+	if data["schema"] != "lesserbody.agent_local_install_plan.v1" || data["grant_id"] == "" || data["download_url"] == "" {
+		t.Fatalf("plan missing identity/download fields: %+v", data)
+	}
+	if data["mcp_endpoint_url"] != "https://api.dev.example.com/mcp/agent-one" || data["mcp_server_name"] == "" {
+		t.Fatalf("plan mcp fields = %+v", data)
+	}
+	packChecksum, _ := data["pack_checksum"].(string)
+	if !strings.HasPrefix(packChecksum, "sha256:") || data["pack_digest"] == "" {
+		t.Fatalf("plan checksum/digest fields = %+v", data)
+	}
+	if entries, ok := data["manifest_entries"].([]any); !ok || len(entries) == 0 {
+		t.Fatalf("manifest_entries = %#v", data["manifest_entries"])
+	}
+	text := out.Result.Content[0].Text
+	for _, forbidden := range []string{"raw-plan-token", "draft soul content", "follow the operator"} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("plan text leaked %q: %s", forbidden, text)
+		}
+	}
+
+	downloadURL, _ := data["download_url"].(string)
+	parsed, err := url.Parse(downloadURL)
+	if err != nil {
+		t.Fatalf("download URL parse: %v", err)
+	}
+	if parsed.Path == "" || parsed.Query().Get("token") == "" {
+		t.Fatalf("download URL missing header-free token path/query: %s", downloadURL)
+	}
+	if parsed.Query().Get("pack_digest") != data["pack_digest"] || parsed.Query().Get("pack_id") != data["pack_id"] {
+		t.Fatalf("download URL binding query mismatch: %s", downloadURL)
+	}
+
+	download := env.Invoke(context.Background(), app, apptheory.Request{
+		Method: "GET",
+		Path:   parsed.Path,
+		Query:  parsed.Query(),
+	})
+	if download.Status != 200 {
+		t.Fatalf("download status = %d, body=%s", download.Status, string(download.Body))
+	}
+	if got := firstHeader(download.Headers, "content-type"); got != "application/zip" {
+		t.Fatalf("Content-Type = %q", got)
+	}
+	if got := checksumHex(download.Body); got != packChecksum {
+		t.Fatalf("download checksum = %q, want %q", got, packChecksum)
+	}
+	manifest := verifyDownloadedInstallPack(t, download.Body, data)
+	if manifest.MCPServerName != data["mcp_server_name"] || manifest.MCPEndpointURL != data["mcp_endpoint_url"] || manifest.PackDigest != data["pack_digest"] {
+		t.Fatalf("manifest mismatch = %+v data=%+v", manifest, data)
+	}
+
+	replay := env.Invoke(context.Background(), app, apptheory.Request{
+		Method: "GET",
+		Path:   parsed.Path,
+		Query:  parsed.Query(),
+	})
+	if replay.Status != 410 {
+		t.Fatalf("replay status = %d, want 410; body=%s", replay.Status, string(replay.Body))
+	}
+}
+
+func verifyDownloadedInstallPack(t testing.TB, zipBytes []byte, plan map[string]any) installpack.Manifest {
+	t.Helper()
+	zr, err := zip.NewReader(bytes.NewReader(zipBytes), int64(len(zipBytes)))
+	if err != nil {
+		t.Fatalf("read downloaded zip: %v", err)
+	}
+	files := map[string][]byte{}
+	for _, file := range zr.File {
+		rc, err := file.Open()
+		if err != nil {
+			t.Fatalf("open zip entry %s: %v", file.Name, err)
+		}
+		var buf bytes.Buffer
+		if _, err := buf.ReadFrom(rc); err != nil {
+			_ = rc.Close()
+			t.Fatalf("read zip entry %s: %v", file.Name, err)
+		}
+		if err := rc.Close(); err != nil {
+			t.Fatalf("close zip entry %s: %v", file.Name, err)
+		}
+		files[file.Name] = buf.Bytes()
+	}
+	var manifest installpack.Manifest
+	if err := json.Unmarshal(files["MANIFEST.json"], &manifest); err != nil {
+		t.Fatalf("decode MANIFEST.json: %v\n%s", err, string(files["MANIFEST.json"]))
+	}
+	if manifest.PackID != plan["pack_id"] || manifest.PackDigest != plan["pack_digest"] {
+		t.Fatalf("manifest pack fields = %q/%q plan=%q/%q", manifest.PackID, manifest.PackDigest, plan["pack_id"], plan["pack_digest"])
+	}
+	for _, entry := range manifest.ManifestEntries {
+		body, ok := files[entry.Path]
+		if !ok {
+			t.Fatalf("manifest entry %s missing from ZIP", entry.Path)
+		}
+		if got := checksumHex(body); got != entry.Checksum {
+			t.Fatalf("entry %s checksum = %q, want %q", entry.Path, got, entry.Checksum)
+		}
+	}
+	return manifest
+}
+
+func checksumHex(body []byte) string {
+	sum := sha256.Sum256(body)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+type baPlanContentStore struct {
+	records map[string]*agentcontent.Record
+}
+
+func newBaPlanContentStore(account, agentID string) *baPlanContentStore {
+	return &baPlanContentStore{records: map[string]*agentcontent.Record{
+		baPlanContentKey(account, agentID, agentcontent.ContentTypeAgentSoul): {
+			Account:            account,
+			AgentID:            agentID,
+			Type:               agentcontent.ContentTypeAgentSoul,
+			Content:            "draft soul content",
+			Version:            1,
+			LifecycleState:     agentcontent.LifecycleStateDraft,
+			CreatedAt:          time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC),
+			UpdatedAt:          time.Date(2026, 7, 15, 12, 30, 0, 0, time.UTC),
+			UpdatedBySubjectID: "subject-agent1",
+		},
+		baPlanContentKey(account, agentID, agentcontent.ContentTypeAgentInstructions): {
+			Account:            account,
+			AgentID:            agentID,
+			Type:               agentcontent.ContentTypeAgentInstructions,
+			Content:            "follow the operator",
+			Version:            2,
+			LifecycleState:     agentcontent.LifecycleStateDraft,
+			CreatedAt:          time.Date(2026, 7, 15, 12, 1, 0, 0, time.UTC),
+			UpdatedAt:          time.Date(2026, 7, 15, 12, 31, 0, 0, time.UTC),
+			UpdatedBySubjectID: "subject-agent1",
+		},
+	}}
+}
+
+func (s *baPlanContentStore) Get(_ context.Context, account string, agentID string, contentType agentcontent.ContentType) (*agentcontent.Record, error) {
+	record := s.records[baPlanContentKey(account, agentID, contentType)]
+	if record == nil {
+		return nil, agentcontent.ErrContentNotFound
+	}
+	clone := *record
+	return &clone, nil
+}
+
+func baPlanContentKey(account, agentID string, contentType agentcontent.ContentType) string {
+	return strings.ToLower(strings.TrimSpace(account)) + "\x00" + strings.TrimSpace(agentID) + "\x00" + string(contentType)
+}

--- a/internal/instanceapp/installer_grants.go
+++ b/internal/instanceapp/installer_grants.go
@@ -5,15 +5,19 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 
+	"github.com/equaltoai/lesser-body/internal/agentcontent"
+	"github.com/equaltoai/lesser-body/internal/baserver"
 	"github.com/equaltoai/lesser-body/internal/downloadgrant"
+	"github.com/equaltoai/lesser-body/internal/installpack"
 	apptheory "github.com/theory-cloud/apptheory/runtime"
 )
 
 const (
 	installerGrantPathPattern = "/instance/downloads/installer-grants/{grantId}"
-	installerGrantBoundRoute  = "/instance/ba/mcp"
+	installerGrantBoundRoute  = baserver.InstallerGrantBoundRoute
 
 	// AWS Lambda's synchronous response payload ceiling is 6 MB. Keep the
 	// installer-pack body below that ceiling before the Lambda adapters serialize
@@ -29,9 +33,8 @@ type DownloadGrantStore interface {
 }
 
 // InstallerPackProvider is the minimal pack-rendering seam for the grant route.
-// The real install-pack renderer lands in #356; this route consumes grants and
-// returns the ZIP bytes supplied by this seam without implementing renderer
-// layout, manifest, or client-specific pack generation here.
+// The default provider re-renders deterministic Ba install packs from the
+// consumed grant binding and current account-scoped agentcontent records.
 type InstallerPackProvider interface {
 	BuildInstallerPack(context.Context, InstallerPackRequest) (*InstallerPack, error)
 }
@@ -53,6 +56,10 @@ type downloadGrantStoreFactory func() (DownloadGrantStore, error)
 type options struct {
 	downloadGrantStoreFactory downloadGrantStoreFactory
 	installerPackProvider     InstallerPackProvider
+	baToolOptions             []baserver.Option
+	baContentStoreFactory     func() (baserver.AgentContentStore, error)
+	baInstanceEndpoint        string
+	baNamespace               string
 }
 
 // Option customizes the instance-plane app composition.
@@ -71,6 +78,9 @@ func WithDownloadGrantStore(store DownloadGrantStore) Option {
 			}
 			return store, nil
 		}
+		if issuer, ok := store.(baserver.DownloadGrantIssuer); ok {
+			opts.baToolOptions = append(opts.baToolOptions, baserver.WithDownloadGrantIssuer(issuer))
+		}
 	}
 }
 
@@ -86,7 +96,7 @@ func WithDownloadGrantStoreFactory(factory func() (DownloadGrantStore, error)) O
 }
 
 // WithInstallerPackProvider injects the install-pack ZIP provider used after a
-// grant is consumed. The #356 renderer will provide the production implementation.
+// grant is consumed. Production uses the Ba installpack-backed default provider.
 func WithInstallerPackProvider(provider InstallerPackProvider) Option {
 	return func(opts *options) {
 		if opts == nil {
@@ -96,11 +106,67 @@ func WithInstallerPackProvider(provider InstallerPackProvider) Option {
 	}
 }
 
+// WithBaContentStore injects the account-scoped content store used by the Ba
+// plan tool and the default grant redemption provider.
+func WithBaContentStore(store baserver.AgentContentStore) Option {
+	return func(opts *options) {
+		if opts == nil {
+			return
+		}
+		opts.baContentStoreFactory = func() (baserver.AgentContentStore, error) {
+			if store == nil {
+				return nil, fmt.Errorf("agent content store is required")
+			}
+			return store, nil
+		}
+		opts.baToolOptions = append(opts.baToolOptions, baserver.WithAgentContentStore(store))
+	}
+}
+
+// WithBaInstanceEndpoint injects the canonical CDK-derived instance endpoint
+// template used to derive pack stage domains and grant download URLs.
+func WithBaInstanceEndpoint(endpoint string) Option {
+	return func(opts *options) {
+		if opts == nil {
+			return
+		}
+		opts.baInstanceEndpoint = strings.TrimSpace(endpoint)
+		opts.baToolOptions = append(opts.baToolOptions, baserver.WithInstanceEndpoint(endpoint))
+	}
+}
+
+// WithBaNamespace injects the namespace used in Ba plan metadata and grant bindings.
+func WithBaNamespace(namespace string) Option {
+	return func(opts *options) {
+		if opts == nil {
+			return
+		}
+		opts.baNamespace = strings.TrimSpace(namespace)
+		opts.baToolOptions = append(opts.baToolOptions, baserver.WithNamespace(namespace))
+	}
+}
+
+// WithBaToolOptions injects additional baserver options, for example a test
+// rate limiter.
+func WithBaToolOptions(toolOpts ...baserver.Option) Option {
+	return func(opts *options) {
+		if opts == nil {
+			return
+		}
+		opts.baToolOptions = append(opts.baToolOptions, toolOpts...)
+	}
+}
+
 func defaultOptions() options {
 	return options{
 		downloadGrantStoreFactory: func() (DownloadGrantStore, error) {
 			return downloadgrant.Default()
 		},
+		baContentStoreFactory: func() (baserver.AgentContentStore, error) {
+			return agentcontent.Default()
+		},
+		baInstanceEndpoint: strings.TrimSpace(os.Getenv(baserver.EnvInstanceMCPEndpoint)),
+		baNamespace:        baserver.DefaultNamespace,
 	}
 }
 
@@ -111,7 +177,87 @@ func applyOptions(custom []Option) options {
 			opt(&opts)
 		}
 	}
+	if opts.installerPackProvider == nil {
+		opts.installerPackProvider = &baInstallerPackProvider{
+			contentStoreFactory: opts.baContentStoreFactory,
+			instanceEndpoint:    opts.baInstanceEndpoint,
+			namespace:           opts.baNamespace,
+			renderer:            installpack.NewRenderer(),
+		}
+	}
 	return opts
+}
+
+type baInstallerPackProvider struct {
+	contentStoreFactory func() (baserver.AgentContentStore, error)
+	instanceEndpoint    string
+	namespace           string
+	renderer            baserver.Renderer
+}
+
+// NewBaInstallerPackProvider builds the default Ba grant redemption provider
+// around an injected content store. It is intended for tests and narrow
+// composition paths; production uses the lazy default provider from New.
+func NewBaInstallerPackProvider(store baserver.AgentContentStore, instanceEndpoint string, namespace string) InstallerPackProvider {
+	return &baInstallerPackProvider{
+		contentStoreFactory: func() (baserver.AgentContentStore, error) {
+			if store == nil {
+				return nil, fmt.Errorf("agent content store is required")
+			}
+			return store, nil
+		},
+		instanceEndpoint: strings.TrimSpace(instanceEndpoint),
+		namespace:        strings.TrimSpace(namespace),
+		renderer:         installpack.NewRenderer(),
+	}
+}
+
+func (p *baInstallerPackProvider) BuildInstallerPack(ctx context.Context, req InstallerPackRequest) (*InstallerPack, error) {
+	if p == nil {
+		return nil, fmt.Errorf("installer pack provider is nil")
+	}
+	if p.contentStoreFactory == nil {
+		return nil, fmt.Errorf("agent content store is not configured")
+	}
+	store, err := p.contentStoreFactory()
+	if err != nil {
+		return nil, err
+	}
+	agentID, err := baserver.AgentIDFromPackID(req.Binding.PackID)
+	if err != nil {
+		return nil, err
+	}
+	namespace := strings.TrimSpace(req.Binding.Namespace)
+	if namespace == "" {
+		namespace = p.namespace
+	}
+	renderer := p.renderer
+	if renderer == nil {
+		renderer = installpack.NewRenderer()
+	}
+	packInput, err := baserver.BuildPackInput(ctx, baserver.PackInputRequest{
+		ContentStore:     store,
+		InstanceEndpoint: p.instanceEndpoint,
+		Namespace:        namespace,
+		Account:          req.Binding.Account,
+		AgentID:          agentID,
+		Actor:            req.Binding.Actor,
+		Client:           req.Binding.Client,
+		Profile:          installpack.Profile(req.Binding.Profile),
+		PackID:           req.Binding.PackID,
+		PackDigest:       req.Binding.PackDigest,
+	})
+	if err != nil {
+		return nil, err
+	}
+	pack, err := renderer.Render(ctx, packInput.RenderRequest)
+	if err != nil {
+		return nil, err
+	}
+	if pack == nil || len(pack.ZIPBytes) == 0 {
+		return nil, fmt.Errorf("installer pack render returned empty zip")
+	}
+	return &InstallerPack{ZIPBytes: pack.ZIPBytes}, nil
 }
 
 func installerGrantHandler(opts options) apptheory.Handler {


### PR DESCRIPTION
## Milestone
Project 48 M6/B15 — Ba packs & grants: register `agent_local_install_plan` and wire plan → one-time grant → install-pack metadata/download path.

Closes #357

## Classification
Tool-surface / MCP-contract additive / instance-plane security.

## Surfaces affected
- `internal/baserver/**`: new Ba static registrar and `agent_local_install_plan` handler/tests.
- `internal/instanceapp/**`: Ba tool registration, grant route provider wiring, plan→download integration tests.
- `docs/mcp.md`: Ba tool contract, response envelope, auth/security invariants.

## Source/spec evidence inspected
- GitHub #353 parent and #357 child, including Factory assignment comment for M6/B15.
- #354 `internal/downloadgrant`: `Issue`, `Binding`, TokenHash-only persistence, TTL, raw token returned only at issue time.
- #355 `internal/instanceapp/installer_grants.go`: header-free `GET /instance/downloads/installer-grants/{grantId}?token=...` redemption and binding query contract.
- #356 `internal/installpack`: deterministic renderer/types/tests, `PackChecksum`, manifest entries, marker metadata, `MCPServerName`, actor endpoint rendering.
- Ptah registration/auth/result patterns in `internal/ptahserver/` and Ba/Ptah server construction in `internal/instanceapp/app.go`.
- `internal/agentcontent` account-scoped `agent_soul` / `agent_instructions` retrieval contract.
- `docs/mcp.md`, `docs/oauth-migration.md`, `docs/body-lab-trust.md`, and CDK source for `INSTANCE_MCP_ENDPOINT` (`https://api.<stageDomain>/instance/{surface}/mcp`) plus canonical actor endpoint (`https://api.<stageDomain>/mcp/{actor}`).
- TheoryMCP `agent_local_install_plan` shape via Factory preflight summary / routed server instructions as spec only: install-pack resource metadata, manifest entries, marker metadata, `mcp_server_name`, merge/update guidance, verification steps, and route-derived download-resource semantics. No proprietary theory-mcp-server code was ported or vendored.

## Implementation notes
- Adds Ba `tools/list` exposure for `agent_local_install_plan` with additive/write annotations.
- Requires account-holder OAuth principal + write scope; rejects agent principals, legacy instance-key principals, read-only callers, and `actor_username` mismatches before side effects.
- Uses `INSTANCE_MCP_ENDPOINT` rather than request host headers to derive stage domain and download origin.
- Reads current account-scoped `agent_soul` and `agent_instructions`, renders with `internal/installpack`, then mints one-time `internal/downloadgrant` grant bound to account/actor/namespace/route/client/profile/pack_id/pack_digest.
- Response envelope includes grant id, header-free download URL, pack checksum/digest, install-pack resource metadata, manifest entries, marker metadata, `mcp_server_name`, merge/update guidance, expiration, and verification steps.
- Download URL includes the raw token in the `token` query param expected by #355; raw token is not persisted or logged.
- Adds bounded in-process per-account grant minting cap with tests and code comments documenting its foundation-slice limitation.
- Wires the default route provider so plan→download→checksum verify→410 replay is testable without deploy/canary work.

## Tests added/updated
- `internal/baserver`: registration/schema annotations, plan envelope, binding/query URL, auth rejection before side effects, actor mismatch, in-process rate cap, pack-id/endpoint derivation.
- `internal/instanceapp`: Ba appears in `tools/list`, Ba route rejects delegated/legacy principals, and full plan→download→checksum/manifest verification→410 replay integration path.

## Validation
Initial base precondition gates and final tip gates both passed. For raw Go tooling, `cdk/node_modules` was temporarily moved outside the repo and restored.

Final tip output:

```text
moved cdk/node_modules to /tmp/lesser-body-cdk-node_modules.validation
gofmt -l .
go test ./...
?   	github.com/equaltoai/lesser-body/cmd/lesser-body	[no test files]
?   	github.com/equaltoai/lesser-body/cmd/lesser-body-instance	[no test files]
ok  	github.com/equaltoai/lesser-body/internal/agentcontent	(cached)
ok  	github.com/equaltoai/lesser-body/internal/agentregistry	(cached)
ok  	github.com/equaltoai/lesser-body/internal/auth	(cached)
ok  	github.com/equaltoai/lesser-body/internal/baserver	(cached)
ok  	github.com/equaltoai/lesser-body/internal/cmsapi	(cached)
ok  	github.com/equaltoai/lesser-body/internal/downloadgrant	(cached)
ok  	github.com/equaltoai/lesser-body/internal/installpack	(cached)
ok  	github.com/equaltoai/lesser-body/internal/instanceapp	(cached)
ok  	github.com/equaltoai/lesser-body/internal/lesserapi	(cached)
ok  	github.com/equaltoai/lesser-body/internal/mcpapp	(cached)
ok  	github.com/equaltoai/lesser-body/internal/mcpserver	(cached)
?   	github.com/equaltoai/lesser-body/internal/memory	[no test files]
ok  	github.com/equaltoai/lesser-body/internal/ptahserver	(cached)
?   	github.com/equaltoai/lesser-body/internal/runtimepolicy	[no test files]
ok  	github.com/equaltoai/lesser-body/internal/soulapi	(cached)
ok  	github.com/equaltoai/lesser-body/internal/soulbinding	(cached)
ok  	github.com/equaltoai/lesser-body/internal/trustconfig	(cached)
go vet ./...
bash scripts/build.sh
Building lesser-body.zip bootstrap (linux/arm64)...
Packaging dist/lesser-body.zip...
OK: dist/lesser-body.zip
Building lesser-body-instance.zip bootstrap (linux/arm64)...
Packaging dist/lesser-body-instance.zip...
OK: dist/lesser-body-instance.zip
Writing dist/checksums.txt...
dist/lesser-body.zip: OK
dist/lesser-body-instance.zip: OK
OK: dist/checksums.txt
restored cdk/node_modules
```

## Risks / follow-ups
- The per-account rate cap is intentionally process-local and does not coordinate across Lambda execution environments; this is documented as a foundation-slice backstop, not durable quota infrastructure.
- Download route re-renders from current account-scoped content at redemption time; if content changes between plan and download, clients should rely on `pack_checksum` verification. Durable pack snapshot storage is outside this slice.
- Lab/canary evidence for parent #353 remains a rollout follow-up after merge/deploy.
