### PR TITLE
docs: add instance-plane operator chapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ routes:
 - `GET /.well-known/mcp.json` → lesser-body (public discovery)
 - `GET /.well-known/oauth-protected-resource/mcp/{actor}` → lesser-body (public OAuth resource metadata)
 - `POST /mcp/{actor}` → lesser-body (authenticated MCP JSON-RPC)
+- `GET /.well-known/oauth-protected-resource/instance/{ptah|ba}/mcp` → lesser-body instance plane
+  (AppTheory/RFC 9728-backed Ptah/Ba OAuth resource metadata)
+- `POST /instance/ptah/mcp` and `POST /instance/ba/mcp` → lesser-body instance plane
+  (authenticated account-holder operator MCP)
 
 It reuses Lesser’s existing primitives:
 
@@ -18,6 +22,7 @@ It reuses Lesser’s existing primitives:
 - Lesser stage DynamoDB table (for memory events)
 - Lesser REST API (for social tools like timelines and post creation)
 - lesser-host Soul Comm APIs (for email/SMS/voice mailbox and outbound communication delegation)
+- Body-owned Ptah/Ba instance-plane tables for operator content, registry, one-time grants, and instance sessions
 
 For inbound MCP clients, the canonical auth path is the Lesser OAuth connector flow. Managed instance key and
 hardcoded bearer-token client configs are deprecated compatibility paths; see `docs/oauth-migration.md`.
@@ -25,6 +30,7 @@ hardcoded bearer-token client configs are deprecated compatibility paths; see `d
 ## Key Features
 
 - **MCP tools/resources/prompts** powered by AppTheory’s MCP runtime
+- **Ptah/Ba instance-plane operator surfaces** backed by AppTheory MCP and RFC 9728 protected-resource metadata
 - **SSM-first cross-stack wiring** (no CloudFormation exports/imports)
 - **Auth + scope enforcement** (`read|write|admin`) for tool calls
 - **Optional DynamoDB-backed MCP sessions** for production continuity
@@ -36,7 +42,7 @@ hardcoded bearer-token client configs are deprecated compatibility paths; see `d
 
 - Deploy: `docs/deployment.md`
 - Configure: `docs/configuration.md`
-- Verify MCP: `docs/mcp.md`
+- Verify MCP and Ptah/Ba instance plane: `docs/mcp.md`
 - Migrate legacy clients: `docs/oauth-migration.md`
 - Plan operator automation replacement: `docs/operator-auth-replacement.md`
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ This directory contains the canonical operator + developer documentation for `le
 1) Deploy the plugin (this repo): `docs/deployment.md`
 2) Managed release contract: `docs/managed-deploy-contract.md`
 3) Configure and verify: `docs/configuration.md`, `docs/mcp.md`
+   - Ptah/Ba instance-plane operator chapter: `docs/mcp.md#instance-plane-operator-chapter-ptahba`
 4) Managed deploy inventory/history: `docs/managed-deploy-inventory.md`
 5) Managed multi-asset fixture: `docs/managed-deploy-fixtures/app-theory-v1.5.0-multi-asset/`
 6) Migrate legacy bearer-token clients: `docs/oauth-migration.md`
@@ -44,6 +45,10 @@ Local dev guide: `docs/development.md`
 - Discovery doc: `GET https://api.<stageDomain>/.well-known/mcp.json`
 - OAuth protected-resource doc: `GET https://api.<stageDomain>/.well-known/oauth-protected-resource/mcp/<actor>`
 - MCP endpoint: `POST https://api.<stageDomain>/mcp/<actor>`
+- Instance-plane OAuth protected-resource docs:
+  `GET https://api.<stageDomain>/.well-known/oauth-protected-resource/instance/{ptah|ba}/mcp`
+- Instance-plane MCP endpoints: `POST https://api.<stageDomain>/instance/ptah/mcp` and
+  `POST https://api.<stageDomain>/instance/ba/mcp`
 
 Protocol + tool catalog: `docs/mcp.md`
 - Skills client flow: `docs/skills-mcp.md`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,20 +9,37 @@ stage and reuse that stage’s existing resources.
 
 ```
 MCP client (AgentCore / other)
-  └── HTTPS POST /mcp (api.<stageDomain>)
+  └── HTTPS POST /mcp/{actor} (api.<stageDomain>)
         └── API Gateway (Lesser REST API)
-              └── Lambda (lesser-body)
-                    ├── MCP server (tools/resources/prompts)
+              └── Lambda (lesser-body Ka)
+                    ├── AppTheory MCP server (tools/resources/prompts)
                     ├── Calls Lesser REST API for social tools
                     ├── Calls lesser-host Soul Comm APIs for email/SMS/voice mailbox and send/reply
                     └── Reads/writes Lesser DynamoDB table for memory events
+
+Operator client
+  ├── HTTPS POST /instance/ptah/mcp (api.<stageDomain>)
+  │     └── Lesser API domain proxy
+  │           └── Lambda (lesser-body instance plane / Ptah)
+  │                 ├── AppTheory MCP server (account-holder orchestration tools)
+  │                 ├── Body-owned INSTANCE_CONTENT_TABLE / INSTANCE_REGISTRY_TABLE
+  │                 └── Lesser-owned APIs for delegation and hosted soul/body binding
+  └── HTTPS POST /instance/ba/mcp (api.<stageDomain>)
+        └── Lesser API domain proxy
+              └── Lambda (lesser-body instance plane / Ba)
+                    ├── AppTheory MCP server (install-pack planning tool)
+                    ├── Body-owned INSTANCE_CONTENT_TABLE / INSTANCE_GRANT_TABLE
+                    └── GET /instance/downloads/installer-grants/{grantId} for one-time ZIP downloads
 ```
 
 Notes:
 
 - The `lesser-body` CDK stack currently provisions its own API Gateway REST API v1 (AppTheory “Remote MCP server”).
   In the Lesser ecosystem, the intended client-facing path is still **through the Lesser API custom domain**
