### PR TITLE
feat(ptah): surface Lesser live agents in agent_list

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -137,7 +137,8 @@ that runtime only for the current read-only `skill_bundle_get` pilot; task state
   - See `docs/oauth-migration.md` for the rollout sequence.
 - `LESSER_API_BASE_URL` (string, optional)
   - Base URL used by social tools when calling the Lesser REST API (for example: `https://api.dev.example.com`).
-  - If not set, it is derived from `MCP_ENDPOINT` by stripping `/mcp/{actor}` (or `/mcp`).
+  - If not set, it is derived from `MCP_ENDPOINT` by stripping `/mcp/{actor}` (or `/mcp`), or on the instance-plane
+    Lambda from `INSTANCE_MCP_ENDPOINT` by stripping `/instance/{surface}/mcp`.
 - `LESSER_SOUL_API_BASE_URL` (string, optional)
   - Base URL used by identity and communication tools when calling the soul API (for example: `https://lab.lesser.host`).
   - In managed deployments, if not set, lesser-body resolves it from the persisted Lesser `TRUST_CONFIG.baseURL` record

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -600,7 +600,7 @@ surface or Ba's `/instance/ba/mcp` surface. Clients discover them with an authen
 | `agent_bind_soul` | Write | Orchestrate Lesser's hosted soul/body binding ceremony for the authenticated account-holder actor. |
 | `agent_create` | Write | Delegate runtime credentials for an existing Lesser local agent account and create a Body/Ptah account-scoped registry entry. |
 | `agent_get` | Read | Read one Body/Ptah account-scoped registry entry for the authenticated account-holder actor. |
-| `agent_list` | Read | List Body/Ptah account-scoped registry entries with cursor pagination. |
+| `agent_list` | Read | List Body/Ptah account-scoped registry entries merged with Lesser's public live-agent directory, with cursor pagination. |
 | `agent_soul_get` | Read | Read the current account-scoped Ptah `agent_soul` draft/archived record. Schema marker: `provisional_agent_soul_schema_pending_lesser_soul_s1`. |
 | `agent_soul_upsert` | Write | Create or update account-scoped Ptah `agent_soul` draft content through `internal/agentcontent.Store`. Schema marker: `provisional_agent_soul_schema_pending_lesser_soul_s1`. |
 | `agent_soul_archive` | Write | Idempotently archive the current account-scoped Ptah `agent_soul` record through `internal/agentcontent.Store`. Schema marker: `provisional_agent_soul_schema_pending_lesser_soul_s1`. |
@@ -651,13 +651,26 @@ Malformed input returns `invalid_request`; registry read failures return `agent_
 - Not accepted: account overrides. The account partition is always derived from the authenticated account-holder
   principal.
 
-`agent_list` requires the same account-holder/read-capable authority as `agent_get`. It uses
-`internal/agentregistry.Store.List`, which performs a TableTheory query over the `ACCOUNT#<account>` partition and
-`AGENT#` sort-key prefix in `INSTANCE_REGISTRY_TABLE`; it does not scan the table, read Lesser's table, or call Lesser.
+`agent_list` requires the same account-holder/read-capable authority as `agent_get`. It first reads the authenticated
+account's Body-owned `internal/agentregistry.Store.List` path, which performs a TableTheory query over the
+`ACCOUNT#<account>` partition and `AGENT#` sort-key prefix in `INSTANCE_REGISTRY_TABLE`; it does not scan the table or
+read `LESSER_TABLE_NAME`. It then reads Lesser's authoritative public `GET /api/v1/agents` directory through the typed
+`internal/lesserapi` client. The request does not forward the Ptah caller bearer, so the live view remains the same public
+contract available to an anonymous Lesser API client.
 
-Successful output includes `structuredContent.data.agents`, where each item contains `registry`, `content_version`, and
-`content_summary` using the same shapes and current `not_available` placeholders as `agent_get`, plus pagination
-metadata:
+The two read-only views are merged deterministically. Registry ids that are actor URLs (or local ids) matching a live
+agent username are represented once with `source: "merged"`; the Body registry contribution remains in `registry` and
+the public Lesser contribution is in `live_agent`. Registry-only entries use `source: "ptah_registry"`; live-only entries
+use `source: "lesser_live"` and do not claim Body account ownership. Duplicate live usernames are case-insensitively
+deduplicated. Registry rows returned outside the authenticated account partition are discarded defensively. The merged
+ordering is stable and the returned cursor is opaque to clients. A live source failure fails closed with
+`agent_live_source_error` rather than returning a partial inventory.
+
+Successful output includes `structuredContent.data.agents`. Registry-backed items retain `registry`, `content_version`,
+and `content_summary` using the same current `not_available` placeholders as `agent_get`. Live-backed items add the
+public `live_agent` summary and source-specific content placeholders. The typed live summary allowlist excludes
+`agent_owner`, `delegated_scopes`, `identity_semantics.soul_agent_id`, OAuth tokens, and delegated runtime secrets. The
+tool never writes Lesser actor data. Pagination metadata remains:
 
 ```json
 {
@@ -670,7 +683,8 @@ metadata:
 }
 ```
 
-Invalid `limit` or `cursor` values return `invalid_request`. Registry failures return `agent_registry_error`.
+Invalid `limit` or cursor values return `invalid_request`. Body registry failures return `agent_registry_error`; Lesser
+directory failures return `agent_live_source_error` with no upstream response body or credential detail.
 
 `agent_soul_get` input:
 

--- a/internal/instanceapp/app_test.go
+++ b/internal/instanceapp/app_test.go
@@ -406,6 +406,10 @@ func TestInstancePlaneMCP_AgentGetAndListReadRegistry(t *testing.T) {
 		return registryStore, nil
 	})
 	t.Cleanup(resetRegistry)
+	resetLive := ptahserver.SetAgentLiveClientFactoryForTests(func() (ptahserver.AgentLiveClient, error) {
+		return &instanceAgentLiveClient{}, nil
+	})
+	t.Cleanup(resetLive)
 
 	t.Setenv("JWT_SECRET", "test-secret")
 	auth.ResetForTests()
@@ -490,6 +494,58 @@ func TestInstancePlaneMCP_AgentGetAndListReadRegistry(t *testing.T) {
 	secondPagination, _ := secondData["pagination"].(map[string]any)
 	if secondPagination["has_more"] != false || secondPagination["next_cursor"] != "" || secondPagination["count"] != float64(1) {
 		t.Fatalf("second pagination = %+v, want terminal page", secondPagination)
+	}
+}
+
+func TestInstancePlaneMCP_AgentListFallsBackToLesserLiveAgents(t *testing.T) {
+	registryStore := newInstanceAgentRegistryStore(t)
+	resetRegistry := ptahserver.SetAgentRegistryFactoryForTests(func() (ptahserver.AgentRegistry, error) {
+		return registryStore, nil
+	})
+	t.Cleanup(resetRegistry)
+	live := &instanceAgentLiveClient{agents: []lesserapi.AgentDirectoryEntry{{
+		Username:     "scout",
+		DisplayName:  "Scout",
+		AgentType:    "CUSTOM",
+		AgentVersion: "1",
+	}}}
+	resetLive := ptahserver.SetAgentLiveClientFactoryForTests(func() (ptahserver.AgentLiveClient, error) {
+		return live, nil
+	})
+	t.Cleanup(resetLive)
+
+	t.Setenv("JWT_SECRET", "test-secret")
+	auth.ResetForTests()
+
+	app, err := instanceapp.New("lesser-body-instance", "dev")
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+	env := testkit.New()
+	token := newTestTokenWithAudience(t, "test-secret", "agent1", []string{"read"}, audienceForPath("/instance/ptah/mcp"))
+	headers := initializedMCPHeaders(t, env, app, "/instance/ptah/mcp", token)
+	out := callMCPTool(t, env, app, "/instance/ptah/mcp", headers, "agent_list", map[string]any{})
+	if out.Result == nil || out.Result.IsError {
+		t.Fatalf("agent_list result = %+v error = %+v", out.Result, out.Error)
+	}
+	if live.calls != 1 {
+		t.Fatalf("live agent calls = %d, want one", live.calls)
+	}
+	data := toolResultData(t, out.Result)
+	agents, _ := data["agents"].([]any)
+	if len(agents) != 1 {
+		t.Fatalf("agents = %+v, want one live agent", data["agents"])
+	}
+	item, _ := agents[0].(map[string]any)
+	if item["source"] != "lesser_live" {
+		t.Fatalf("source = %v, want lesser_live", item["source"])
+	}
+	if _, ok := item["registry"]; ok {
+		t.Fatalf("live-only item claimed Body registry ownership: %+v", item)
+	}
+	liveSummary, _ := item["live_agent"].(map[string]any)
+	if liveSummary["username"] != "scout" {
+		t.Fatalf("live_agent = %+v, want scout", liveSummary)
 	}
 }
 
