### PR TITLE
fix: advertise Ptah operator OAuth scopes

### DIFF
--- a/docs/operator-auth-replacement.md
+++ b/docs/operator-auth-replacement.md
@@ -39,6 +39,7 @@ Expected properties:
 - auditable `client_id`
 - explicit `client_class=operator` or equivalent machine-readable identity marker in token claims
 - explicit operator/admin authority carried by OAuth rather than inferred from possession of an infrastructure secret
+- Ptah protected-resource metadata advertises `admin` and `operator` alongside the normal OAuth scopes so clients can discover the operator claim path before authorization
 - normal MCP bearer-token transport to `POST /mcp`
 
 The exact authority model depends on `equaltoai/lesser#259`.

--- a/internal/instanceapp/app_test.go
+++ b/internal/instanceapp/app_test.go
@@ -764,18 +764,21 @@ func TestInstancePlaneWellKnownProtectedResourceMetadata(t *testing.T) {
 		surface  string
 		path     string
 		resource string
+		scopes   []string
 	}{
 		{
 			name:     "ptah",
 			surface:  "ptah",
 			path:     "/.well-known/oauth-protected-resource/instance/ptah/mcp",
 			resource: "https://api.example.com/instance/ptah/mcp",
+			scopes:   []string{"read", "write", "follow", "push", "admin", "operator"},
 		},
 		{
 			name:     "ba",
 			surface:  "ba",
 			path:     "/.well-known/oauth-protected-resource/instance/ba/mcp",
 			resource: "https://api.example.com/instance/ba/mcp",
+			scopes:   []string{"read", "write", "follow", "push"},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -816,11 +819,11 @@ func TestInstancePlaneWellKnownProtectedResourceMetadata(t *testing.T) {
 			if want := []string{"https://api.example.com"}; !reflect.DeepEqual(out.AuthorizationServers, want) {
 				t.Fatalf("authorization_servers = %#v, want %#v", out.AuthorizationServers, want)
 			}
-			if want := []string{"read", "write", "follow", "push"}; !reflect.DeepEqual(out.ScopesSupported, want) {
-				t.Fatalf("scopes_supported = %#v, want %#v", out.ScopesSupported, want)
+			if !reflect.DeepEqual(out.ScopesSupported, tc.scopes) {
+				t.Fatalf("scopes_supported = %#v, want %#v", out.ScopesSupported, tc.scopes)
 			}
-			if strings.Contains(strings.ToLower(string(resp.Body)), "admin") || strings.Contains(string(resp.Body), "instance:") {
-				t.Fatalf("instance metadata advertised non-issuable/internal scopes: %s", string(resp.Body))
+			if tc.surface == "ba" && (strings.Contains(strings.ToLower(string(resp.Body)), "admin") || strings.Contains(string(resp.Body), "operator") || strings.Contains(string(resp.Body), "instance:")) {
+				t.Fatalf("ba metadata advertised Ptah-only or internal scopes: %s", string(resp.Body))
 			}
 			if want := []string{"header"}; !reflect.DeepEqual(out.BearerMethodsSupported, want) {
 				t.Fatalf("bearer_methods_supported = %#v, want %#v", out.BearerMethodsSupported, want)

--- a/internal/instanceapp/instance_x402_test.go
+++ b/internal/instanceapp/instance_x402_test.go
@@ -17,7 +17,7 @@ import (
 
 const testSoulAgentID = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
-func TestInstancePlaneX402_BaInstallPlanRequiresGrantBeforeDownloadGrant(t *testing.T) {
+func TestInstancePlaneX402_BaInstallPlanPublicOAuthTokenRequiresGrantBeforeDownloadGrant(t *testing.T) {
 	const endpoint = "https://api.dev.example.com/instance/{surface}/mcp"
 	resetConsumer := instancex402.SetConsumerForTests(func(context.Context, instancex402.ConsumeRequestForTests) (instancex402.ConsumeResponseForTests, error) {
 		t.Fatalf("missing x402 grant must fail before Host consume")

--- a/internal/instanceapp/well_known.go
+++ b/internal/instanceapp/well_known.go
@@ -14,7 +14,10 @@ import (
 
 const instanceSurfacePlaceholder = "{surface}"
 
-var instanceOAuthDiscoveryScopes = []string{"read", "write", "follow", "push"}
+var instanceOAuthDiscoveryScopes = map[string][]string{
+	SurfacePtah: {"read", "write", "follow", "push", "admin", "operator"},
+	SurfaceBa:   {"read", "write", "follow", "push"},
+}
 
 type instanceEndpointInfo struct {
 	BasePath string
@@ -52,7 +55,7 @@ func wellKnownProtectedResourceHandler(instanceEndpointTemplate string, surface 
 		if err != nil {
 			return nil, fmt.Errorf("build instance protected resource metadata: %w", err)
 		}
-		md.ScopesSupported = append([]string(nil), instanceOAuthDiscoveryScopes...)
+		md.ScopesSupported = append([]string(nil), instanceOAuthDiscoveryScopes[surface]...)
 		md.BearerMethodsSupported = []string{"header"}
 
 		body, err := json.Marshal(md)


### PR DESCRIPTION
# fix: advertise Ptah operator OAuth scopes

## Summary

Ptah's protected-resource metadata did not advertise the OAuth authority paths used for the existing operator/admin x402 exemption. This prevented OAuth clients from discovering those requestable privileges even though Ptah recognizes explicit operator authority. The metadata now advertises `admin` and `operator` for Ptah only, while Ba retains its existing public scope set.

Fixes #422

## Changes

- advertise `admin` and `operator` in Ptah protected-resource metadata only
- cover Ptah-specific discovery scopes and preserve Ba's existing scope metadata
- clarify the discoverable operator/admin OAuth path and name the existing public-token x402 test accordingly

## Testing

Attempted the relevant sandboxed test command:

```text
sandbox-run "go test ./internal/instanceapp"
```

It could not run because the sandbox image does not provide the Go toolchain (`go: command not found`). A container fallback was also unavailable because `docker` is not installed in the sandbox (`docker: command not found`).

Confirmed `git diff --check` passes before committing.

---
### AI assistance disclosure

This contribution was produced by an autonomous AI coding agent (Claude Code) that @Dodothereal operates and monitors. @Dodothereal is accountable for it, will address review feedback promptly, and will close this PR immediately if this kind of contribution is unwelcome in this project. Commits carry an `Assisted-by: Claude Code` trailer.