-  (`https://api.<stageDomain>/mcp`) when `soulEnabled=true`.
+  (`https://api.<stageDomain>/mcp/{actor}`) when `soulEnabled=true`.
+- The Ptah/Ba instance plane is also reached through the Lesser API custom domain. It uses a separate Lambda entrypoint,
+  separate AppTheory MCP server instances, and Body-owned instance tables so Ptah/Ba operator state does not become
+  Lesser actor-table writes.
 
 ## Components
 
@@ -32,7 +49,16 @@ Notes:
   - boots an AppTheory app
   - mounts:
     - `GET /.well-known/mcp.json` (discovery)
+    - `GET /.well-known/oauth-protected-resource/mcp/{actor}` (RFC 9728 protected-resource metadata)
     - `/mcp` (MCP JSON-RPC handler; auth required)
+- `cmd/lesser-body-instance/main.go`
+  - boots the Ptah/Ba AppTheory app
+  - mounts:
+    - `GET /.well-known/oauth-protected-resource/instance/ptah/mcp`
+    - `GET /.well-known/oauth-protected-resource/instance/ba/mcp`
+    - `POST /instance/ptah/mcp`
+    - `POST /instance/ba/mcp`
+    - `GET /instance/downloads/installer-grants/{grantId}`
 
 ### MCP server (tool registry)
 
@@ -41,6 +67,21 @@ Notes:
   - optional DynamoDB-backed session store when `MCP_SESSION_TABLE` is set
   - optional DynamoDB-backed stream replay store when `MCP_STREAM_TABLE` is set; AppTheory spills large logical stream
     events to the private `MCP_STREAM_SPILL_BUCKET` without changing the client-visible SSE / `Last-Event-ID` contract
+
+### Instance plane (Ptah/Ba)
+
+- `internal/instanceapp/`
+  - creates separate AppTheory MCP server instances for `ptah` and `ba`
+  - serves Ptah/Ba RFC 9728 protected-resource metadata from configured `INSTANCE_MCP_ENDPOINT`
+  - rejects agent-delegated and legacy managed-instance-key principals before instance tool dispatch
+  - serves the Ba header-free one-time installer-grant download route
+- `internal/ptahserver/`
+  - registers account-holder orchestration tools for agent registry, draft content, delegation, and binding
+  - uses Body-owned instance tables and Lesser-owned APIs rather than direct Lesser table writes
+- `internal/baserver/`
+  - registers `agent_local_install_plan`
+  - derives install-pack stage/domain and download origin from `INSTANCE_MCP_ENDPOINT`, not request Host headers
+  - persists only one-time grant hashes and safe binding fields through `internal/downloadgrant`
 
 ### Auth
 
@@ -86,15 +127,23 @@ Notes:
 
 The intended integration is:
 
-1) `lesser-body` publishes `mcp_lambda_arn` to SSM
-2) Lesser imports that ARN when `soulEnabled=true` and wires:
+1) `lesser-body` publishes Ka and instance-plane exports to SSM
+2) Lesser imports `mcp_lambda_arn` when `soulEnabled=true` and wires:
    - `POST /mcp` (streaming integration)
    - `GET /.well-known/mcp.json`
+   - `GET /.well-known/oauth-protected-resource/mcp/{actor}`
+3) Lesser imports `instance_mcp_lambda_arn` when its instance-plane routing flag is enabled and wires:
+   - `POST /instance/ptah/mcp`
+   - `POST /instance/ba/mcp`
+   - `GET /.well-known/oauth-protected-resource/instance/ptah/mcp`
+   - `GET /.well-known/oauth-protected-resource/instance/ba/mcp`
+   - `GET /instance/downloads/installer-grants/{grantId}`
 
 See:
 
 - `docs/deployment.md`
 - `docs/configuration.md`