@@ -1069,6 +1125,16 @@ func newInstanceAgentRegistryStore(t testing.TB) *agentregistry.Store {
 		t.Fatalf("CreateTable() error = %v", err)
 	}
 	return store
+}
+
+type instanceAgentLiveClient struct {
+	calls  int
+	agents []lesserapi.AgentDirectoryEntry
+}
+
+func (f *instanceAgentLiveClient) ListAgents(_ context.Context) ([]lesserapi.AgentDirectoryEntry, error) {
+	f.calls++
+	return f.agents, nil
 }
 
 type instanceAgentRegistryRecord struct {

--- a/internal/lesserapi/agents_list.go
+++ b/internal/lesserapi/agents_list.go
@@ -1,0 +1,98 @@
+package lesserapi
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const agentsListPath = "/api/v1/agents"
+
+// AgentDirectoryEntry is the public, source-backed representation returned by
+// Lesser's GET /api/v1/agents endpoint. Deliberately private fields from
+// Lesser's richer model (agent_owner, delegated_scopes, and
+// identity_semantics.soul_agent_id) are not represented here. OAuth or
+// delegated credentials are likewise not part of this type.
+type AgentDirectoryEntry struct {
+	Username          string                     `json:"username"`
+	DisplayName       string                     `json:"display_name"`
+	Bio               string                     `json:"bio,omitempty"`
+	CreatedAt         *time.Time                 `json:"created_at,omitempty"`
+	Verified          bool                       `json:"verified"`
+	VerifiedAt        *time.Time                 `json:"verified_at,omitempty"`
+	QuarantineStatus  string                     `json:"quarantine_status,omitempty"`
+	QuarantineStart   *time.Time                 `json:"quarantine_start,omitempty"`
+	QuarantineEnd     *time.Time                 `json:"quarantine_end,omitempty"`
+	QuarantineActive  bool                       `json:"quarantine_active"`
+	AgentType         string                     `json:"agent_type"`
+	AgentVersion      string                     `json:"agent_version"`
+	AgentCapabilities AgentDirectoryCapabilities `json:"agent_capabilities"`
+	MCPAccess         AgentDirectoryMCPAccess    `json:"mcp_access"`
+	IdentitySemantics AgentDirectoryIdentity     `json:"identity_semantics"`
+}
+
+// AgentDirectoryCapabilities contains the public capability summary from
+// Lesser's agent directory response.
+type AgentDirectoryCapabilities struct {
+	CanPost           bool     `json:"can_post"`
+	CanReply          bool     `json:"can_reply"`
+	CanBoost          bool     `json:"can_boost"`
+	CanFollow         bool     `json:"can_follow"`
+	CanDM             bool     `json:"can_dm"`
+	RestrictedDomains []string `json:"restricted_domains,omitempty"`
+	MaxPostsPerHour   int      `json:"max_posts_per_hour"`
+	RequiresApproval  bool     `json:"requires_approval"`
+}
+
+// AgentDirectoryMCPAccess contains the public, client-neutral access links
+// advertised by Lesser for an agent.
+type AgentDirectoryMCPAccess struct {
+	MCPURL                 string   `json:"mcp_url"`
+	ProtectedResourceURL   string   `json:"protected_resource_url"`
+	AuthorizationServerURL string   `json:"authorization_server_url"`
+	RegistrationURL        string   `json:"registration_url"`
+	Scopes                 []string `json:"scopes"`
+	Guidance               []string `json:"guidance"`
+}
+
+// AgentDirectoryIdentity contains only the public identity semantics. The
+// source's soul_agent_id is intentionally omitted because anonymous Lesser
+// responses redact it as private binding metadata.
+type AgentDirectoryIdentity struct {
+	IdentityState             string `json:"identity_state"`
+	IdentityLabel             string `json:"identity_label"`
+	LifecycleState            string `json:"lifecycle_state"`
+	SoulBindingState          string `json:"soul_binding_state"`
+	ContinuityState           string `json:"continuity_state"`
+	ContinuitySummary         string `json:"continuity_summary"`
+	BodyIdentityPreserved     bool   `json:"body_identity_preserved"`
+	TimelinePresencePreserved bool   `json:"timeline_presence_preserved"`
+	MemoryReferencesPreserved bool   `json:"memory_references_preserved"`
+	AttributionLabel          string `json:"attribution_label"`
+	ModerationLabel           string `json:"moderation_label"`
+}
+
+// ListAgents reads Lesser's public live-agent directory. The endpoint is
+// intentionally called without a caller bearer: Body consumes the same public
+// view as an anonymous Lesser client and never forwards a Ptah OAuth token.
+func (c *Client) ListAgents(ctx context.Context) ([]AgentDirectoryEntry, error) {
+	body, err := c.DoRawJSON(ctx, http.MethodGet, agentsListPath, nil, "", nil)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(string(body)) == "" {
+		return []AgentDirectoryEntry{}, nil
+	}
+
+	var agents []AgentDirectoryEntry
+	if err := json.Unmarshal(body, &agents); err != nil {
+		return nil, fmt.Errorf("decode Lesser live-agent directory: %w", err)
+	}
+	if agents == nil {
+		agents = []AgentDirectoryEntry{}
+	}
+	return agents, nil
+}

--- a/internal/lesserapi/agents_list_test.go
+++ b/internal/lesserapi/agents_list_test.go
@@ -1,0 +1,128 @@
+package lesserapi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestListAgentsReadsPublicDirectoryWithoutCallerBearer(t *testing.T) {
+	var authorization string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("method = %s, want GET", r.Method)
+		}
+		if r.URL.Path != "/api/v1/agents" {
+			t.Fatalf("path = %s, want /api/v1/agents", r.URL.Path)
+		}
+		if r.URL.RawQuery != "" {
+			t.Fatalf("query = %q, want empty", r.URL.RawQuery)
+		}
+		authorization = r.Header.Get("Authorization")
+		if got := r.Header.Get("Accept"); got != "application/json" {
+			t.Fatalf("Accept = %q, want application/json", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[
+			{
+				"username":"scout",
+				"display_name":"Scout",
+				"bio":"public directory entry",
+				"created_at":"2026-07-15T12:00:00Z",
+				"verified":true,
+				"agent_type":"CUSTOM",
+				"agent_version":"1",
+				"agent_capabilities":{"can_post":true,"can_reply":true,"max_posts_per_hour":10},
+				"mcp_access":{"mcp_url":"https://api.example.com/mcp/scout","scopes":["read"]},
+				"identity_semantics":{"identity_state":"DRONE","soul_agent_id":"private-soul-id"},
+				"agent_owner":"private-owner",
+				"delegated_scopes":["write"],
+				"access_token":"must-not-be-decoded",
+				"refresh_token":"must-not-be-decoded"
+			}
+		]`))
+	}))
+	defer server.Close()
+
+	client := newAgentDelegateTestClient(t, server)
+	agents, err := client.ListAgents(context.Background())
+	if err != nil {
+		t.Fatalf("ListAgents: %v", err)
+	}
+	if authorization != "" {
+		t.Fatalf("Authorization = %q, want no caller bearer", authorization)
+	}
+	if len(agents) != 1 {
+		t.Fatalf("agents = %+v, want one entry", agents)
+	}
+	if agents[0].Username != "scout" || agents[0].DisplayName != "Scout" || !agents[0].Verified {
+		t.Fatalf("agent identity = %+v", agents[0])
+	}
+	if agents[0].CreatedAt == nil || agents[0].CreatedAt.UTC().Format("2006-01-02T15:04:05Z07:00") != "2026-07-15T12:00:00Z" {
+		t.Fatalf("created_at = %v", agents[0].CreatedAt)
+	}
+	if agents[0].IdentitySemantics.SoulBindingState != "" {
+		t.Fatalf("private identity field was decoded: %+v", agents[0].IdentitySemantics)
+	}
+	encoded, err := json.Marshal(agents)
+	if err != nil {
+		t.Fatalf("marshal public agents: %v", err)
+	}
+	if strings.Contains(string(encoded), "must-not-be-decoded") || strings.Contains(string(encoded), "private-owner") || strings.Contains(string(encoded), "private-soul-id") {
+		t.Fatalf("private or credential fields leaked through typed response: %s", encoded)
+	}
+}
+
+func TestListAgentsUsesInstanceEndpointBaseFallback(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/agents" {
+			t.Fatalf("path = %s, want /api/v1/agents", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer server.Close()
+
+	t.Setenv(envBaseURL, "")
+	t.Setenv(envMcpURL, "")
+	t.Setenv(envInstanceMcpURL, server.URL+"/instance/{surface}/mcp")
+	ResetForTests()
+	t.Cleanup(ResetForTests)
+
+	client, err := Default()
+	if err != nil {
+		t.Fatalf("Default: %v", err)
+	}
+	if _, err := client.ListAgents(context.Background()); err != nil {
+		t.Fatalf("ListAgents: %v", err)
+	}
+}
+
+func TestListAgentsReturnsAPIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"error":"directory unavailable","access_token":"secret"}`))
+	}))
+	defer server.Close()
+
+	client := newAgentDelegateTestClient(t, server)
+	_, err := client.ListAgents(context.Background())
+	if err == nil {
+		t.Fatal("ListAgents returned nil error")
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error = %T %v, want APIError", err, err)
+	}
+	if apiErr.Status != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", apiErr.Status, http.StatusServiceUnavailable)
+	}
+	if strings.Contains(err.Error(), "secret") {
+		t.Fatalf("API error leaked credential: %v", err)
+	}
+}

