### PR TITLE
feat(instance): publish instance discovery and oauth metadata

### DIFF
--- a/gov-infra/verifiers/gov-verify-rubric.sh
+++ b/gov-infra/verifiers/gov-verify-rubric.sh
@@ -27,6 +27,11 @@ export GOTOOLCHAIN="${GOTOOLCHAIN:-auto}"
 export CDK_DEFAULT_ACCOUNT="${CDK_DEFAULT_ACCOUNT:-000000000000}"
 export CDK_DEFAULT_REGION="${CDK_DEFAULT_REGION:-us-east-1}"
 
+# Keep Go validation scoped to the repo-owned Go modules. Local dependency
+# material such as cdk/node_modules may contain generated Go templates that are
+# intentionally not Go packages and must not affect source validation.
+GO_PACKAGE_PATTERNS="./cmd/... ./internal/..."
+
 PASS_COUNT=0
 FAIL_COUNT=0
 BLOCKED_COUNT=0
@@ -82,41 +87,6 @@ run_check() {
   fi
 }
 
-
-run_go_check() {
-  local id="$1"
-  local category="$2"
-  local command="$3"
-  local evidence_path="${EVIDENCE_DIR}/${id}-output.log"
-  local hidden_node_modules=""
-
-  echo "=== ${id} ${category}: ${command} ==="
-  printf '$ %s\n' "${command}" >"${evidence_path}"
-
-  if [[ -d "${REPO_ROOT}/cdk/node_modules" ]]; then
-    hidden_node_modules="${REPO_ROOT}/cdk/.node_modules.gov-verify"
-    rm -rf "${hidden_node_modules}"
-    mv "${REPO_ROOT}/cdk/node_modules" "${hidden_node_modules}"
-  fi
-
-  if bash -lc "${command}" >>"${evidence_path}" 2>&1; then
-    local rc=0
-  else
-    local rc=$?
-  fi
-
-  if [[ -n "${hidden_node_modules}" && -d "${hidden_node_modules}" ]]; then
-    mv "${hidden_node_modules}" "${REPO_ROOT}/cdk/node_modules"
-  fi
-
-  if [[ ${rc} -eq 0 ]]; then
-    append_result "${id}" "${category}" "PASS" "Command succeeded" "${evidence_path#${REPO_ROOT}/}"
-    echo "${id}: PASS"
-  else
-    append_result "${id}" "${category}" "FAIL" "Command failed with exit ${rc}" "${evidence_path#${REPO_ROOT}/}"
-    echo "${id}: FAIL (exit ${rc})"
-  fi
-}
 
 run_blocking_file_check() {
   local id="$1"
@@ -268,10 +238,10 @@ run_blocking_file_check "GOV-README" "Governance" "gov-infra/README.md"
 run_no_runtime_diff_check
 run_report_shape_self_check
 
-run_go_check "GO-BUILD" "Completeness" "go build ./..."
-run_go_check "GO-TEST" "Quality" "go test ./..."
-run_go_check "GO-VET" "Consistency" "go vet ./..."
-run_check "GOFMT" "Consistency" "test -z \"\$(gofmt -l .)\""
+run_check "GO-BUILD" "Completeness" "go build ${GO_PACKAGE_PATTERNS}"
+run_check "GO-TEST" "Quality" "go test ${GO_PACKAGE_PATTERNS}"
+run_check "GO-VET" "Consistency" "go vet ${GO_PACKAGE_PATTERNS}"
+run_check "GOFMT" "Consistency" "test -z \"\$(git ls-files -z '*.go' | xargs -0 gofmt -l)\""
 run_check "SOURCE-BUILD" "Completeness" "bash scripts/build.sh"
 run_check "RELEASE-ASSETS" "Completeness" "bash scripts/verify_release_assets.sh v0.0.0-test dist/release-test"
 run_check "RELEASE-CHECKSUM-REGRESSION" "Quality" "bash scripts/check_release_asset_checksum_regression.sh v0.0.0-test dist/release-test"

--- a/internal/instanceapp/app.go
+++ b/internal/instanceapp/app.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/equaltoai/lesser-body/internal/auth"
 	"github.com/equaltoai/lesser-body/internal/baserver"
+	"github.com/equaltoai/lesser-body/internal/mcpapp"
 	"github.com/equaltoai/lesser-body/internal/ptahserver"
 	apptheory "github.com/theory-cloud/apptheory/runtime"
 	mcpruntime "github.com/theory-cloud/apptheory/runtime/mcp"
@@ -47,8 +48,8 @@ func New(name, version string, custom ...Option) (*apptheory.App, error) {
 	app.Post("/instance/ptah/mcp", requireInstancePrincipal(withToolContext(ptah.Handler())), apptheory.RequireAuth())
 	app.Post("/instance/ba/mcp", requireInstancePrincipal(withToolContext(ba.Handler())), apptheory.RequireAuth())
 	app.Get(installerGrantPathPattern, installerGrantHandler(opts))
-	app.Get("/.well-known/oauth-protected-resource/instance/ptah/mcp", wellKnownStubHandler(SurfacePtah))
-	app.Get("/.well-known/oauth-protected-resource/instance/ba/mcp", wellKnownStubHandler(SurfaceBa))
+	app.Get(instanceProtectedResourceMetadataPath(SurfacePtah), mcpapp.WithBrowserCORS(wellKnownProtectedResourceHandler(opts.baInstanceEndpoint, SurfacePtah)))
+	app.Get(instanceProtectedResourceMetadataPath(SurfaceBa), mcpapp.WithBrowserCORS(wellKnownProtectedResourceHandler(opts.baInstanceEndpoint, SurfaceBa)))
 
 	return app, nil
 }
@@ -197,21 +198,6 @@ func instanceAudienceForRequest(ctx *apptheory.Context) string {
 		Host:   host,
 		Path:   path,
 	}).String()