+- `docs/mcp.md#instance-plane-operator-chapter-ptahba`
 - `docs/oauth-migration.md`
 - `docs/operator-auth-replacement.md`
 - `ROADMAP.md` (implementation sequencing and constraints)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -110,10 +110,19 @@ that runtime only for the current read-only `skill_bundle_get` pilot; task state
 - `MCP_ENDPOINT` (string, required for public discovery/OAuth metadata)
   - The public MCP endpoint template clients should use (for example: `https://api.dev.example.com/mcp/{actor}`).
   - Used by `GET /.well-known/mcp.json` and by the `agent://config` resource.
+  - Also used by public discovery to derive the `instance_surfaces` locator for Ptah/Ba.
   - Discovery validates that inbound requests are arriving on the same public MCP URL instead of emitting
     mismatched `resource` metadata.
   - Public discovery fails closed when unset; lesser-body does not infer OAuth resource metadata from `Host` or
     `X-Forwarded-Host` headers.
+- `INSTANCE_MCP_ENDPOINT` (string, required for the instance-plane Lambda)
+  - The canonical instance-plane endpoint template, for example:
+    `https://api.dev.example.com/instance/{surface}/mcp`.
+  - `{surface}` is replaced with `ptah` or `ba` for RFC 9728 protected-resource metadata and Ba install-plan URLs.
+  - Used by Ptah/Ba protected-resource metadata to publish exact `resource` URLs and by Ba to derive the stage domain,
+    actor MCP endpoint, and one-time install-pack download origin.
+  - The configured value is canonical. Instance discovery may compare request-derived host/protocol values against it,
+    but raw `Host` / `X-Forwarded-Host` headers are never a substitute when configuration is missing or mismatched.
 - `MCP_ALLOWED_ORIGINS` (string, optional but recommended for browser clients)
   - Comma-separated list of allowed browser origins for discovery and MCP responses.
   - Deployed CDK defaults include `https://claude.ai`, `https://claude.com`, and the stage domains.
@@ -192,6 +201,21 @@ Published by this repo’s CDK stack:
   - Session table name (if provisioned).
 - `/<app>/<stage>/lesser-body/exports/v1/mcp_stream_table_name`
   - Stream table used for MCP streaming state.
+- `/<app>/<stage>/lesser-body/exports/v1/instance_mcp_lambda_arn`
+  - Imported by Lesser when its instance-plane routing flag is enabled to wire
+    `POST /instance/ptah/mcp`, `POST /instance/ba/mcp`,
+    `GET /.well-known/oauth-protected-resource/instance/ptah/mcp`,
+    `GET /.well-known/oauth-protected-resource/instance/ba/mcp`, and the Ba installer-grant download route.
+- `/<app>/<stage>/lesser-body/exports/v1/instance_mcp_endpoint_url`
+  - Convenience value intended to equal `https://api.<stageDomain>/instance/{surface}/mcp`.
+- `/<app>/<stage>/lesser-body/exports/v1/instance_content_table_name`
+  - Body-owned Ptah/Ba content table name.
+- `/<app>/<stage>/lesser-body/exports/v1/instance_registry_table_name`
+  - Body-owned Ptah account-scoped agent registry table name.
+- `/<app>/<stage>/lesser-body/exports/v1/instance_grant_table_name`
+  - Body-owned Ba one-time install/download grant table name.
+- `/<app>/<stage>/lesser-body/exports/v1/instance_session_table_name`
+  - Body-owned instance-plane MCP session table name.
 
 The MCP task table is intentionally internal while the `tasks` capability is disabled. The current CDK stack does not
 publish `/<app>/<stage>/lesser-body/exports/v1/mcp_task_table_name`; adding that SSM export would be a separate

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -8,6 +8,10 @@ API domain as:
 - `GET /.well-known/mcp.json` (public discovery)
 - `GET /.well-known/oauth-protected-resource/mcp/{actor}` (public OAuth protected-resource metadata)
 - `POST /mcp/{actor}` (authenticated MCP JSON-RPC)
+- `GET /.well-known/oauth-protected-resource/instance/ptah/mcp` and
+  `GET /.well-known/oauth-protected-resource/instance/ba/mcp` (public Ptah/Ba OAuth protected-resource metadata)
+- `POST /instance/ptah/mcp` and `POST /instance/ba/mcp` (authenticated account-holder instance-plane MCP)
+- `GET /instance/downloads/installer-grants/{grantId}` (Ba one-time install-pack download grants)
 
 ## Prerequisites
 
@@ -21,17 +25,21 @@ API domain as:
 This repo’s CDK stack deploys:
 
 - `lesser-body` MCP Lambda (`cmd/lesser-body`)