--- a/internal/lesserapi/client.go
+++ b/internal/lesserapi/client.go
@@ -17,9 +17,10 @@ import (
 )
 
 const (
-	envBaseURL  = "LESSER_API_BASE_URL"
-	envMcpURL   = "MCP_ENDPOINT"
-	envTimeoutS = "LESSER_API_TIMEOUT_SECONDS"
+	envBaseURL        = "LESSER_API_BASE_URL"
+	envMcpURL         = "MCP_ENDPOINT"
+	envInstanceMcpURL = "INSTANCE_MCP_ENDPOINT"
+	envTimeoutS       = "LESSER_API_TIMEOUT_SECONDS"
 )
 
 type Client struct {
@@ -201,6 +202,16 @@ func resolveBaseURL() (*url.URL, error) {
 		}
 		return u, nil
 	}
+	if raw := strings.TrimSpace(os.Getenv(envInstanceMcpURL)); raw != "" {
+		u, err := parseBaseURL(raw)
+		if err != nil {
+			return nil, err
+		}
+		if err := stripInstanceMcpPath(u); err != nil {
+			return nil, err
+		}
+		return u, nil
+	}
 	return nil, fmt.Errorf("%s or %s is required", envBaseURL, envMcpURL)
 }
 
@@ -276,5 +287,27 @@ func stripMcpPath(u *url.URL) error {
 	if u.Path == "/" {
 		u.Path = ""
 	}
+	return nil
+}
+
+func stripInstanceMcpPath(u *url.URL) error {
+	if u == nil {
+		return fmt.Errorf("instance MCP endpoint URL is nil")
+	}
+
+	path := strings.TrimRight(strings.TrimSpace(u.Path), "/")
+	const suffix = "/mcp"
+	if !strings.HasPrefix(path, "/instance/") || !strings.HasSuffix(path, suffix) {
+		return fmt.Errorf("instance MCP endpoint path must include /instance/{surface}/mcp")
+	}
+
+	instancePath := strings.TrimSuffix(path, suffix)
+	parts := strings.Split(strings.TrimPrefix(instancePath, "/instance/"), "/")
+	if len(parts) != 1 || strings.TrimSpace(parts[0]) == "" {
+		return fmt.Errorf("instance MCP endpoint path must include /instance/{surface}/mcp")
+	}
+
+	u.Path = ""
+	u.RawPath = ""
 	return nil
 }