-}
-
-func wellKnownStubHandler(surface string) apptheory.Handler {
-	surface = strings.TrimSpace(surface)
-	return func(_ *apptheory.Context) (*apptheory.Response, error) {
-		return apptheory.MustJSON(501, map[string]any{
-			"error": map[string]any{
-				"code":    "instance_metadata_not_implemented",
-				"message": "instance-plane OAuth metadata is not implemented in this foundation slice",
-				"details": map[string]any{
-					"surface": surface,
-				},
-			},
-		}), nil
-	}
 }
 
 func firstHeaderValue(ctx *apptheory.Context, name string) string {

--- a/internal/instanceapp/app_test.go
+++ b/internal/instanceapp/app_test.go
@@ -809,7 +809,10 @@ func TestInstancePlaneMCP_UnknownPlaneIsNotMounted(t *testing.T) {
 	}
 }
 
-func TestInstancePlaneWellKnownStubs_FailClosed(t *testing.T) {
+func TestInstancePlaneWellKnownProtectedResourceMetadata(t *testing.T) {
+	t.Setenv(baserver.EnvInstanceMCPEndpoint, "https://api.example.com/instance/{surface}/mcp")
+	t.Setenv("MCP_ALLOWED_ORIGINS", "https://claude.ai")
+
 	app, err := instanceapp.New("lesser-body-instance", "dev")
 	if err != nil {
 		t.Fatalf("new app: %v", err)
@@ -817,24 +820,130 @@ func TestInstancePlaneWellKnownStubs_FailClosed(t *testing.T) {
 	env := testkit.New()
 
 	for _, tc := range []struct {
-		name string
-		path string
+		name     string
+		surface  string
+		path     string
+		resource string
 	}{
-		{name: "ptah", path: "/.well-known/oauth-protected-resource/instance/ptah/mcp"},
-		{name: "ba", path: "/.well-known/oauth-protected-resource/instance/ba/mcp"},
+		{
+			name:     "ptah",
+			surface:  "ptah",
+			path:     "/.well-known/oauth-protected-resource/instance/ptah/mcp",
+			resource: "https://api.example.com/instance/ptah/mcp",
+		},
+		{
+			name:     "ba",
+			surface:  "ba",
+			path:     "/.well-known/oauth-protected-resource/instance/ba/mcp",
+			resource: "https://api.example.com/instance/ba/mcp",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			resp := env.Invoke(context.Background(), app, apptheory.Request{
 				Method: "GET",
 				Path:   tc.path,
+				Headers: map[string][]string{
+					"host":              {testHost},
+					"x-forwarded-proto": {"https"},
+					"origin":            {"https://claude.ai"},
+				},
 			})
-			if resp.Status != 501 {
-				t.Fatalf("status = %d, want 501; body = %s", resp.Status, string(resp.Body))
+			if resp.Status != 200 {
+				t.Fatalf("status = %d, want 200; body = %s", resp.Status, string(resp.Body))
 			}
-			if !strings.Contains(string(resp.Body), "instance_metadata_not_implemented") {
-				t.Fatalf("response did not include fail-closed stub code: %s", string(resp.Body))
+			if got := firstHeader(resp.Headers, "content-type"); got != "application/json" {
+				t.Fatalf("content-type = %q, want application/json", got)
+			}
+			if got := firstHeader(resp.Headers, "cache-control"); got != "public, max-age=60" {
+				t.Fatalf("cache-control = %q, want public, max-age=60", got)
+			}
+			if got := firstHeader(resp.Headers, "access-control-allow-origin"); got != "https://claude.ai" {
+				t.Fatalf("access-control-allow-origin = %q, want https://claude.ai", got)
+			}
+
+			var out struct {
+				Resource               string   `json:"resource"`
+				AuthorizationServers   []string `json:"authorization_servers"`
+				ScopesSupported        []string `json:"scopes_supported"`
+				BearerMethodsSupported []string `json:"bearer_methods_supported"`
+			}
+			if err := json.Unmarshal(resp.Body, &out); err != nil {
+				t.Fatalf("unmarshal metadata: %v", err)
+			}
+			if out.Resource != tc.resource {
+				t.Fatalf("resource = %q, want %q", out.Resource, tc.resource)
+			}
+			if want := []string{"https://api.example.com"}; !reflect.DeepEqual(out.AuthorizationServers, want) {
+				t.Fatalf("authorization_servers = %#v, want %#v", out.AuthorizationServers, want)
+			}
+			if want := []string{"read", "write", "follow", "push"}; !reflect.DeepEqual(out.ScopesSupported, want) {
+				t.Fatalf("scopes_supported = %#v, want %#v", out.ScopesSupported, want)
+			}
+			if strings.Contains(strings.ToLower(string(resp.Body)), "admin") || strings.Contains(string(resp.Body), "instance:") {
+				t.Fatalf("instance metadata advertised non-issuable/internal scopes: %s", string(resp.Body))
+			}
+			if want := []string{"header"}; !reflect.DeepEqual(out.BearerMethodsSupported, want) {
+				t.Fatalf("bearer_methods_supported = %#v, want %#v", out.BearerMethodsSupported, want)
 			}
 		})
+	}
+}
+
+func TestInstancePlaneWellKnownProtectedResource_RejectsMissingConfiguredEndpoint(t *testing.T) {
+	t.Setenv(baserver.EnvInstanceMCPEndpoint, "")
+
+	app, err := instanceapp.New("lesser-body-instance", "dev")
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+	env := testkit.New()
+
+	resp := env.Invoke(context.Background(), app, apptheory.Request{
+		Method: "GET",
+		Path:   "/.well-known/oauth-protected-resource/instance/ptah/mcp",
+		Headers: map[string][]string{
+			"host":              {"evil.example"},
+			"x-forwarded-proto": {"https"},
+		},
+	})
+	if resp.Status != 500 {
+		t.Fatalf("status = %d, want 500; body = %s", resp.Status, string(resp.Body))
+	}
+	body := string(resp.Body)
+	if !strings.Contains(body, baserver.EnvInstanceMCPEndpoint+" is required") {
+		t.Fatalf("expected missing endpoint error, got %s", body)
+	}
+	if strings.Contains(body, "evil.example") {
+		t.Fatalf("missing endpoint response must not infer from untrusted host headers: %s", body)
+	}
+}
+
+func TestInstancePlaneWellKnownProtectedResource_RejectsConfiguredEndpointMismatch(t *testing.T) {
+	t.Setenv(baserver.EnvInstanceMCPEndpoint, "https://api.example.com/instance/{surface}/mcp")
+
+	app, err := instanceapp.New("lesser-body-instance", "dev")
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+	env := testkit.New()
+
+	resp := env.Invoke(context.Background(), app, apptheory.Request{
+		Method: "GET",
+		Path:   "/.well-known/oauth-protected-resource/instance/ba/mcp",
+		Headers: map[string][]string{
+			"x-forwarded-host":  {"other.example.com"},
+			"x-forwarded-proto": {"https"},
+		},
+	})
+	if resp.Status != 400 {
+		t.Fatalf("status = %d, want 400; body = %s", resp.Status, string(resp.Body))
+	}
+	body := string(resp.Body)
+	if !strings.Contains(body, "app.invalid_public_url") {
+		t.Fatalf("expected invalid public url error, got %s", body)
+	}
+	if !strings.Contains(body, "https://api.example.com/.well-known/oauth-protected-resource/instance/ba/mcp") {
+		t.Fatalf("expected canonical metadata URL in mismatch response, got %s", body)
 	}
 }
 

--- a/internal/instanceapp/well_known.go
+++ b/internal/instanceapp/well_known.go
@@ -1,0 +1,295 @@
+package instanceapp
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/equaltoai/lesser-body/internal/baserver"
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+	oauthruntime "github.com/theory-cloud/apptheory/runtime/oauth"
+)
+
+const instanceSurfacePlaceholder = "{surface}"
+
+var instanceOAuthDiscoveryScopes = []string{"read", "write", "follow", "push"}
+
+type instanceEndpointInfo struct {
+	BasePath string
+	Surface  string
+}
+
+type instanceEndpointMismatchError struct {
+	Configured string
+	Requested  string
+}
+
+func (e *instanceEndpointMismatchError) Error() string {
+	if e == nil {
+		return "configured INSTANCE_MCP_ENDPOINT does not match request URL"
+	}
+	return fmt.Sprintf("configured INSTANCE_MCP_ENDPOINT %q does not match request URL %q", e.Configured, e.Requested)
+}
+
+func wellKnownProtectedResourceHandler(instanceEndpointTemplate string, surface string) apptheory.Handler {
+	instanceEndpointTemplate = strings.TrimSpace(instanceEndpointTemplate)
+	surface = strings.TrimSpace(surface)
+
+	return func(ctx *apptheory.Context) (*apptheory.Response, error) {
+		resource, err := instanceEndpointForRequest(ctx, instanceEndpointTemplate, surface)
+		if err != nil {
+			return invalidInstanceDiscoveryConfigResponse(err), nil
+		}
+
+		authorizationServerURL, err := authorizationServerURLForInstanceEndpoint(resource, surface)
+		if err != nil {
+			return invalidInstanceDiscoveryConfigResponse(fmt.Errorf("derive authorization server URL from instance MCP endpoint: %w", err)), nil
+		}
+
+		md, err := oauthruntime.NewProtectedResourceMetadata(resource, []string{authorizationServerURL})
+		if err != nil {
+			return nil, fmt.Errorf("build instance protected resource metadata: %w", err)
+		}
+		md.ScopesSupported = append([]string(nil), instanceOAuthDiscoveryScopes...)
+		md.BearerMethodsSupported = []string{"header"}
+
+		body, err := json.Marshal(md)
+		if err != nil {
+			return nil, fmt.Errorf("marshal instance protected resource metadata: %w", err)
+		}
+
+		return &apptheory.Response{
+			Status: 200,
+			Headers: map[string][]string{
+				"content-type":  {"application/json"},
+				"cache-control": {"public, max-age=60"},
+			},
+			Body: body,
+		}, nil
+	}
+}
+
+func instanceEndpointForRequest(ctx *apptheory.Context, endpointTemplate string, surface string) (string, error) {
+	configured, err := instanceEndpointForSurface(endpointTemplate, surface)
+	if err != nil {
+		return "", err
+	}
+
+	inferred := inferInstanceEndpointFromRequest(ctx, surface)
+	if inferred == "" {
+		return configured, nil
+	}
+
+	validatedInferred, err := validateInstanceEndpoint(inferred, surface)
+	if err != nil {
+		return "", fmt.Errorf("infer instance MCP endpoint from request: %w", err)
+	}
+	if validatedInferred != configured {
+		return "", &instanceEndpointMismatchError{
+			Configured: configured,
+			Requested:  validatedInferred,
+		}
+	}
+
+	return configured, nil
+}
+
+func instanceEndpointForSurface(endpointTemplate string, surface string) (string, error) {
+	endpointTemplate = strings.TrimSpace(endpointTemplate)
+	surface = strings.TrimSpace(surface)
+	if endpointTemplate == "" {
+		return "", fmt.Errorf("%s is required for instance protected-resource metadata", baserver.EnvInstanceMCPEndpoint)
+	}
+	if surface != SurfacePtah && surface != SurfaceBa {
+		return "", fmt.Errorf("unsupported instance surface %q", surface)
+	}
+
+	endpoint := strings.ReplaceAll(endpointTemplate, instanceSurfacePlaceholder, surface)
+	return validateInstanceEndpoint(endpoint, surface)
+}
+
+func validateInstanceEndpoint(raw string, surface string) (string, error) {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return "", fmt.Errorf("parse %s: %w", baserver.EnvInstanceMCPEndpoint, err)
+	}
+	if u.Scheme != "https" {
+		return "", fmt.Errorf("%s must be an https URL", baserver.EnvInstanceMCPEndpoint)
+	}
+	if strings.TrimSpace(u.Host) == "" {
+		return "", fmt.Errorf("%s host is empty", baserver.EnvInstanceMCPEndpoint)
+	}
+	info, err := parseInstanceEndpointPath(u.Path, surface)
+	if err != nil {
+		return "", err
+	}
+	u.RawQuery = ""
+	u.Fragment = ""
+	return canonicalInstanceAbsoluteURL(u, buildInstanceEndpointPath(info)), nil
+}
+
+func inferInstanceEndpointFromRequest(ctx *apptheory.Context, surface string) string {
+	if ctx == nil {
+		return ""
+	}
+	resourcePath := instanceEndpointPathFromRequest(ctx.Request.Path, surface)
+	if resourcePath == "" {
+		return ""
+	}
+
+	host := firstRequestHeaderValue(ctx.Request.Headers, "x-forwarded-host")
+	if host == "" {
+		host = firstRequestHeaderValue(ctx.Request.Headers, "host")
+	}
+	if strings.TrimSpace(host) == "" {
+		return ""
+	}
+
+	proto := firstRequestHeaderValue(ctx.Request.Headers, "x-forwarded-proto")
+	if proto == "" {
+		proto = "https"
+	}
+	proto = strings.ToLower(strings.TrimSpace(proto))
+	if proto != "http" && proto != "https" {
+		proto = "https"
+	}
+
+	return fmt.Sprintf("%s://%s%s", proto, strings.TrimSpace(host), resourcePath)
+}
+
+func instanceEndpointPathFromRequest(requestPath string, surface string) string {
+	requestPath = strings.TrimRight(strings.TrimSpace(requestPath), "/")
+	switch requestPath {
+	case "/instance/" + surface + "/mcp":
+		return requestPath
+	case instanceProtectedResourceMetadataPath(surface):
+		return "/instance/" + surface + "/mcp"
+	default:
+		return ""
+	}
+}
+
+func instanceProtectedResourceMetadataPath(surface string) string {
+	return "/.well-known/oauth-protected-resource/instance/" + strings.TrimSpace(surface) + "/mcp"
+}
+
+func authorizationServerURLForInstanceEndpoint(resource string, surface string) (string, error) {
+	u, err := url.Parse(strings.TrimSpace(resource))
+	if err != nil {
+		return "", fmt.Errorf("parse instance endpoint: %w", err)
+	}
+	info, err := parseInstanceEndpointPath(u.Path, surface)
+	if err != nil {
+		return "", err
+	}
+	return canonicalInstanceAbsoluteURL(u, info.BasePath), nil
+}
+
+func parseInstanceEndpointPath(path string, surface string) (instanceEndpointInfo, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return instanceEndpointInfo{}, fmt.Errorf("%s path must include /instance/%s/mcp", baserver.EnvInstanceMCPEndpoint, surface)
+	}
+	path = strings.TrimRight(path, "/")
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+
+	segments := strings.Split(strings.TrimPrefix(path, "/"), "/")
+	if len(segments) < 3 {
+		return instanceEndpointInfo{}, fmt.Errorf("%s path must include /instance/%s/mcp", baserver.EnvInstanceMCPEndpoint, surface)
+	}
+	for i := 0; i <= len(segments)-3; i++ {
+		if segments[i] != "instance" || segments[i+1] != surface || segments[i+2] != "mcp" {
+			continue
+		}
+		if i+3 != len(segments) {
+			return instanceEndpointInfo{}, fmt.Errorf("%s path may not include segments after /instance/%s/mcp", baserver.EnvInstanceMCPEndpoint, surface)
+		}
+		basePath := ""
+		if i > 0 {
+			basePath = "/" + strings.Join(segments[:i], "/")
+		}
+		return instanceEndpointInfo{
+			BasePath: basePath,
+			Surface:  surface,
+		}, nil
+	}
+
+	return instanceEndpointInfo{}, fmt.Errorf("%s path must include /instance/%s/mcp", baserver.EnvInstanceMCPEndpoint, surface)
+}
+
+func buildInstanceEndpointPath(info instanceEndpointInfo) string {
+	path := strings.TrimRight(strings.TrimSpace(info.BasePath), "/")
+	if path == "" {
+		path = "/instance/" + info.Surface + "/mcp"
+	} else {
+		path += "/instance/" + info.Surface + "/mcp"
+	}
+	return path
+}
+
+func canonicalInstanceAbsoluteURL(u *url.URL, path string) string {
+	if u == nil {
+		return ""
+	}
+	scheme := strings.TrimSpace(u.Scheme)
+	host := strings.TrimSpace(u.Host)
+	if scheme == "" || host == "" {
+		return ""
+	}
+	if path != "" && !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	if path == "/" {
+		path = ""
+	}
+	return fmt.Sprintf("%s://%s%s", scheme, host, path)
+}
+
+func invalidInstanceDiscoveryConfigResponse(err error) *apptheory.Response {
+	status := 500
+	code := "app.config_invalid"
+	message := "invalid instance discovery configuration"
+	details := map[string]any{}
+	if err != nil && strings.TrimSpace(err.Error()) != "" {
+		message = strings.TrimSpace(err.Error())
+	}
+
+	var mismatch *instanceEndpointMismatchError
+	if errors.As(err, &mismatch) {
+		status = 400
+		code = "app.invalid_public_url"
+		details["reason"] = "configured_endpoint_mismatch"
+		details["canonical_mcp_url"] = mismatch.Configured
+		details["requested_mcp_url"] = mismatch.Requested
+		if resourceMetadataURL, ok := oauthruntime.ResourceMetadataURLFromMcpEndpoint(mismatch.Configured); ok {
+			details["canonical_resource_metadata_url"] = resourceMetadataURL
+		}
+	}
+
+	return apptheory.MustJSON(status, map[string]any{
+		"error": map[string]any{
+			"code":    code,
+			"message": message,
+			"details": details,
+		},
+	})
+}
+
+func firstRequestHeaderValue(headers map[string][]string, key string) string {
+	for candidate, values := range headers {
+		if !strings.EqualFold(strings.TrimSpace(candidate), key) {
+			continue
+		}
+		for _, value := range values {
+			value = strings.TrimSpace(value)
+			if value != "" {
+				return value
+			}
+		}
+	}
+	return ""
+}

--- a/internal/mcpapp/oauth_protected_resource_test.go
+++ b/internal/mcpapp/oauth_protected_resource_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"reflect"
+	"strings"
 	"testing"
 
 	apptheory "github.com/theory-cloud/apptheory/runtime"
@@ -72,6 +73,11 @@ func TestWellKnownOAuthProtectedResource(t *testing.T) {
 	}
 	if want := []string{"read", "write", "follow", "push"}; !reflect.DeepEqual(out.ScopesSupported, want) {
 		t.Fatalf("unexpected scopes_supported: got %#v want %#v", out.ScopesSupported, want)
+	}
+	for _, scope := range out.ScopesSupported {
+		if scope == "admin" || strings.Contains(scope, "instance") {
+			t.Fatalf("per-actor metadata advertised non-public scope %q", scope)
+		}
 	}
 	if len(out.BearerMethodsSupported) != 1 || out.BearerMethodsSupported[0] != "header" {
 		t.Fatalf("unexpected bearer_methods_supported: %#v", out.BearerMethodsSupported)

--- a/internal/mcpapp/well_known.go
+++ b/internal/mcpapp/well_known.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"strings"
 
 	apptheory "github.com/theory-cloud/apptheory/runtime"
@@ -15,19 +16,26 @@ import (
 )
 
 type mcpWellKnownDoc struct {
-	Name            string                            `json:"name"`
-	Version         string                            `json:"version"`
-	Endpoint        string                            `json:"endpoint,omitempty"`
-	Capabilities    map[string]bool                   `json:"capabilities"`
-	Auth            map[string]any                    `json:"auth"`
-	RuntimeProfiles map[string]runtimepolicy.Contract `json:"runtime_profiles,omitempty"`
-	Tools           []mcpWellKnownToolHint            `json:"tools,omitempty"`
+	Name             string                                 `json:"name"`
+	Version          string                                 `json:"version"`
+	Endpoint         string                                 `json:"endpoint,omitempty"`
+	Capabilities     map[string]bool                        `json:"capabilities"`
+	Auth             map[string]any                         `json:"auth"`
+	RuntimeProfiles  map[string]runtimepolicy.Contract      `json:"runtime_profiles,omitempty"`
+	InstanceSurfaces map[string]mcpWellKnownInstanceSurface `json:"instance_surfaces,omitempty"`
+	Tools            []mcpWellKnownToolHint                 `json:"tools,omitempty"`
 }
 
 type mcpWellKnownToolHint struct {
 	Name         string          `json:"name"`
 	Description  string          `json:"description,omitempty"`
 	OutputSchema json.RawMessage `json:"outputSchema,omitempty"`
+}
+
+type mcpWellKnownInstanceSurface struct {
+	Endpoint                     string `json:"endpoint"`
+	ProtectedResourceMetadataURL string `json:"protected_resource_metadata_url"`
+	ToolsDiscovery               string `json:"tools_discovery"`
 }
 
 type protectedResourceMetadataDocument struct {
@@ -63,6 +71,11 @@ func WellKnownMcpHandler(srv *mcpserver.Server, name string, version string) app
 			},
 			RuntimeProfiles: runtimepolicy.Contracts(),
 		}
+		instanceSurfaces, err := publicInstanceSurfacesForMcpEndpoint(endpoint)
+		if err != nil {
+			return invalidDiscoveryConfigResponse(err), nil
+		}
+		doc.InstanceSurfaces = instanceSurfaces
 		if mcpserver.TasksPublicDiscoveryEnabled(srv) {
 			doc.Capabilities["tasks"] = true
 		}
@@ -163,6 +176,50 @@ func protectedResourceMetadataURLForRequest(ctx *apptheory.Context) string {
 		return url
 	}
 	return ""
+}
+
+func publicInstanceSurfacesForMcpEndpoint(mcpEndpoint string) (map[string]mcpWellKnownInstanceSurface, error) {
+	template, err := publicInstanceEndpointTemplateForMcpEndpoint(mcpEndpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make(map[string]mcpWellKnownInstanceSurface, 2)
+	for _, surface := range []string{"ptah", "ba"} {
+		endpoint := strings.ReplaceAll(template, "{surface}", surface)
+		metadataURL, ok := oauthruntime.ResourceMetadataURLFromMcpEndpoint(endpoint)
+		if !ok {
+			return nil, fmt.Errorf("derive instance protected-resource metadata URL for %s", surface)
+		}
+		out[surface] = mcpWellKnownInstanceSurface{
+			Endpoint:                     endpoint,
+			ProtectedResourceMetadataURL: metadataURL,
+			ToolsDiscovery:               "authenticated tools/list",
+		}
+	}
+	return out, nil
+}
+
+func publicInstanceEndpointTemplateForMcpEndpoint(mcpEndpoint string) (string, error) {
+	validatedEndpoint, err := validatedMcpEndpoint(mcpEndpoint)
+	if err != nil {
+		return "", err
+	}
+	u, err := url.Parse(validatedEndpoint)
+	if err != nil {
+		return "", fmt.Errorf("parse MCP endpoint: %w", err)
+	}
+	info, err := parseMcpEndpointPath(u.Path)
+	if err != nil {
+		return "", err
+	}
+	path := strings.TrimRight(strings.TrimSpace(info.BasePath), "/")
+	if path == "" {
+		path = "/instance/{surface}/mcp"
+	} else {
+		path += "/instance/{surface}/mcp"
+	}
+	return canonicalAbsoluteURL(u, path), nil
 }
 
 func inferMcpEndpointFromRequest(ctx *apptheory.Context) string {

--- a/internal/mcpapp/well_known_test.go
+++ b/internal/mcpapp/well_known_test.go
@@ -34,13 +34,43 @@ func TestM7_WellKnownMcpJSON(t *testing.T) {
 		t.Fatalf("unexpected status: %d (%s)", resp.Status, string(resp.Body))
 	}
 
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(resp.Body, &raw); err != nil {
+		t.Fatalf("unmarshal raw mcp.json: %v", err)
+	}
+	wantTopLevel := map[string]bool{
+		"name":              true,
+		"version":           true,
+		"endpoint":          true,
+		"capabilities":      true,
+		"auth":              true,
+		"runtime_profiles":  true,
+		"instance_surfaces": true,
+		"tools":             true,
+	}
+	for key := range raw {
+		if !wantTopLevel[key] {
+			t.Fatalf("unexpected top-level discovery key %q in %s", key, string(resp.Body))
+		}
+	}
+	for key := range wantTopLevel {
+		if _, ok := raw[key]; !ok {
+			t.Fatalf("missing top-level discovery key %q in %s", key, string(resp.Body))
+		}
+	}
+
 	var out struct {
-		Name         string           `json:"name"`
-		Version      string           `json:"version"`
-		Endpoint     string           `json:"endpoint"`
-		Capabilities map[string]bool  `json:"capabilities"`
-		Tools        []map[string]any `json:"tools"`
-		Auth         struct {
+		Name             string           `json:"name"`
+		Version          string           `json:"version"`
+		Endpoint         string           `json:"endpoint"`
+		Capabilities     map[string]bool  `json:"capabilities"`
+		Tools            []map[string]any `json:"tools"`
+		InstanceSurfaces map[string]struct {
+			Endpoint                     string `json:"endpoint"`
+			ProtectedResourceMetadataURL string `json:"protected_resource_metadata_url"`
+			ToolsDiscovery               string `json:"tools_discovery"`
+		} `json:"instance_surfaces"`
+		Auth struct {
 			Type   string   `json:"type"`
 			Scopes []string `json:"scopes"`
 			Notes  string   `json:"notes"`
@@ -73,6 +103,28 @@ func TestM7_WellKnownMcpJSON(t *testing.T) {
 	if strings.Contains(strings.ToLower(out.Auth.Notes), "or managed instance key") {
 		t.Fatalf("discovery should not recommend managed instance key, got %q", out.Auth.Notes)
 	}
+	for _, scope := range out.Auth.Scopes {
+		if scope == "admin" || strings.Contains(scope, "instance") {
+			t.Fatalf("discovery advertised non-public scope %q", scope)
+		}
+	}
+	if got := out.InstanceSurfaces["ptah"].Endpoint; got != "https://api.example.com/instance/ptah/mcp" {
+		t.Fatalf("ptah endpoint = %q", got)
+	}
+	if got := out.InstanceSurfaces["ptah"].ProtectedResourceMetadataURL; got != "https://api.example.com/.well-known/oauth-protected-resource/instance/ptah/mcp" {
+		t.Fatalf("ptah protected_resource_metadata_url = %q", got)
+	}
+	if got := out.InstanceSurfaces["ba"].Endpoint; got != "https://api.example.com/instance/ba/mcp" {
+		t.Fatalf("ba endpoint = %q", got)
+	}
+	if got := out.InstanceSurfaces["ba"].ProtectedResourceMetadataURL; got != "https://api.example.com/.well-known/oauth-protected-resource/instance/ba/mcp" {
+		t.Fatalf("ba protected_resource_metadata_url = %q", got)
+	}
+	for surface, hint := range out.InstanceSurfaces {
+		if hint.ToolsDiscovery != "authenticated tools/list" {
+			t.Fatalf("%s tools_discovery = %q", surface, hint.ToolsDiscovery)
+		}
+	}
 
 	foundEcho := false
 	foundSkillsCatalog := false
@@ -80,6 +132,8 @@ func TestM7_WellKnownMcpJSON(t *testing.T) {
 	foundArticleDraftCreate := false
 	foundArticleDraftPublish := false
 	foundPhoneCall := false
+	foundAgentCreate := false
+	foundAgentLocalInstallPlan := false
 	for _, tool := range out.Tools {
 		if tool["name"] == "echo" {
 			foundEcho = true
@@ -99,6 +153,12 @@ func TestM7_WellKnownMcpJSON(t *testing.T) {
 		if tool["name"] == "phone_call" {
 			foundPhoneCall = true
 		}
+		if tool["name"] == "agent_create" {
+			foundAgentCreate = true
+		}
+		if tool["name"] == "agent_local_install_plan" {
+			foundAgentLocalInstallPlan = true
+		}
 	}
 	if !foundEcho {
 		t.Fatalf("expected echo tool in well-known doc")
@@ -114,6 +174,9 @@ func TestM7_WellKnownMcpJSON(t *testing.T) {
 	}
 	if foundPhoneCall {
 		t.Fatalf("phone_call should not appear in well-known doc")
+	}
+	if foundAgentCreate || foundAgentLocalInstallPlan {
+		t.Fatalf("instance-plane tools must not appear in Ka public tools list")
 	}
 }
 
@@ -136,12 +199,25 @@ func TestM7_WellKnownMcpJSON_AdvertisesActorTemplateEndpoint(t *testing.T) {
 	}
 
 	var out struct {
-		Endpoint string `json:"endpoint"`
+		Endpoint         string `json:"endpoint"`
+		InstanceSurfaces map[string]struct {
+			Endpoint                     string `json:"endpoint"`
+			ProtectedResourceMetadataURL string `json:"protected_resource_metadata_url"`
+		} `json:"instance_surfaces"`
 	}
 	if err := json.Unmarshal(resp.Body, &out); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	if out.Endpoint != "https://api.example.com/mcp/{actor}" {
 		t.Fatalf("unexpected endpoint: %q", out.Endpoint)
+	}
+	if got := out.InstanceSurfaces["ptah"].Endpoint; got != "https://api.example.com/instance/ptah/mcp" {
+		t.Fatalf("unexpected ptah instance endpoint: %q", got)
+	}
+	if got := out.InstanceSurfaces["ba"].Endpoint; got != "https://api.example.com/instance/ba/mcp" {
+		t.Fatalf("unexpected ba instance endpoint: %q", got)
+	}
+	if got := out.InstanceSurfaces["ptah"].ProtectedResourceMetadataURL; got != "https://api.example.com/.well-known/oauth-protected-resource/instance/ptah/mcp" {
+		t.Fatalf("unexpected ptah metadata url: %q", got)
 	}
 }


### PR DESCRIPTION
## Milestone
Legend of Lesser Project 48 M9/B16 — publish instance discovery and RFC 9728 metadata.

Parent: #361
Child: #362

Closes #362

## Classification
MCP-contract additive / instance-plane public discovery.

## Surfaces affected
- `GET /.well-known/oauth-protected-resource/instance/ptah/mcp`
- `GET /.well-known/oauth-protected-resource/instance/ba/mcp`
- `GET /.well-known/mcp.json` additive `instance_surfaces` section only
- Compatibility guard for `GET /.well-known/oauth-protected-resource/mcp/{actor}` scopes

## Specialist walks referenced
- MCP contract: additive field and two new RFC 9728 documents; actor metadata remains issuable Lesser OAuth scopes only.
- Tool surface: no Ptah/Ba tools are registered or advertised on Ka public discovery; instance tools remain authenticated `tools/list` only.
- Lesser integration/framework: uses AppTheory v1.17.0 OAuth protected-resource metadata helpers; no TableTheory/data-store changes.

## Implementation notes
- Replaces the two instance metadata stubs with AppTheory `oauth.NewProtectedResourceMetadata` documents.
- Uses configured `INSTANCE_MCP_ENDPOINT` for Ptah/Ba resources and fails closed on missing/mismatched public URL instead of deriving from untrusted Host headers.
- Adds `instance_surfaces.ptah` and `instance_surfaces.ba` to Ka public discovery with endpoint + protected-resource metadata URLs.
- Keeps public scopes at `read`, `write`, `follow`, `push`; does not advertise `admin` or instance-only scopes.

## Source gate inspected
- `go.mod` pins: `github.com/theory-cloud/apptheory v1.17.0`, `github.com/theory-cloud/tabletheory/v2 v2.0.3`
- AppTheory v1.17.0 `runtime/oauth/protected_resource.go`
- AppTheory v1.17.0 `runtime/aws_apigw_proxy.go` and `runtime/aws_apigw_proxy_test.go` route normalization for `.well-known/oauth-protected-resource/mcp/{actor}`
- Existing body `internal/mcpapp/well_known.go`
- Existing body `internal/mcpapp/discovery_validation_test.go`
- Existing body `internal/instanceapp/app.go`
- Existing `instance_metadata_not_implemented` tests in `internal/instanceapp/app_test.go`

## JSON/test evidence
- Ptah metadata test asserts `resource == https://api.example.com/instance/ptah/mcp`, `authorization_servers == [https://api.example.com]`, `scopes_supported == [read, write, follow, push]`, `bearer_methods_supported == [header]`, cache + CORS parity.
- Ba metadata test asserts `resource == https://api.example.com/instance/ba/mcp`, same issuer/scope/bearer/cache/CORS contract.
- Ka discovery test locks top-level keys to the previous contract plus additive `instance_surfaces`, and asserts:
  - `ptah.endpoint == https://api.example.com/instance/ptah/mcp`
  - `ptah.protected_resource_metadata_url == https://api.example.com/.well-known/oauth-protected-resource/instance/ptah/mcp`
  - `ba.endpoint == https://api.example.com/instance/ba/mcp`
  - `ba.protected_resource_metadata_url == https://api.example.com/.well-known/oauth-protected-resource/instance/ba/mcp`
  - Ka public tools do not include `agent_create` or `agent_local_install_plan`.
- Per-actor metadata test explicitly rejects advertised `admin` or instance-only scopes.

## Validation
- `git diff --check`
- `git ls-files '*.go' | xargs gofmt -l` (empty)
- `go test ./cmd/... ./internal/...`
- `go build ./cmd/... ./internal/...`
- `go vet ./cmd/... ./internal/...`
- `bash scripts/build.sh`

## Rollout / follow-ups
- No deployment in this PR.
- CI must pass before review/merge.
- No canary scripts (#364), no operator-doc chapter (#363), no M10 rollout, no sibling repo edits.