+- `lesser-body` instance-plane Lambda (`cmd/lesser-body-instance`) for Ptah/Ba
 - A standalone **Remote MCP gateway** (API Gateway REST API v1) via AppTheory CDK (`AppTheoryRemoteMcpServer`)
 - (Recommended) DynamoDB session table for MCP sessions
 - DynamoDB stream table for MCP streaming state
 - Private S3 stream-spill bucket for large logical MCP stream events
 - DynamoDB task table for future MCP task runtime state, with the `tasks` capability still disabled
+- Body-owned DynamoDB tables for Ptah/Ba content, registry, one-time grants, and instance-plane MCP sessions
 - SSM exports used by the Lesser stack to wire routes
 
 Notes:
 
 - The **canonical** client-facing endpoint in the Lesser ecosystem is `https://api.<stageDomain>/mcp/{actor}` (wired by
   the Lesser stack when `soulEnabled=true`).
+- The canonical instance-plane endpoint template is `https://api.<stageDomain>/instance/{surface}/mcp` (wired by the
+  Lesser stack when its instance-plane routing flag is enabled).
 - The standalone execute-api endpoint exists as part of the current `lesser-body` stack implementation; treat it as an
   implementation detail unless you are intentionally using it for isolated testing.
 
@@ -49,6 +57,12 @@ And it publishes these (consumed by Lesser when `soulEnabled=true`):
 - `/<app>/<stage>/lesser-body/exports/v1/mcp_endpoint_url`
 - `/<app>/<stage>/lesser-body/exports/v1/mcp_session_table_name` (when session table is enabled)
 - `/<app>/<stage>/lesser-body/exports/v1/mcp_stream_table_name`
+- `/<app>/<stage>/lesser-body/exports/v1/instance_mcp_lambda_arn`
+- `/<app>/<stage>/lesser-body/exports/v1/instance_mcp_endpoint_url`
+- `/<app>/<stage>/lesser-body/exports/v1/instance_content_table_name`
+- `/<app>/<stage>/lesser-body/exports/v1/instance_registry_table_name`
+- `/<app>/<stage>/lesser-body/exports/v1/instance_grant_table_name`
+- `/<app>/<stage>/lesser-body/exports/v1/instance_session_table_name`
 
 The stream-spill bucket is internal to body's AppTheory-backed MCP transport. It is not an SSM export and does not
 change the public MCP endpoint contract; clients still resume by logical `Last-Event-ID`.
@@ -59,16 +73,22 @@ AppTheory's task runtime for the read-only `skill_bundle_get` task pilot and the
 
 ## Deploy order (avoid the “missing SSM param” trap)
 
-Because Lesser wires `/mcp/{actor}` by importing `mcp_lambda_arn` from SSM, and `lesser-body` requires Lesser’s SSM exports, the
-safe sequence is:
+Because Lesser wires `/mcp/{actor}` and `/instance/{surface}/mcp` by importing Body Lambda ARNs from SSM, and
+`lesser-body` requires Lesser's SSM exports, the safe first-time sequence is:
 
-1) Deploy Lesser with `soulEnabled=false` (so it does **not** try to import lesser-body yet)
-2) Deploy `lesser-body` (this repo)
-3) Re-deploy Lesser with `soulEnabled=true` (so `/mcp/{actor}`, `/.well-known/mcp.json`, and
-   `/.well-known/oauth-protected-resource/mcp/{actor}` route to the lesser-body Lambda)
+1) Deploy Lesser with Body routing disabled (`soulEnabled=false`; keep the Lesser-side `instancePlaneEnabled` routing
+   flag off as well) so it does **not** try to import Body SSM exports yet.
+2) Deploy `lesser-body` (this repo). This publishes the Ka exports plus the instance-plane exports and provisions the
+   Ptah/Ba state tables.
+3) Re-deploy Lesser with `soulEnabled=true` and, when enabling Ptah/Ba, `instancePlaneEnabled=true` so
+   `/mcp/{actor}`, `/.well-known/mcp.json`, `/.well-known/oauth-protected-resource/mcp/{actor}`,
+   `/.well-known/oauth-protected-resource/instance/ptah/mcp`,
+   `/.well-known/oauth-protected-resource/instance/ba/mcp`, `/instance/ptah/mcp`, `/instance/ba/mcp`, and the Ba
+   installer-grant download route proxy to Body.
 
-If you already have `mcp_lambda_arn` present for the target stage, you can deploy Lesser with `soulEnabled=true`
-immediately.
+If you already have the relevant Body SSM exports present for the target stage, you can deploy Lesser with the matching
+routing flag(s) enabled immediately. Do not rename, delete, or manually patch the `/exports/v1/` SSM parameters; older
+Lesser deployments may still read them.
 
 ## Build the Lambda artifact
 
@@ -81,6 +101,7 @@ bash scripts/build.sh
 Output:
 
 - `dist/lesser-body.zip`
+- `dist/lesser-body-instance.zip`
 
 ## Deploy (CDK directly)
 