--- a/internal/lesserapi/client_test.go
+++ b/internal/lesserapi/client_test.go
@@ -5,6 +5,7 @@ import "testing"
 func TestResolveBaseURL_FallsBackToActorTemplateEndpoint(t *testing.T) {
 	t.Setenv(envBaseURL, "")
 	t.Setenv(envMcpURL, "https://api.example.com/mcp/{actor}")
+	t.Setenv(envInstanceMcpURL, "")
 
 	u, err := resolveBaseURL()
 	if err != nil {
@@ -12,6 +13,20 @@ func TestResolveBaseURL_FallsBackToActorTemplateEndpoint(t *testing.T) {
 	}
 	if got := u.String(); got != "https://api.example.com" {
 		t.Fatalf("expected mcp endpoint fallback, got %q", got)
+	}
+}
+
+func TestResolveBaseURL_FallsBackToInstanceTemplateEndpoint(t *testing.T) {
+	t.Setenv(envBaseURL, "")
+	t.Setenv(envMcpURL, "")
+	t.Setenv(envInstanceMcpURL, "https://api.example.com/instance/{surface}/mcp")
+
+	u, err := resolveBaseURL()
+	if err != nil {
+		t.Fatalf("resolveBaseURL: %v", err)
+	}
+	if got := u.String(); got != "https://api.example.com" {
+		t.Fatalf("expected instance MCP endpoint fallback, got %q", got)
 	}
 }
 

--- a/internal/ptahserver/ptahserver.go
+++ b/internal/ptahserver/ptahserver.go
@@ -3,13 +3,16 @@ package ptahserver
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"os"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -71,6 +74,13 @@ type AgentRegistry interface {
 	List(ctx context.Context, in agentregistry.ListInput) (*agentregistry.ListResult, error)
 }
 
+// AgentLiveClient is the read-only Lesser public live-agent directory
+// dependency used by Ptah agent_list. Its implementation is the typed client
+// in internal/lesserapi; it never receives the caller's Ptah bearer token.
+type AgentLiveClient interface {
+	ListAgents(ctx context.Context) ([]lesserapi.AgentDirectoryEntry, error)
+}
+
 type config struct {
 	soulBinding        soulBindingClient
 	soulBindingFactory func() (soulBindingClient, error)
@@ -79,6 +89,8 @@ type config struct {
 	agentDelegateFactory func() (agentDelegateClient, error)
 	agentRegistry        AgentRegistry
 	agentRegistryFactory func() (AgentRegistry, error)
+	agentLiveClient      AgentLiveClient
+	agentLiveFactory     func() (AgentLiveClient, error)
 
 	agentContent        AgentContentStore
 	agentContentFactory func() (AgentContentStore, error)
@@ -115,6 +127,14 @@ func WithAgentRegistryStore(store AgentRegistry) Option {
 	}
 }
 
+// WithAgentLiveClient injects the read-only Lesser public live-agent client
+// used by agent_list.
+func WithAgentLiveClient(client AgentLiveClient) Option {
+	return func(cfg *config) {
+		cfg.agentLiveClient = client
+	}
+}
+
 // WithAgentContentStore injects the body-owned agent content store used by
 // Ptah authoring tools.
 func WithAgentContentStore(store AgentContentStore) Option {
@@ -136,6 +156,8 @@ func WithIntegrationBearer(bearer string) Option {
 var (
 	agentRegistryFactoryMu       sync.RWMutex
 	agentRegistryFactoryForTests func() (AgentRegistry, error)
+	agentLiveFactoryMu           sync.RWMutex
+	agentLiveFactoryForTests     func() (AgentLiveClient, error)
 )
 
 // SetAgentRegistryFactoryForTests overrides the production registry factory for
@@ -151,6 +173,23 @@ func SetAgentRegistryFactoryForTests(factory func() (AgentRegistry, error)) func
 		agentRegistryFactoryMu.Lock()
 		agentRegistryFactoryForTests = previous
 		agentRegistryFactoryMu.Unlock()
+	}
+}
+
+// SetAgentLiveClientFactoryForTests overrides the production Lesser live-agent
+// client factory for tests that construct the instance app, whose public New
+// function intentionally does not expose tool-registration dependency
+// injection.
+func SetAgentLiveClientFactoryForTests(factory func() (AgentLiveClient, error)) func() {
+	agentLiveFactoryMu.Lock()
+	previous := agentLiveFactoryForTests
+	agentLiveFactoryForTests = factory
+	agentLiveFactoryMu.Unlock()
+
+	return func() {
+		agentLiveFactoryMu.Lock()
+		agentLiveFactoryForTests = previous
+		agentLiveFactoryMu.Unlock()
 	}
 }
 
@@ -206,6 +245,7 @@ func defaultConfig() config {
 			return lesserapi.Default()
 		},
 		agentRegistryFactory: defaultAgentRegistry,
+		agentLiveFactory:     defaultAgentLiveClient,
 		agentContentFactory: func() (AgentContentStore, error) {
 			return agentcontent.Default()
 		},
@@ -223,6 +263,16 @@ func defaultAgentRegistry() (AgentRegistry, error) {
 		return factory()
 	}
 	return agentregistry.Default()
+}
+
+func defaultAgentLiveClient() (AgentLiveClient, error) {
+	agentLiveFactoryMu.RLock()
+	factory := agentLiveFactoryForTests
+	agentLiveFactoryMu.RUnlock()
+	if factory != nil {
+		return factory()
+	}
+	return lesserapi.Default()
 }
 
 func agentBindSoulDef() mcpruntime.ToolDef {
@@ -320,7 +370,7 @@ func agentListDef() mcpruntime.ToolDef {
 	return mcpruntime.ToolDef{
 		Name:        toolAgentList,
 		Title:       "List registered agents",
-		Description: "List Body/Ptah account-scoped agent registry entries for the authenticated account-holder principal. Requires read scope.",
+		Description: "List the authenticated account-holder's Body/Ptah registry entries merged with Lesser's public live-agent directory. Requires read scope; live entries contain public metadata only.",
 		Annotations: readOnlyToolAnnotations(),
 		InputSchema: json.RawMessage(fmt.Sprintf(`{
 			"type":"object",
@@ -333,7 +383,7 @@ func agentListDef() mcpruntime.ToolDef {
 		OutputSchema: json.RawMessage(`{
 			"type":"object",
 			"properties":{
-				"data":{"type":"object","description":"Account-scoped registry entries and pagination metadata."},
+				"data":{"type":"object","description":"Merged Body/Ptah registry and public Lesser live-agent entries with stable pagination metadata."},
 				"error":{"type":"object","description":"Structured tool error when isError=true."}
 			}
 		}`),
@@ -512,6 +562,62 @@ type agentGetInput struct {
 type agentListInput struct {
 	Limit  *int   `json:"limit"`
 	Cursor string `json:"cursor"`
+}
+
+const (
+	agentListCursorPrefix       = "ptah-agent-list-v1:"
+	maxAgentRegistryListPages   = 1000
+	agentListLiveSourceCode     = "lesser_live"
+	agentListRegistrySourceCode = "ptah_registry"
+	agentListMergedSourceCode   = "merged"
+)
+
+type agentListCursor struct {
+	After                string
+	LegacyRegistryCursor string
+}
+
+type encodedAgentListCursor struct {
+	Version int    `json:"version"`
+	After   string `json:"after"`
+}
+
+type mergedAgentListEntry struct {
+	Key      string
+	Registry *agentregistry.Agent
+	Live     *lesserapi.AgentDirectoryEntry
+}
+
+func decodeAgentListCursor(raw string) (agentListCursor, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return agentListCursor{}, nil
+	}
+	if !strings.HasPrefix(raw, agentListCursorPrefix) {
+		// Cursors issued by the previous registry-only implementation remain
+		// readable as a one-time compatibility path. The next response always
+		// emits the merged-view cursor format.
+		return agentListCursor{LegacyRegistryCursor: raw}, nil
+	}
+
+	encoded := strings.TrimPrefix(raw, agentListCursorPrefix)
+	decoded, err := base64.RawURLEncoding.DecodeString(encoded)
+	if err != nil {
+		return agentListCursor{}, fmt.Errorf("decode merged agent cursor: %w", err)
+	}
+	var cursor encodedAgentListCursor
+	if err := json.Unmarshal(decoded, &cursor); err != nil {
+		return agentListCursor{}, fmt.Errorf("decode merged agent cursor: %w", err)
+	}
+	if cursor.Version != 1 || strings.TrimSpace(cursor.After) == "" {
+		return agentListCursor{}, fmt.Errorf("merged agent cursor is invalid")
+	}
+	return agentListCursor{After: strings.TrimSpace(cursor.After)}, nil
+}
+
+func encodeAgentListCursor(after string) string {
+	payload, _ := json.Marshal(encodedAgentListCursor{Version: 1, After: after})
+	return agentListCursorPrefix + base64.RawURLEncoding.EncodeToString(payload)
 }
 
 type agentSoulGetInput struct {
@@ -803,6 +909,12 @@ func (cfg config) handleAgentList(ctx context.Context, args json.RawMessage) (*m
 	if errResult != nil || err != nil {
 		return errResult, err
 	}
+	cursor, err := decodeAgentListCursor(in.Cursor)
+	if err != nil {
+		return toolErrorResult("invalid_request", "cursor is invalid", http.StatusBadRequest, map[string]any{
+			"source": "agent_list",
+		})
+	}
 
 	registry, err := cfg.registry()
 	if err != nil {
@@ -823,11 +935,7 @@ func (cfg config) handleAgentList(ctx context.Context, args json.RawMessage) (*m
 		"cursor_present", strings.TrimSpace(in.Cursor) != "",
 	)
 
-	page, err := registry.List(ctx, agentregistry.ListInput{
-		Account: actorUsername,
-		Limit:   limit,
-		Cursor:  in.Cursor,
-	})
+	registryAgents, err := listAllAgentRegistryEntries(ctx, registry, actorUsername, cursor.LegacyRegistryCursor)
 	if err != nil {
 		switch {
 		case errors.Is(err, agentregistry.ErrInvalidCursor):
@@ -849,7 +957,186 @@ func (cfg config) handleAgentList(ctx context.Context, args json.RawMessage) (*m
 			})
 		}
 	}
-	return agentListSuccessResult(actorUsername, limit, page)
+
+	liveClient, err := cfg.liveAgents()
+	if err != nil {
+		return agentLiveSourceError(err)
+	}
+	if liveClient == nil {
+		return agentLiveSourceError(fmt.Errorf("Lesser live-agent client is nil"))
+	}
+	liveAgents, err := liveClient.ListAgents(ctx)
+	if err != nil {
+		return agentLiveSourceError(err)
+	}
+
+	entries := mergeAgentListEntries(actorUsername, registryAgents, liveAgents)
+	start := 0
+	if cursor.After != "" {
+		start = sort.Search(len(entries), func(index int) bool {
+			return entries[index].Key > cursor.After
+		})
+	}
+	if start > len(entries) {
+		start = len(entries)
+	}
+	end := start + limit
+	if end > len(entries) {
+		end = len(entries)
+	}
+	pageEntries := entries[start:end]
+	hasMore := end < len(entries)
+	nextCursor := ""
+	if hasMore && len(pageEntries) > 0 {
+		nextCursor = encodeAgentListCursor(pageEntries[len(pageEntries)-1].Key)
+	}
+	return agentListSuccessResult(actorUsername, limit, pageEntries, nextCursor, hasMore)
+}
+
+func listAllAgentRegistryEntries(ctx context.Context, registry AgentRegistry, account string, startCursor string) ([]*agentregistry.Agent, error) {
+	cursor := strings.TrimSpace(startCursor)
+	seenCursors := map[string]struct{}{}
+	if cursor != "" {
+		seenCursors[cursor] = struct{}{}
+	}
+	agents := make([]*agentregistry.Agent, 0)
+
+	for pageNumber := 0; pageNumber < maxAgentRegistryListPages; pageNumber++ {
+		page, err := registry.List(ctx, agentregistry.ListInput{
+			Account: account,
+			Limit:   agentregistry.MaxListLimit,
+			Cursor:  cursor,
+		})
+		if err != nil {
+			return nil, err
+		}
+		if page == nil {
+			return nil, fmt.Errorf("agent registry returned a nil page")
+		}
+		agents = append(agents, page.Agents...)
+		if !page.HasMore {
+			return agents, nil
+		}
+
+		nextCursor := strings.TrimSpace(page.NextCursor)
+		if nextCursor == "" {
+			return nil, fmt.Errorf("agent registry pagination did not provide a next cursor")
+		}
+		if _, ok := seenCursors[nextCursor]; ok {
+			return nil, fmt.Errorf("agent registry pagination cursor repeated")
+		}
+		seenCursors[nextCursor] = struct{}{}
+		cursor = nextCursor
+	}
+	return nil, fmt.Errorf("agent registry pagination exceeded safety bound")
+}
+
+func agentLiveSourceError(err error) (*mcpruntime.ToolResult, error) {
+	var apiErr *lesserapi.APIError
+	if errors.As(err, &apiErr) && apiErr != nil {
+		slog.Warn("ptah agent_list Lesser live-agent source failed", "upstream_status", apiErr.Status)
+	} else {
+		slog.Warn("ptah agent_list Lesser live-agent source unavailable", "error", "source request failed")
+	}
+	return toolErrorResult("agent_live_source_error", "Body failed to read Lesser's public live-agent directory", http.StatusBadGateway, map[string]any{
+		"source": agentListLiveSourceCode,
+	})
+}
+
+func mergeAgentListEntries(account string, registryAgents []*agentregistry.Agent, liveAgents []lesserapi.AgentDirectoryEntry) []mergedAgentListEntry {
+	orderedLive := make([]lesserapi.AgentDirectoryEntry, 0, len(liveAgents))
+	for _, agent := range liveAgents {
+		if normalizeAgentIdentity(agent.Username) == "" {
+			continue
+		}
+		orderedLive = append(orderedLive, agent)
+	}
+	sort.SliceStable(orderedLive, func(left, right int) bool {
+		leftKey := normalizeAgentIdentity(orderedLive[left].Username)
+		rightKey := normalizeAgentIdentity(orderedLive[right].Username)
+		if leftKey != rightKey {
+			return leftKey < rightKey
+		}
+		if orderedLive[left].Username != orderedLive[right].Username {
+			return orderedLive[left].Username < orderedLive[right].Username
+		}
+		return orderedLive[left].DisplayName < orderedLive[right].DisplayName
+	})
+
+	liveByIdentity := make(map[string]*lesserapi.AgentDirectoryEntry, len(orderedLive))
+	for index := range orderedLive {
+		identity := normalizeAgentIdentity(orderedLive[index].Username)
+		if _, exists := liveByIdentity[identity]; exists {
+			continue
+		}
+		liveByIdentity[identity] = &orderedLive[index]
+	}
+
+	orderedRegistry := make([]*agentregistry.Agent, 0, len(registryAgents))
+	for _, agent := range registryAgents {
+		if agent == nil || normalizeActorUsername(agent.Account) != normalizeActorUsername(account) || normalizeAgentIdentity(agent.AgentID) == "" {
+			continue
+		}
+		orderedRegistry = append(orderedRegistry, agent)
+	}
+	sort.SliceStable(orderedRegistry, func(left, right int) bool {
+		leftKey := normalizeAgentIdentity(orderedRegistry[left].AgentID)
+		rightKey := normalizeAgentIdentity(orderedRegistry[right].AgentID)
+		if leftKey != rightKey {
+			return leftKey < rightKey
+		}
+		return strings.ToLower(strings.TrimSpace(orderedRegistry[left].AgentID)) < strings.ToLower(strings.TrimSpace(orderedRegistry[right].AgentID))
+	})
+
+	entries := make([]mergedAgentListEntry, 0, len(orderedRegistry)+len(liveByIdentity))
+	seenKeys := make(map[string]struct{}, len(orderedRegistry)+len(liveByIdentity))
+	matchedLive := make(map[string]struct{}, len(liveByIdentity))
+	for _, agent := range orderedRegistry {
+		identity := normalizeAgentIdentity(agent.AgentID)
+		live := liveByIdentity[identity]
+		key := "registry:" + strings.ToLower(strings.TrimSpace(agent.AgentID))
+		if live != nil {
+			key = "agent:" + identity
+			matchedLive[identity] = struct{}{}
+		}
+		if _, exists := seenKeys[key]; exists {
+			continue
+		}
+		seenKeys[key] = struct{}{}
+		entries = append(entries, mergedAgentListEntry{Key: key, Registry: agent, Live: live})
+	}
+	for index := range orderedLive {
+		identity := normalizeAgentIdentity(orderedLive[index].Username)
+		if _, matched := matchedLive[identity]; matched {
+			continue
+		}
+		key := "agent:" + identity
+		if _, exists := seenKeys[key]; exists {
+			continue
+		}
+		seenKeys[key] = struct{}{}
+		entries = append(entries, mergedAgentListEntry{Key: key, Live: &orderedLive[index]})
+	}
+
+	sort.SliceStable(entries, func(left, right int) bool {
+		return entries[left].Key < entries[right].Key
+	})
+	return entries
+}
+
+func normalizeAgentIdentity(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	if value == "" {
+		return ""
+	}
+	if parsed, err := url.Parse(value); err == nil && parsed.Host != "" && parsed.Path != "" {
+		value = parsed.Path
+	}
+	value = strings.Trim(value, "/")
+	if slash := strings.LastIndex(value, "/"); slash >= 0 {
+		value = value[slash+1:]
+	}
+	return strings.TrimPrefix(value, "@")
 }
 
 func (cfg config) handleAgentSoulGet(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
@@ -1479,6 +1766,16 @@ func (cfg config) registry() (AgentRegistry, error) {
 	return cfg.agentRegistryFactory()
 }
 
+func (cfg config) liveAgents() (AgentLiveClient, error) {
+	if cfg.agentLiveClient != nil {
+		return cfg.agentLiveClient, nil
+	}
+	if cfg.agentLiveFactory == nil {
+		return nil, fmt.Errorf("Lesser live-agent client is not configured")
+	}
+	return cfg.agentLiveFactory()
+}
+
 func (cfg config) content() (AgentContentStore, error) {
 	if cfg.agentContent != nil {
 		return cfg.agentContent, nil
@@ -1642,25 +1939,36 @@ func agentGetSuccessResult(actorUsername string, agent *agentregistry.Agent) (*m
 	return toolJSONTextResult(text, map[string]any{"data": data})
 }
 
-func agentListSuccessResult(actorUsername string, limit int, page *agentregistry.ListResult) (*mcpruntime.ToolResult, error) {
-	agents := []*agentregistry.Agent(nil)
-	nextCursor := ""
-	hasMore := false
-	count := 0
-	if page != nil {
-		agents = page.Agents
-		nextCursor = page.NextCursor
-		hasMore = page.HasMore
-		count = page.Count
+func agentListSuccessResult(actorUsername string, limit int, entries []mergedAgentListEntry, nextCursor string, hasMore bool) (*mcpruntime.ToolResult, error) {
+	items := make([]map[string]any, 0, len(entries))
+	for _, entry := range entries {
+		source := agentListLiveSourceCode
+		contentSource := agentListLiveSourceCode
+		if entry.Registry != nil && entry.Live != nil {
+			source = agentListMergedSourceCode
+			contentSource = "agentregistry"
+		} else if entry.Registry != nil {
+			source = agentListRegistrySourceCode
+			contentSource = "agentregistry"
+		}
+		item := map[string]any{
+			"content_version": unavailableContentVersionForSource(contentSource),
+			"content_summary": unavailableContentSummaryForSource(contentSource),
+			"source":          source,
+		}
+		if entry.Registry != nil {
+			item["registry"] = registryAgentSummary(entry.Registry)
+		}
+		if entry.Live != nil {
+			liveSummary, err := mapFromJSON(entry.Live)
+			if err != nil {
+				return nil, err
+			}
+			item["live_agent"] = liveSummary
+		}
+		items = append(items, item)
 	}
-	items := make([]map[string]any, 0, len(agents))
-	for _, agent := range agents {
-		items = append(items, map[string]any{
-			"registry":        registryAgentSummary(agent),
-			"content_version": unavailableContentVersion(),
-			"content_summary": unavailableContentSummary(),
-		})
-	}
+	count := len(items)
 
 	pagination := map[string]any{
 		"limit":       limit,
@@ -1675,7 +1983,7 @@ func agentListSuccessResult(actorUsername string, limit int, page *agentregistry
 	}
 
 	text := map[string]any{
-		"summary":    "Ptah registry entries listed",
+		"summary":    "Ptah registry and Lesser live-agent entries listed",
 		"count":      count,
 		"has_more":   hasMore,
 		"pagination": pagination,
@@ -1999,18 +2307,34 @@ func registryAgentSummary(agent *agentregistry.Agent) map[string]any {
 }
 
 func unavailableContentVersion() map[string]any {
+	return unavailableContentVersionForSource("agentregistry")
+}
+
+func unavailableContentVersionForSource(source string) map[string]any {
+	reason := "Body/Ptah registry records do not currently store source-backed content version metadata."
+	if source == agentListLiveSourceCode {
+		reason = "Lesser's public live-agent directory does not expose Body/Ptah content version metadata."
+	}
 	return map[string]any{
 		"status": "not_available",
-		"source": "agentregistry",
-		"reason": "Body/Ptah registry records do not currently store source-backed content version metadata.",
+		"source": source,
+		"reason": reason,
 	}
 }
 
 func unavailableContentSummary() map[string]any {
+	return unavailableContentSummaryForSource("agentregistry")
+}
+
+func unavailableContentSummaryForSource(source string) map[string]any {
+	reason := "Body/Ptah registry records do not currently store source-backed content summary metadata."
+	if source == agentListLiveSourceCode {
+		reason = "Lesser's public live-agent directory does not expose Body/Ptah content summary metadata."
+	}
 	return map[string]any{
 		"status": "not_available",
-		"source": "agentregistry",
-		"reason": "Body/Ptah registry records do not currently store source-backed content summary metadata.",
+		"source": source,
+		"reason": reason,
 	}
 }
 

--- a/internal/ptahserver/ptahserver_test.go
+++ b/internal/ptahserver/ptahserver_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"reflect"
 	"strings"
 	"testing"
@@ -730,29 +731,28 @@ func TestAgentListReadsAccountScopedRegistryWithPagination(t *testing.T) {
 				UpdatedAt: time.Date(2026, 7, 15, 12, 3, 0, 0, time.UTC),
 			},
 		},
-		NextCursor: "cursor-2",
-		HasMore:    true,
-		Count:      2,
+		Count: 2,
 	}}
+	live := &fakeAgentLiveClient{}
 	registry := mcpruntime.NewToolRegistry()
-	if err := RegisterTools(registry, WithAgentRegistryStore(store)); err != nil {
+	if err := RegisterTools(registry, WithAgentRegistryStore(store), WithAgentLiveClient(live)); err != nil {
 		t.Fatalf("RegisterTools: %v", err)
 	}
 
-	result, err := registry.Call(toolContext("Drone-Ada", []string{"read"}, "owner-oauth-token"), toolAgentList, json.RawMessage(`{"limit":2,"cursor":"cursor-1"}`))
+	result, err := registry.Call(toolContext("Drone-Ada", []string{"read"}, "owner-oauth-token"), toolAgentList, json.RawMessage(`{"limit":1}`))
 	if err != nil {
 		t.Fatalf("Call: %v", err)
 	}
 	if result == nil || result.IsError {
 		t.Fatalf("result = %+v", result)
 	}
-	if store.listCalls != 1 || store.listIn.Account != "drone-ada" || store.listIn.Limit != 2 || store.listIn.Cursor != "cursor-1" {
-		t.Fatalf("registry List input = calls %d %+v, want account-scoped limit/cursor", store.listCalls, store.listIn)
+	if store.listCalls != 1 || store.listIn.Account != "drone-ada" || store.listIn.Limit != agentregistry.MaxListLimit || store.listIn.Cursor != "" {
+		t.Fatalf("registry List input = calls %d %+v, want account-scoped full-page read", store.listCalls, store.listIn)
 	}
 	data := structuredData(t, result)
 	agents, _ := data["agents"].([]map[string]any)
-	if len(agents) != 2 {
-		t.Fatalf("agents = %+v, want two", data["agents"])
+	if len(agents) != 1 {
+		t.Fatalf("agents = %+v, want one", data["agents"])
 	}
 	gotIDs := []string{}
 	for _, item := range agents {
@@ -763,12 +763,193 @@ func TestAgentListReadsAccountScopedRegistryWithPagination(t *testing.T) {
 			t.Fatalf("content_version = %+v, want not_available", contentVersion)
 		}
 	}
-	if want := []string{"agent-001", "agent-002"}; !reflect.DeepEqual(gotIDs, want) {
+	if want := []string{"agent-001"}; !reflect.DeepEqual(gotIDs, want) {
 		t.Fatalf("agent ids = %v, want %v", gotIDs, want)
 	}
 	pagination, _ := data["pagination"].(map[string]any)
-	if pagination["next_cursor"] != "cursor-2" || pagination["has_more"] != true || pagination["count"] != 2 || pagination["limit"] != 2 {
+	nextCursor, _ := pagination["next_cursor"].(string)
+	if nextCursor == "" || pagination["has_more"] != true || pagination["count"] != 1 || pagination["limit"] != 1 {
 		t.Fatalf("pagination = %+v", pagination)
+	}
+
+	result, err = registry.Call(toolContext("Drone-Ada", []string{"read"}, "owner-oauth-token"), toolAgentList, json.RawMessage(fmt.Sprintf(`{"limit":10,"cursor":%q}`, nextCursor)))
+	if err != nil {
+		t.Fatalf("second Call: %v", err)
+	}
+	if result == nil || result.IsError {
+		t.Fatalf("second result = %+v", result)
+	}
+	if store.listCalls != 2 || store.listIn.Account != "drone-ada" || store.listIn.Limit != agentregistry.MaxListLimit || store.listIn.Cursor != "" {
+		t.Fatalf("second registry List input = calls %d %+v, want account-scoped full-page read", store.listCalls, store.listIn)
+	}
+	secondData := structuredData(t, result)
+	secondAgents, _ := secondData["agents"].([]map[string]any)
+	if len(secondAgents) != 1 {
+		t.Fatalf("second agents = %+v, want one", secondData["agents"])
+	}
+	secondRegistry, _ := secondAgents[0]["registry"].(map[string]any)
+	if secondRegistry["agent_id"] != "agent-002" {
+		t.Fatalf("second registry = %+v, want agent-002", secondRegistry)
+	}
+}
+
+func TestAgentListFallsBackToLesserLiveAgentsWhenRegistryIsEmpty(t *testing.T) {
+	store := &fakeAgentRegistry{listResult: &agentregistry.ListResult{}}
+	live := &fakeAgentLiveClient{agents: []lesserapi.AgentDirectoryEntry{{
+		Username:     "scout",
+		DisplayName:  "Scout",
+		AgentType:    "CUSTOM",
+		AgentVersion: "1",
+	}}}
+	registry := mcpruntime.NewToolRegistry()
+	if err := RegisterTools(registry, WithAgentRegistryStore(store), WithAgentLiveClient(live)); err != nil {
+		t.Fatalf("RegisterTools: %v", err)
+	}
+
+	result, err := registry.Call(toolContext("Drone-Ada", []string{"read"}, "owner-oauth-token"), toolAgentList, json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if result == nil || result.IsError {
+		t.Fatalf("result = %+v", result)
+	}
+	if store.listCalls != 1 || live.calls != 1 {
+		t.Fatalf("dependency calls = registry:%d live:%d, want one each", store.listCalls, live.calls)
+	}
+	data := structuredData(t, result)
+	agents, _ := data["agents"].([]map[string]any)
+	if len(agents) != 1 {
+		t.Fatalf("agents = %+v, want one live entry", data["agents"])
+	}
+	if _, ok := agents[0]["registry"]; ok {
+		t.Fatalf("live-only entry unexpectedly claimed Body registry ownership: %+v", agents[0])
+	}
+	if agents[0]["source"] != "lesser_live" {
+		t.Fatalf("source = %v, want lesser_live", agents[0]["source"])
+	}
+	liveSummary, _ := agents[0]["live_agent"].(map[string]any)
+	if liveSummary["username"] != "scout" {
+		t.Fatalf("live_agent = %+v, want scout", liveSummary)
+	}
+	encoded, _ := json.Marshal(result.StructuredContent)
+	if strings.Contains(string(encoded), "access_token") || strings.Contains(string(encoded), "refresh_token") || strings.Contains(string(encoded), "delegated_scopes") {
+		t.Fatalf("agent_list leaked credential/private field names: %s", encoded)
+	}
+}
+
+func TestAgentListPreservesRegistryEntriesAcrossRegistryPages(t *testing.T) {
+	store := &fakeAgentRegistry{listResults: map[string]*agentregistry.ListResult{
+		"": {
+			Agents:     []*agentregistry.Agent{{Account: "drone-ada", AgentID: "agent-001"}},
+			NextCursor: "registry-page-2",
+			HasMore:    true,
+		},
+		"registry-page-2": {
+			Agents: []*agentregistry.Agent{{Account: "drone-ada", AgentID: "agent-002"}},
+		},
+	}}
+	live := &fakeAgentLiveClient{}
+	registry := mcpruntime.NewToolRegistry()
+	if err := RegisterTools(registry, WithAgentRegistryStore(store), WithAgentLiveClient(live)); err != nil {
+		t.Fatalf("RegisterTools: %v", err)
+	}
+
+	result, err := registry.Call(toolContext("drone-ada", []string{"read"}, "owner-oauth-token"), toolAgentList, json.RawMessage(`{"limit":100}`))
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if result == nil || result.IsError {
+		t.Fatalf("result = %+v", result)
+	}
+	if store.listCalls != 2 || live.calls != 1 {
+		t.Fatalf("dependency calls = registry:%d live:%d, want two registry pages and one live read", store.listCalls, live.calls)
+	}
+	agents, _ := structuredData(t, result)["agents"].([]map[string]any)
+	if len(agents) != 2 {
+		t.Fatalf("agents = %+v, want both registry entries", agents)
+	}
+}
+
+func TestAgentListMergesAndDeduplicatesRegistryAndLiveAgentsStably(t *testing.T) {
+	store := &fakeAgentRegistry{listResult: &agentregistry.ListResult{Agents: []*agentregistry.Agent{
+		{Account: "drone-ada", AgentID: "https://lesser.example/users/scout"},
+		{Account: "drone-ada", AgentID: "ptah-only"},
+	}}}
+	live := &fakeAgentLiveClient{agents: []lesserapi.AgentDirectoryEntry{
+		{Username: "scout", DisplayName: "Scout"},
+		{Username: "live-only", DisplayName: "Live Only"},
+		{Username: "scout", DisplayName: "Scout duplicate"},
+	}}
+	registry := mcpruntime.NewToolRegistry()
+	if err := RegisterTools(registry, WithAgentRegistryStore(store), WithAgentLiveClient(live)); err != nil {
+		t.Fatalf("RegisterTools: %v", err)
+	}
+
+	result, err := registry.Call(toolContext("Drone-Ada", []string{"read"}, "owner-oauth-token"), toolAgentList, json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if result == nil || result.IsError {
+		t.Fatalf("result = %+v", result)
+	}
+	agents, _ := structuredData(t, result)["agents"].([]map[string]any)
+	if len(agents) != 3 {
+		t.Fatalf("agents = %+v, want three deduplicated entries", agents)
+	}
+	orderedNames := make([]string, 0, len(agents))
+	var sawScout, sawPtahOnly, sawLiveOnly bool
+	for _, item := range agents {
+		liveSummary, _ := item["live_agent"].(map[string]any)
+		registrySummary, _ := item["registry"].(map[string]any)
+		switch liveSummary["username"] {
+		case "scout":
+			orderedNames = append(orderedNames, "scout")
+			sawScout = true
+			if item["source"] != "merged" || registrySummary["agent_id"] != "https://lesser.example/users/scout" {
+				t.Fatalf("scout merge = %+v", item)
+			}
+		case "live-only":
+			orderedNames = append(orderedNames, "live-only")
+			sawLiveOnly = true
+			if item["source"] != "lesser_live" || registrySummary != nil {
+				t.Fatalf("live-only merge = %+v", item)
+			}
+		default:
+			if liveSummary != nil {
+				t.Fatalf("unexpected live username in item = %+v", item)
+			}
+			registryID, _ := registrySummary["agent_id"].(string)
+			orderedNames = append(orderedNames, registryID)
+			if item["source"] != "ptah_registry" || registrySummary["agent_id"] != "ptah-only" {
+				t.Fatalf("registry-only merge = %+v", item)
+			}
+			sawPtahOnly = true
+		}
+	}
+	if !sawScout || !sawPtahOnly || !sawLiveOnly {
+		t.Fatalf("merge coverage = scout:%t ptah-only:%t live-only:%t", sawScout, sawPtahOnly, sawLiveOnly)
+	}
+	if want := []string{"live-only", "scout", "ptah-only"}; !reflect.DeepEqual(orderedNames, want) {
+		t.Fatalf("merged ordering = %v, want %v", orderedNames, want)
+	}
+}
+
+func TestAgentListReturnsSanitizedLiveSourceError(t *testing.T) {
+	store := &fakeAgentRegistry{listResult: &agentregistry.ListResult{}}
+	live := &fakeAgentLiveClient{err: errors.New("upstream body contains private detail")}
+	registry := mcpruntime.NewToolRegistry()
+	if err := RegisterTools(registry, WithAgentRegistryStore(store), WithAgentLiveClient(live)); err != nil {
+		t.Fatalf("RegisterTools: %v", err)
+	}
+
+	result, err := registry.Call(toolContext("Drone-Ada", []string{"read"}, "owner-oauth-token"), toolAgentList, json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	payload := assertToolError(t, result, "agent_live_source_error", http.StatusBadGateway)
+	encoded, _ := json.Marshal(payload)
+	if strings.Contains(string(encoded), "private detail") {
+		t.Fatalf("live source error leaked upstream detail: %s", encoded)
 	}
 }
 
@@ -818,8 +999,9 @@ func TestAgentListRejectsInvalidInputAndPrincipalsBeforeRegistryRead(t *testing.
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			store := &fakeAgentRegistry{listResult: &agentregistry.ListResult{}}
+			live := &fakeAgentLiveClient{}
 			registry := mcpruntime.NewToolRegistry()
-			if err := RegisterTools(registry, WithAgentRegistryStore(store)); err != nil {
+			if err := RegisterTools(registry, WithAgentRegistryStore(store), WithAgentLiveClient(live)); err != nil {
 				t.Fatalf("RegisterTools: %v", err)
 			}
 
@@ -830,6 +1012,9 @@ func TestAgentListRejectsInvalidInputAndPrincipalsBeforeRegistryRead(t *testing.
 			assertToolError(t, result, tc.wantCode, tc.wantState)
 			if store.listCalls != 0 {
 				t.Fatalf("registry List calls = %d, want 0", store.listCalls)
+			}
+			if live.calls != 0 {
+				t.Fatalf("live agent calls = %d, want 0", live.calls)
 			}
 		})
 	}
@@ -851,8 +1036,8 @@ func TestAgentListMapsInvalidCursor(t *testing.T) {
 	if strings.Contains(string(encoded), "hidden cursor decode detail") {
 		t.Fatalf("invalid cursor leaked store detail: %s", string(encoded))
 	}
-	if store.listCalls != 1 || store.listIn.Account != "drone-ada" || store.listIn.Limit != agentregistry.DefaultListLimit || store.listIn.Cursor != "bad-cursor" {
-		t.Fatalf("registry List input = calls %d %+v, want default-limit account scoped cursor", store.listCalls, store.listIn)
+	if store.listCalls != 1 || store.listIn.Account != "drone-ada" || store.listIn.Limit != agentregistry.MaxListLimit || store.listIn.Cursor != "bad-cursor" {
+		t.Fatalf("registry List input = calls %d %+v, want full-page account scoped legacy cursor", store.listCalls, store.listIn)
 	}
 }
 
@@ -1371,6 +1556,20 @@ type fakeAgentDelegateClient struct {
 	err    error
 }
 
+type fakeAgentLiveClient struct {
+	calls  int
+	agents []lesserapi.AgentDirectoryEntry
+	err    error
+}
+
+func (f *fakeAgentLiveClient) ListAgents(_ context.Context) ([]lesserapi.AgentDirectoryEntry, error) {
+	f.calls++
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.agents, nil
+}
+
 func (f *fakeAgentDelegateClient) DelegateAgent(_ context.Context, bearerToken string, req lesserapi.AgentDelegationRequest) (*lesserapi.AgentDelegationResponse, error) {
 	f.calls++
 	f.bearer = bearerToken
@@ -1393,10 +1592,11 @@ type fakeAgentRegistry struct {
 	getAgent   *agentregistry.Agent
 	getErr     error
 
-	listCalls  int
-	listIn     agentregistry.ListInput
-	listResult *agentregistry.ListResult
-	listErr    error
+	listCalls   int
+	listIn      agentregistry.ListInput
+	listResult  *agentregistry.ListResult
+	listResults map[string]*agentregistry.ListResult
+	listErr     error
 }
 
 type fakeAgentContentStore struct {
@@ -1445,6 +1645,11 @@ func (f *fakeAgentRegistry) List(_ context.Context, in agentregistry.ListInput) 
 	f.listIn = in
 	if f.listErr != nil {
 		return nil, f.listErr
+	}
+	if f.listResults != nil {
+		if result, ok := f.listResults[in.Cursor]; ok {
+			return result, nil
+		}
 	}
 	if f.listResult != nil {
 		return f.listResult, nil


### PR DESCRIPTION
## Summary
- add a typed, bearer-free Lesser public agent-directory client for Ptah
- merge live directory entries with the account-scoped TableTheory-backed Body registry using stable opaque pagination
- preserve account-holder/read authorization, reject agent and non-account principals, redact private/credential fields, and document instance endpoint fallback

Closes #419

## Validation
- focused: `go test ./internal/lesserapi ./internal/agentregistry ./internal/ptahserver ./internal/instanceapp`
- scoped build/test/vet: `go build ./cmd/... ./internal/...`, `go test ./cmd/... ./internal/...`, `go vet ./cmd/... ./internal/...`
- `git diff --check`
- `bash scripts/build.sh`
- `cd cdk && npm test`
- representative `cdk synth` with CDK account/region context
- `scripts/check_cdk_discovery_routes.sh`

No deploy, release, merge, AWS/cloud mutation, or sibling-repository changes.