@@ -165,6 +186,8 @@ After deploy, confirm exports exist:
 ```bash
 aws ssm get-parameter --name "/<app>/<stage>/lesser-body/exports/v1/mcp_lambda_arn"
 aws ssm get-parameter --name "/<app>/<stage>/lesser-body/exports/v1/mcp_endpoint_url"
+aws ssm get-parameter --name "/<app>/<stage>/lesser-body/exports/v1/instance_mcp_lambda_arn"
+aws ssm get-parameter --name "/<app>/<stage>/lesser-body/exports/v1/instance_mcp_endpoint_url"
 ```
 
 Do not expect an `mcp_task_table_name` export in this phase; the task table remains an internal AppTheory runtime asset
@@ -201,6 +224,26 @@ Expected headers include:
 - `vary: origin`
 
 MCP calls require auth. See `docs/mcp.md` for examples and auth expectations.
+
+When Lesser is also deployed with `instancePlaneEnabled=true`, verify the AppTheory/RFC 9728-backed Ptah/Ba metadata
+before invoking instance tools:
+
+```bash
+curl -sS "https://api.<stageDomain>/.well-known/oauth-protected-resource/instance/ptah/mcp" | jq .
+curl -sS "https://api.<stageDomain>/.well-known/oauth-protected-resource/instance/ba/mcp" | jq .
+```
+
+Expected instance protected-resource fields are the same `resource`, `authorization_servers`, `scopes_supported`, and
+`bearer_methods_supported` fields. `resource` must match the exact instance endpoint
+(`https://api.<stageDomain>/instance/ptah/mcp` or `https://api.<stageDomain>/instance/ba/mcp`), and scopes should remain
+the public Lesser OAuth catalog (`read`, `write`, `follow`, `push`).
+
+After metadata verification, use an account-holder OAuth token with an audience for the exact instance resource URL,
+send MCP `initialize`, and then call authenticated `tools/list` on the Ptah or Ba endpoint. Do not synthesize local
+OAuth metadata, skip AppTheory initialization, or reuse actor-scoped `/mcp/{actor}` tokens against instance resources.
+
+Project 48 status note: the #364 Ptah/Ba lab canary evidence and M10 rollout/soak remain pending. Do not mark lab soak,
+deploy-stage staging soak, or live rollout complete from the metadata checks above alone.
 
 For host-backed communication validation in lab, run the mailbox canary with an actor-scoped OAuth token. The script
 checks `identity_whoami`, `identity_lookup`, default/standard mailbox compatibility, and explicit

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -12,10 +12,16 @@
   - `GET /mcp/{actor}` and `DELETE /mcp/{actor}` are also supported for MCP Streamable HTTP compatibility.
 - Shared compatibility endpoint: `GET|POST|DELETE /mcp`
   - Returns HTTP `410 Gone` with migration guidance. It no longer serves MCP traffic.
+- Instance-plane Ptah OAuth protected-resource metadata:
+  `GET /.well-known/oauth-protected-resource/instance/ptah/mcp`
 - Instance-plane Ptah MCP (authenticated): `POST /instance/ptah/mcp`
   - Uses a separate AppTheory MCP server instance for account-holder orchestration tools.
+- Instance-plane Ba OAuth protected-resource metadata:
+  `GET /.well-known/oauth-protected-resource/instance/ba/mcp`
 - Instance-plane Ba MCP (authenticated): `POST /instance/ba/mcp`
   - Uses a separate AppTheory MCP server instance for account-holder install-pack/grant tooling.
+- Instance-plane Ba install-pack download grants:
+  `GET /instance/downloads/installer-grants/{grantId}`
 
 Canonical base URL for a Lesser stage:
 
@@ -140,6 +146,142 @@ Client registration remains a Lesser concern. Today the Lesser API exposes publi
 `lesser-body` does not proxy or emulate client registration. If your MCP client specifically expects RFC 7591 dynamic
 client registration rather than Lesser's existing app-registration flow, pre-register the OAuth client and configure
 its credentials out of band.
+
+## Instance-plane operator chapter (Ptah/Ba)
+
+The instance plane is the operator-facing control surface for authoring and installing Lesser agents. It is deliberately
+separate from Ka, the actor-scoped agent MCP surface. Operators should treat the three surfaces as separate MCP
+resources:
+
+| Plane | Public route | Purpose | Tool discovery |
+|-------|--------------|---------|----------------|
+| Ka actor surface | `/mcp/{actor}` | An individual Lesser agent's social, memory, communication, identity, resources, prompts, and task-capable read tools. | Public `/.well-known/mcp.json` lists Ka tools; authenticated `tools/list` is profile-filtered for that actor. |
+| Ptah instance surface | `/instance/ptah/mcp` | Account-holder orchestration: account-scoped agent registry, draft `agent_soul` / `agent_instructions`, Lesser delegation, and hosted soul/body binding. | Authenticated Ptah `tools/list` only. Ptah tools are not advertised as Ka tools. |
+| Ba instance surface | `/instance/ba/mcp` | Account-holder local install planning: deterministic install pack rendering and one-time download-grant minting. | Authenticated Ba `tools/list` only. Ba tools are not advertised as Ka tools. |
+| Ba download route | `/instance/downloads/installer-grants/{grantId}` | Header-free one-time ZIP download after `agent_local_install_plan` issues a grant. | Not an MCP endpoint; it is a public GET guarded by the opaque token and full binding query. |
+
+### Discovery and RFC 9728 metadata
+
+Ptah/Ba discovery and auth metadata are AppTheory/RFC 9728-backed. Body uses AppTheory's OAuth protected-resource
+metadata model for the published `resource`, `authorization_servers`, `scopes_supported`, and
+`bearer_methods_supported` fields; operators must not replace it with a local OAuth metadata shim or an MCP-client
+specific shortcut.
+
+- Ka public discovery is `GET /.well-known/mcp.json`. It includes an `instance_surfaces` map for `ptah` and `ba` derived
+  from the configured `MCP_ENDPOINT`, with each instance endpoint and protected-resource metadata URL. This is a locator
+  for operators; it is not Ptah/Ba tool-schema discovery.
+- Ptah protected-resource metadata is
+  `GET /.well-known/oauth-protected-resource/instance/ptah/mcp` and its `resource` is the exact
+  `https://api.<stageDomain>/instance/ptah/mcp` URL.
+- Ba protected-resource metadata is
+  `GET /.well-known/oauth-protected-resource/instance/ba/mcp` and its `resource` is the exact
+  `https://api.<stageDomain>/instance/ba/mcp` URL.
+- Public OAuth metadata advertises only issuable Lesser scopes: `read`, `write`, `follow`, and `push`. It does not
+  advertise `admin` or Host instance-capability strings.
+
+`MCP_ENDPOINT` and `INSTANCE_MCP_ENDPOINT` are the source of truth for public resource identifiers. Runtime discovery
+may validate request-derived host/protocol information against those configured URLs, but the configured endpoints remain
+canonical; raw `Host` or `X-Forwarded-Host` headers are not trusted as a substitute when configuration is absent or
+mismatched.
+
+### Required configuration
+
+The operator-facing endpoint variables are:
+
+- `MCP_ENDPOINT` on the Ka Lambda, for example `https://api.<stageDomain>/mcp/{actor}`.
+  - Required for `/.well-known/mcp.json`, Ka RFC 9728 metadata, and Ka resource URLs.
+  - Used to derive the `instance_surfaces` locator in public discovery.
+- `INSTANCE_MCP_ENDPOINT` on the instance Lambda, for example
+  `https://api.<stageDomain>/instance/{surface}/mcp`.
+  - Required for Ptah/Ba RFC 9728 metadata.
+  - `{surface}` is replaced with `ptah` or `ba`.
+  - Used by Ba to derive the stage domain, canonical actor MCP endpoints inside install packs, and grant download
+    origin.
+
+Body CDK publishes the Ka SSM exports (`mcp_lambda_arn`, `mcp_endpoint_url`, session/stream table names) and the
+instance-plane SSM exports (`instance_mcp_lambda_arn`, `instance_mcp_endpoint_url`,
+`instance_content_table_name`, `instance_registry_table_name`, `instance_grant_table_name`, and
+`instance_session_table_name`) under `/<app>/<stage>/lesser-body/exports/v1/`. Lesser imports those exports when its
+corresponding routing flags are enabled.
+
+### Deploy order and rollout status
+
+For a first-time stage, keep the SSM-first order:
+
+1. Deploy Lesser without Body routing enabled (`soulEnabled=false`; keep the Lesser-side `instancePlaneEnabled` routing
+   flag off as well).
+2. Deploy `lesser-body`. This publishes both Ka and instance-plane SSM exports and provisions the instance-plane state
+   tables.
+3. Re-deploy Lesser with `soulEnabled=true` and, when the stage is ready for Ptah/Ba, `instancePlaneEnabled=true` so
+   Lesser wires `/mcp/{actor}`, Ka discovery, Ptah/Ba protected-resource metadata, Ptah/Ba MCP routes, and the Ba
+   installer-grant download route through the Lesser API domain.
+
+Subsequent deployments can update Body and Lesser independently as long as the existing SSM exports remain present and
+stable. Do not rename or delete the `/exports/v1/` parameters.
+
+Project 48 status note: #364 lab canary evidence and M10 rollout/soak remain pending. This document describes the
+operator contract and validation expectations; it does not claim that lab canaries, lab soak, deploy-stage staging soak,
+or live rollout have completed.
+
+### Auth model and threat model
+
+Ptah and Ba require Lesser OAuth JWT bearer authentication against the exact instance resource URL:
+
+- `https://api.<stageDomain>/instance/ptah/mcp`
+- `https://api.<stageDomain>/instance/ba/mcp`
+
+The principal must be an account-holder OAuth token. Agent-delegated principals, legacy managed-instance-key principals,
+missing bearer tokens, and actor-username mismatches fail closed before tool side effects. Write tools still require
+write-capable OAuth scope, and read tools require read-capable scope. The managed instance key remains a server-to-server
+credential for lesser-host communication and compatibility paths; it is not an instance-plane operator login.
+
+Threat model invariants:
+
+- Ptah/Ba tools are not dynamically registered and are not advertised in the Ka public tool list.
+- Discovery/auth stays AppTheory/RFC 9728-backed; do not synthesize local OAuth metadata or bypass the AppTheory MCP
+  initialization / authenticated `tools/list` path.
+- Configured public endpoint templates are canonical. Raw Host headers, caller-supplied origins, and download query
+  fields are validation inputs, not authority.
+- Ptah writes only Body-owned instance content/registry state or delegates through Lesser-owned APIs; it does not write
+  Lesser's actor table directly.
+- Ba grant state lives in Body's `INSTANCE_GRANT_TABLE`; only token hashes and safe binding fields persist.
+- Logs and text content must never include bearer tokens, raw grant tokens, full grant URLs, token hashes,
+  `LESSER_HOST_INSTANCE_KEY`, `agent_soul` bodies, or `agent_instructions` bodies.
+
+### Instance-plane x402 policy
+
+Instance-plane x402 capability grants are distinct from actor-scoped public x402 invocation grants:
+
+- OAuth is still required. The grant augments a non-operator account-holder OAuth request; it does not create an OAuth
+  principal and does not grant actor-scoped public invocation authority.
+- Explicit operator OAuth authority is exempt from the instance x402 gate for the operator principal only.
+- `agent_create` consumes Host capability `instance-capability/v1` / `instance:agent_create`, bound to
+  `tool="agent_create"` and `resource="instance://tools/agent_create"`.
+- `agent_local_install_plan` consumes Host capability `instance-capability/v1` / `instance:install_plan`, bound to
+  `tool="agent_local_install_plan"` and `resource="instance://tools/agent_local_install_plan"`.
+- Body hashes payment evidence before Host consume, rejects actor/scoped invocation grants such as
+  `scoped-invocation/v1` / `tools.invoke`, and performs no non-idempotent side effect until Host accepts the exact
+  capability/tool/resource/request/payment binding.
+
+### Ba grant and download URL semantics
+
+`agent_local_install_plan` returns a TheoryMCP-compatible install-plan envelope in `structuredContent.data`. The text
+content is only a locator; operators and canaries should read the structured fields:
+
+- `install_pack_resource.uri` / `download_url` is a one-time header-free GET URL for local installer clients.
+- `install_pack_resource.requires_authorization_header` is `false`; clients must not attach OAuth bearer tokens to the
+  download request.
+- The URL contains the raw token only once, at issuance. Treat it as a secret and do not print it in logs, shell
+  history, issue comments, canary output, or release notes.
+- The route consumes a matching active grant atomically. A successful first GET returns `application/zip` with
+  `Cache-Control: no-store`; same-token replay returns `410 Gone`; unknown, expired, mismatched-token, and
+  mismatched-binding requests return a generic `404 Not Found`.
+- Clients must verify `pack_checksum` against the ZIP bytes, inspect `MANIFEST.json`, and verify every
+  `manifest_entries[].checksum` before writing or merging local files.
+
+Detailed Ptah/Ba tool schemas and result shapes remain in the
+[Instance-plane Ptah tools](#instance-plane-ptah-tools) and
+[Instance-plane Ba tools](#instance-plane-ba-tools) sections below.
 
 ## Canonical vs transitional auth paths
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -7,8 +7,13 @@ This doc describes the implemented security posture of `lesser-body`.
 ## Public surface
 
 - **Public:** `GET /.well-known/mcp.json`
-- **Public:** `GET /.well-known/oauth-protected-resource`
-- **Auth required:** `POST /mcp` (also `GET /mcp`, `DELETE /mcp`)
+- **Public:** `GET /.well-known/oauth-protected-resource/mcp/{actor}`
+- **Public:** `GET /.well-known/oauth-protected-resource/instance/ptah/mcp`
+- **Public:** `GET /.well-known/oauth-protected-resource/instance/ba/mcp`
+- **Public one-time download:** `GET /instance/downloads/installer-grants/{grantId}` with the opaque token and full
+  binding query issued by Ba
+- **Auth required:** `POST /mcp/{actor}` (also `GET /mcp/{actor}`, `DELETE /mcp/{actor}`)
+- **Auth required:** `POST /instance/ptah/mcp`, `POST /instance/ba/mcp`
 
 ## Authentication model
 
@@ -27,6 +32,26 @@ This doc describes the implemented security posture of `lesser-body`.
   - default secret id fallback: `lesser/jwt-secret`
 - Tokens must include a non-empty `username` claim (used as the request identity).
 - Tokens are rejected if `iat` is older than 24 hours (a safety check independent of `exp`).
+
+### Instance-plane authentication and threat model
+
+Ptah (`/instance/ptah/mcp`) and Ba (`/instance/ba/mcp`) use separate AppTheory MCP server instances and separate RFC
+9728 protected-resource metadata documents. Their OAuth `resource` identifiers are the exact instance endpoint URLs
+derived from `INSTANCE_MCP_ENDPOINT`, for example `https://api.<stageDomain>/instance/ptah/mcp` and
+`https://api.<stageDomain>/instance/ba/mcp`. Operators must not replace this with local OAuth metadata, raw Host-header
+inference, or an MCP-client-specific shortcut.
+
+Instance-plane MCP requests require a Lesser OAuth JWT bearer token for an account-holder principal:
+
+- agent-delegated principals are rejected before tool dispatch;
+- legacy managed-instance-key principals are rejected before tool dispatch;
+- `actor_username` arguments, when present, must match the authenticated account-holder username;
+- read surfaces require read-capable scope and write/minting surfaces require write-capable scope; and
+- configured endpoint templates are canonical. Request Host / forwarded Host values can only be validated against
+  configuration, never used as authority when configuration is missing or mismatched.
+
+Ptah/Ba tools are not Ka actor tools. They are discovered with authenticated `tools/list` on the corresponding instance
+MCP endpoint, not by broadening `/.well-known/mcp.json` beyond its Ka tool catalog.
 
 ### Scope enforcement (MCP calls)
 
@@ -213,6 +238,9 @@ At a minimum, the MCP Lambda needs:
 - DynamoDB read/write on the MCP task table when task storage is provisioned. This is transient task runtime state used
   for session-scoped MCP task records; body advertises the MCP `tasks` capability only when `MCP_TASK_TABLE` is set and
   the read-only `skill_bundle_get` task pilot is registered.
+- DynamoDB read/write on Body-owned instance-plane tables for the instance Lambda only:
+  `INSTANCE_CONTENT_TABLE`, `INSTANCE_REGISTRY_TABLE`, `INSTANCE_GRANT_TABLE`, and `INSTANCE_SESSION_TABLE`. These
+  tables back Ptah/Ba operator state and one-time grant/session state; they are not Lesser actor data tables.
 - `ssm:GetParameter*` to read cross-stack parameters (Lesser exports, optional lesser-soul exports)
 
 ## Client considerations


### PR DESCRIPTION
## Milestone
Legend of Lesser Project 48 M9/B20 — lesser-body#363 operator documentation for the Ptah/Ba instance plane.

Closes #363

## Classification
docs / MCP-contract documentation / operator guidance

## Surfaces affected
- `docs/mcp.md`: consolidated Ptah/Ba instance-plane operator chapter
- `docs/configuration.md`: `MCP_ENDPOINT`, `INSTANCE_MCP_ENDPOINT`, instance SSM exports
- `docs/deployment.md`: deploy order including `instancePlaneEnabled`, instance metadata verification, pending canary/rollout note
- `docs/security.md`: instance-plane auth/threat model and IAM notes
- `docs/architecture.md`: Ka vs Ptah/Ba topology
- `README.md`, `docs/README.md`: operator entry-point links

## Specialist walks referenced
- MCP contract: docs-only audit; no runtime JSON shape change. Preserves AppTheory/RFC 9728 protected-resource metadata and authenticated `tools/list` discovery for Ptah/Ba.
- Lesser integration: SSM-first deploy order documented; Lesser-side `soulEnabled` and `instancePlaneEnabled` routing flags called out without changing source.
- Host delegation/x402: documents Host-authored instance capability grants and Ba one-time grant URL handling without raw-token examples.

## Consumer impact
Operator docs now explain how Ka actor MCP differs from Ptah/Ba instance MCP, which endpoint templates are canonical, and how to validate protected-resource metadata without local OAuth/discovery substitutes.

## Validation
- `git diff --check` ✅
- Introduced relative markdown link check ✅ (`0` introduced markdown links with missing targets)
- Secret/token pattern scan over changed docs ✅
- Pending status grep: only pending/no-completion statements for #364/M10 ✅
- Code untouched; local Go/CDK gates not required for this docs-only change. CI must still run on the PR.

## Explicit non-claims
- #364 lab canary evidence remains pending; PR #414 is not bundled here.
- M10 rollout/soak/live completion is not claimed.
- No deploy, release, cloud, sibling repo, or submodule-pin mutation is included.

## Stage rollout plan (handoff only)
- [ ] PR reviewed and merged to git branch `staging`
- [ ] #364 canary evidence remains separate
- [ ] M10 rollout/soak remains separate
