### PR TITLE
fix(ptah): accept Host candidate re-edit projections

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -616,7 +616,7 @@ not wrap AppTheory initialize or hard-code product instructions into protocol ne
 | Tool | Scope | Description |
 |------|-------|-------------|
 | `agent_bind_soul` | Write | Orchestrate Lesser's hosted soul/body binding ceremony for a Host-finalized local agent actor under the authenticated account-holder; call `agent_genesis_finalize` first for new Host-genesis agents so Body can write the Host-derived registry row. |
-| `agent_genesis_skill_get` | Read + owner/operator | Fetch the read-only, client-native genesis operator skill bundle before `agent_genesis_begin`. Returns deterministic AppTheory MCP `structuredContent` with a `SKILL.md` operating playbook, bounded references, `bundle_id`, and Host PR `#978` exact-head provenance. Ptah serves content only. |
+| `agent_genesis_skill_get` | Read + owner/operator | Fetch the read-only, client-native genesis operator skill bundle before `agent_genesis_begin`. Returns deterministic AppTheory MCP `structuredContent` with a `SKILL.md` operating playbook, bounded references, `bundle_id`, and Host PR `#980` deployed-commit provenance. Ptah serves content only. |
 | `agent_genesis_begin` | Write + owner/operator | Begin a new-agent, instance-trust registration in lesser-host's durable genesis state machine; no pre-existing Lesser agent is required and no x402 payment is used. First: `agent_genesis_skill_get`. Next: `agent_genesis_advance`. |
 | `agent_genesis_list` | Read + owner/operator | Host-backed recovery/navigation index for durable genesis conversations for one `agent_id`. It calls Host's summary-only HostedGenesisSession list endpoint, returns `status="ok"`, sanitized `conversations[]`, and `recommended_start` / exact next-tool arguments. Start here when `registration_id` / `conversation_id` are unclear. |
 | `agent_genesis_read` | Read + owner/operator | Read the bounded Host `HostedGenesisSession` projection. The latest transcript message remains capped at 8,192 characters, while `conversation.declaration_candidate.review.review_text` is a distinct lossless field accepted through 65,536 characters. Malformed candidate projections fail closed with `host_genesis_projection_invalid`. The sole no-candidate exception is Host's exact terminal `failed` + `restart_soul_bootstrap` hard-cut projection for an untyped/stale lane; Body relays its fresh-begin guidance without reconstructing candidate state. `in_progress` is wait/read-only. |
@@ -636,14 +636,15 @@ not wrap AppTheory initialize or hard-code product instructions into protocol ne
 ### Instance-plane Ptah resources and prompts
 
 Ptah guidance resources and prompts are Body's MCP guidance surface for Host-backed five-body genesis. The source
-contract is Host-owned, not Body-owned. Body mirrors the exact producer artifacts from `equaltoai/lesser-host` PR
-`#978` at accepted head `2339acffe646c49fb951e7a7164f55174d841770` (Host issue `#977`). The mirror pins the
+contract is Host-owned, not Body-owned. Body mirrors the PR `#978` typed-candidate artifacts as repaired by
+`equaltoai/lesser-host` PR `#980` at deployed staging merge commit
+`5f873e184ba70e662ed2c945a71357385ac196bc` (Host issue `#977`, Project 48 / Host `#940`). The mirror pins the
 candidate-action request shape, declaration-candidate/review response shape, representative conversation fixtures,
 and the unchanged five-body schema references:
 
 - `schemaVersion`: `soul-five-body-schema.v2`
 - `guidanceVersion`: `soul-five-body-guidance.v2`
-- `hosted-genesis-conversation.md`: `0f6f9f745de7e2438bbab20cc03baee6a9a151d0cc09f7d42747d0d67340a5ff`
+- `hosted-genesis-conversation.md`: `5bc7b76f9d8fb3bc40c336aef99183980325a35c06309b75534358bcbf878875`
 - `openapi.yaml`: `665ee0b4eef312962ab7474befbbab2375bf9a9a4e043daa601f3c13afbda953`
 - `hosted-genesis.conversation.response.schema.json`: `827d623c6b3c0521668537c8e2c661b5526bcb0805a004c403b8641886a9839e`
 - in-progress / assistant-turn-ready / declaration-ready / published / failed fixtures:
@@ -681,14 +682,14 @@ The five first-class bodies are `identity`, `philosophy`, `discipline`, `boundar
 `transparency` are satellites. The refusal floor requires at least three concrete rows with `bypass`, `invariant`, and
 `closestSafePath`. At review, the exact Host `review_text` is authoritative evidence for the owner to inspect. Only the
 structural action bound to the exact revision and hashes can affirm or reopen a section; message phrases never do.
-Host PR `#978` does not publish a Body-consumable model allowlist; callers use Host-configured models.
+The mirrored Host contract does not publish a Body-consumable model allowlist; callers use Host-configured models.
 
 The genesis operator skill bundle (`agent_genesis_skill_get` / `ptah://genesis/genesis-operator-skill`) packages this
 guidance as a client-native skill an LLM client fetches before operating the `agent_genesis_*` tools. The response is
 deterministic: a stable skill id/name, a version derived from `soul-five-body-guidance.v2` plus the pinned Host contract
 head, a `bundle_id` computed from the file checksums, `content.mode="inline_files"` with a file-count summary, and
 install-neutral file entries (`SKILL.md` plus a bounded `references/genesis-guidance-map.md`). Provenance points at Host
-PR `#978`/exact accepted head and Body's mirrored contract checksums. For clients that do not expose `structuredContent`,
+PR `#980`/exact deployed merge commit and Body's mirrored contract checksums. For clients that do not expose `structuredContent`,
 `agent_genesis_skill_get` also renders deterministic MCP-visible Markdown containing the complete `SKILL.md`, the
 bounded guidance map, bundle identity/provenance, and no-install/no-write semantics. The semantics are explicitly
 no-write/no-install: Ptah serves content only, and the calling client decides whether and how to materialize or use the

--- a/internal/hostapi/genesis.go
+++ b/internal/hostapi/genesis.go
@@ -154,7 +154,7 @@ func (a *DeclarationCandidateAction) UnmarshalJSON(data []byte) error {
 	return a.Validate()
 }
 
-// Validate enforces Host PR #978's candidate-action contract without
+// Validate enforces Host PR #980's candidate-action contract without
 // normalizing any value.
 func (a DeclarationCandidateAction) Validate() error {
 	if a.decoded && (!a.actionPresent || !a.candidateRevisionPresent || !a.candidateHashPresent || !a.reviewHashPresent) {

--- a/internal/instanceapp/app_test.go
+++ b/internal/instanceapp/app_test.go
@@ -224,7 +224,7 @@ func TestInstancePlaneMCP_InitializeAndToolsList(t *testing.T) {
 					t.Fatalf("resources/read error: %+v", readRPC.Error)
 				}
 				readEncoded, _ := json.Marshal(readRPC.Result)
-				if !strings.Contains(string(readEncoded), "soul-five-body-schema.v2") || !strings.Contains(string(readEncoded), "2339acffe646c49fb951e7a7164f55174d841770") {
+				if !strings.Contains(string(readEncoded), "soul-five-body-schema.v2") || !strings.Contains(string(readEncoded), "5f873e184ba70e662ed2c945a71357385ac196bc") {
 					t.Fatalf("resources/read did not return Host contract metadata: %s", string(readEncoded))
 				}
 

--- a/internal/ptahserver/five_body_guidance.go
+++ b/internal/ptahserver/five_body_guidance.go
@@ -16,8 +16,8 @@ import (
 const (
 	fiveBodySchemaVersion   = "soul-five-body-schema.v2"
 	fiveBodyGuidanceVersion = "soul-five-body-guidance.v2"
-	fiveBodyHostPR          = 978
-	fiveBodyHostHeadSHA     = "2339acffe646c49fb951e7a7164f55174d841770"
+	fiveBodyHostPR          = 980
+	fiveBodyHostHeadSHA     = "5f873e184ba70e662ed2c945a71357385ac196bc"
 
 	resourceSoulSchemaV2              = "soul-schema-v2"
 	resourceGenesisInterviewGuide     = "genesis-interview-guide"
@@ -61,7 +61,7 @@ type fiveBodyContractArtifact struct {
 }
 
 // RegisterResources registers Ptah's static AppTheory MCP guidance resources.
-// The content mirrors Host PR #978 contract artifacts; Body renders guidance
+// The content mirrors Host PR #980 contract artifacts; Body renders guidance
 // from the pinned Host contract instead of defining a competing schema.
 func RegisterResources(srv *mcpruntime.Server) error {
 	if srv == nil || srv.Resources() == nil {
@@ -288,7 +288,7 @@ func fiveBodyPlaybookResource(context.Context) ([]mcpruntime.ResourceContent, er
 				"declaration_ready": toolAgentGenesisFinalizePreflight,
 				"published":         []string{toolAgentGet, toolAgentList},
 			},
-			"model_guidance": "Host PR #978 does not publish a Body-consumable model allowlist artifact or endpoint; operators must use Host-configured models.",
+			"model_guidance": "The mirrored Host contract does not publish a Body-consumable model allowlist artifact or endpoint; operators must use Host-configured models.",
 		},
 	})
 }
@@ -323,7 +323,7 @@ func fiveBodyRubricResource(context.Context) ([]mcpruntime.ResourceContent, erro
 				"required_fields": []string{"bypass", "invariant", "closestSafePath"},
 				"reject_generic":  []string{"unsafe requests", "policy violations", "bad things", "be safe", "n/a"},
 			},
-			"fail_closed": "If Host PR #978 exact accepted head changes any mirrored candidate request/response artifact or checksum, Body fixtures/tests fail and must be synchronized before deploy proof.",
+			"fail_closed": "If Host PR #980's exact deployed merge commit changes any mirrored candidate request/response artifact or checksum, Body fixtures/tests fail and must be synchronized before deploy proof.",
 		},
 	})
 }

--- a/internal/ptahserver/five_body_guidance_test.go
+++ b/internal/ptahserver/five_body_guidance_test.go
@@ -153,7 +153,7 @@ func TestFiveBodyHostContractFixtureChecksumsAndVersions(t *testing.T) {
 
 	// When the sibling lesser-host checkout is available in the delegated factory
 	// workspace, compare the Host contract artifacts themselves. The checkout may
-	// be on a later Host branch whose unrelated head moved while the PR #978
+	// be on a later Host branch whose unrelated head moved while the PR #980
 	// contract bytes stayed identical; only artifact drift should break Body's
 	// mirror guard. Explicit env-provided Host dirs are stricter and must contain
 	// every mirrored artifact.
@@ -190,7 +190,7 @@ func TestFiveBodyHostContractArtifactGuardRejectsArtifactDrift(t *testing.T) {
 	writeHostContractArtifact(t, dir, "docs/contracts/soul-five-body-schema.md", []byte("changed host contract"))
 
 	err := verifyHostContractArtifacts(dir, true, mustFiveBodyMetadata())
-	if err == nil || !strings.Contains(err.Error(), "sync Host PR #978 before merge") {
+	if err == nil || !strings.Contains(err.Error(), "sync Host PR #980 before merge") {
 		t.Fatalf("verifyHostContractArtifacts drift error = %v", err)
 	}
 }

--- a/internal/ptahserver/genesis.go
+++ b/internal/ptahserver/genesis.go
@@ -934,7 +934,14 @@ func genesisNextToolGuidance(operation string, data map[string]any) map[string]a
 	case genesisOwnerInputStatus(status):
 		guidance["next_tool"] = toolAgentGenesisAdvance
 		guidance["alternate_next_tool"] = toolAgentGenesisRead
-		guidance["instruction"] = "Host candidate phase is section. Call agent_genesis_advance with the next normal owner message for current_section; Host's five provider declaration tools remain inside its AppTheory MicroVM and are never Body-local tools. Optionally read first to refresh the Host projection."
+		candidate := nestedMap(data, "conversation", "declaration_candidate")
+		completed, _ := candidate["completed_sections"].([]any)
+		currentSection := stringValue(candidate, "current_section")
+		if len(completed) == len(genesisDeclarationSections) {
+			guidance["instruction"] = "Host reopened current_section=" + currentSection + " after review. Call agent_genesis_advance with a normal owner revision message for this exact current_section; Host's five provider declaration tools remain inside its AppTheory MicroVM and are never Body-local tools. Optionally read first to refresh the Host projection."
+		} else {
+			guidance["instruction"] = "Host candidate phase is section. Call agent_genesis_advance with the next normal owner message for current_section; Host's five provider declaration tools remain inside its AppTheory MicroVM and are never Body-local tools. Optionally read first to refresh the Host projection."
+		}
 	default:
 		guidance["next_tool"] = toolAgentGenesisRead
 		guidance["instruction"] = "Poll agent_genesis_read and follow the Host status; Body does not substitute a local genesis state machine."
@@ -1700,10 +1707,10 @@ func sanitizeDeclarationCandidate(raw map[string]any) (map[string]any, error) {
 	}
 	switch phase {
 	case "section":
-		if currentSection == "" || review != nil || len(completed) >= len(genesisDeclarationSections) {
+		if currentSection == "" || review != nil {
 			return nil, errors.New("host declaration candidate section phase is inconsistent")
 		}
-		if currentSection != genesisDeclarationSections[len(completed)] {
+		if len(completed) < len(genesisDeclarationSections) && currentSection != genesisDeclarationSections[len(completed)] {
 			return nil, errors.New("host declaration candidate section order is inconsistent")
 		}
 	case "review", "affirmed", "finalized":

--- a/internal/ptahserver/genesis_skill.go
+++ b/internal/ptahserver/genesis_skill.go
@@ -24,7 +24,7 @@ type genesisSkillFile struct {
 }
 
 // genesisSkillVersion derives the stable skill version from the Host-owned
-// guidance version and the pinned Host contract head. A Host PR #978 refresh
+// guidance version and the pinned Host contract commit. A Host PR #980 refresh
 // changes this version and the bundle id together with the mirrored fixtures.
 func genesisSkillVersion() string {
 	head := fiveBodyHostHeadSHA
@@ -113,7 +113,7 @@ func agentGenesisSkillGetDef() mcpruntime.ToolDef {
 	return mcpruntime.ToolDef{
 		Name:        toolAgentGenesisSkillGet,
 		Title:       "Get Ptah genesis operator skill",
-		Description: "Fetch the read-only, client-native genesis operator skill bundle before calling agent_genesis_begin. Returns AppTheory MCP structuredContent with a SKILL.md operating playbook, bounded references, and provenance pinned to Host PR #978 exact accepted head. Ptah serves content only: no local installation, filesystem write, publish, or cloud/on-chain mutation. Requires explicit instance owner/operator OAuth authority and read scope.",
+		Description: "Fetch the read-only, client-native genesis operator skill bundle before calling agent_genesis_begin. Returns AppTheory MCP structuredContent with a SKILL.md operating playbook, bounded references, and provenance pinned to Host PR #980's exact deployed merge commit. Ptah serves content only: no local installation, filesystem write, publish, or cloud/on-chain mutation. Requires explicit instance owner/operator OAuth authority and read scope.",
 		Annotations: readOnlyToolAnnotations(),
 		InputSchema: json.RawMessage(`{
 			"type":"object",
@@ -147,7 +147,7 @@ func agentGenesisSkillGetDef() mcpruntime.ToolDef {
 							"sha256":{"type":"string"},
 							"content":{"type":"string"}
 						}}},
-						"provenance":{"type":"object","description":"Host PR #978 exact accepted head plus Body's mirrored contract versions and checksums."},
+							"provenance":{"type":"object","description":"Host PR #980 exact deployed merge commit plus Body's mirrored contract versions and checksums."},
 						"semantics":{"type":"object","description":"Explicit no-write/no-install semantics: Ptah serves content only; clients decide materialization."},
 						"guidance":{"type":"object","properties":{"next_tool":{"type":"string","enum":["agent_genesis_begin"]},"status":{"type":"string"},"instruction":{"type":"string"}}}
 					}
@@ -317,11 +317,11 @@ func genesisSkillGuidanceMap() string {
 
 Bounded reference for LLM clients operating Body/Ptah Host-backed genesis. Contract:
 ` + fiveBodySchemaVersion + ` / ` + fiveBodyGuidanceVersion + ` pinned at equaltoai/lesser-host PR #` +
-		strconv.Itoa(fiveBodyHostPR) + ` head ` + fiveBodyHostHeadSHA + `.
+		strconv.Itoa(fiveBodyHostPR) + ` deployed merge commit ` + fiveBodyHostHeadSHA + `.
 
 ## Ptah resources
 
-- ` + fiveBodyResourceURI(resourceSoulSchemaV2) + ` — mirrored Host schema, golden example, and PR #978 provenance/checksums.
+- ` + fiveBodyResourceURI(resourceSoulSchemaV2) + ` — mirrored Host schema, golden example, and PR #980 provenance/checksums.
 - ` + fiveBodyResourceURI(resourceGenesisInterviewGuide) + ` — staged five-body interview and structural review guide.
 - ` + fiveBodyResourceURI(resourceAgentSideGenesisPlaybook) + ` — operator/client playbook for the agent_genesis_*
   tools.

--- a/internal/ptahserver/genesis_test.go
+++ b/internal/ptahserver/genesis_test.go
@@ -1112,16 +1112,109 @@ func TestGenesisCandidateSectionGuidanceUsesNormalOwnerMessage(t *testing.T) {
 	}
 }
 
-func TestGenesisCandidateSectionRejectsCompletedReviewShape(t *testing.T) {
-	raw := genesisConversationResponse("assistant_turn_ready", "private transcript")
-	candidate := nestedMap(raw, "conversation", "declaration_candidate")
-	candidate["completed_sections"] = []any{"identity", "philosophy", "discipline", "boundaries", "soul"}
-	candidate["current_section"] = "soul"
+func TestGenesisCandidateSectionAcceptsHostReviewReeditShape(t *testing.T) {
+	raw := genesisReviewReeditConversationResponse("assistant_turn_ready", "boundaries")
 	result, err := genesisSuccessResult(toolAgentGenesisRead, "read", raw)
 	if err != nil {
 		t.Fatalf("genesisSuccessResult: %v", err)
 	}
-	assertToolError(t, result, "host_genesis_projection_invalid", http.StatusBadGateway)
+	data := structuredGenesisData(t, result)
+	candidate := nestedMap(data, "conversation", "declaration_candidate")
+	want := map[string]any{
+		"version":            "hosted-genesis-declaration-candidate.v1",
+		"phase":              "section",
+		"current_section":    "boundaries",
+		"completed_sections": []any{"identity", "philosophy", "discipline", "boundaries", "soul"},
+		"revision":           int64(6),
+		"candidate_hash":     "sha256:" + strings.Repeat("6", 64),
+	}
+	if !reflect.DeepEqual(candidate, want) {
+		t.Fatalf("Host review re-edit projection changed in relay: got=%#v want=%#v", candidate, want)
+	}
+	guidance := nestedMap(data, "guidance")
+	if guidance["next_tool"] != toolAgentGenesisAdvance {
+		t.Fatalf("review re-edit guidance = %#v, want %s", guidance, toolAgentGenesisAdvance)
+	}
+	instruction := guidance["instruction"].(string)
+	for _, wantText := range []string{"normal owner revision message", "current_section=boundaries"} {
+		if !strings.Contains(instruction, wantText) {
+			t.Fatalf("review re-edit guidance missing %q: %s", wantText, instruction)
+		}
+	}
+}
+
+func TestGenesisCandidateSectionReviewReeditInProgressRemainsReadOnly(t *testing.T) {
+	raw := genesisReviewReeditConversationResponse("in_progress", "boundaries")
+	result, err := genesisSuccessResult(toolAgentGenesisRead, "read", raw)
+	if err != nil {
+		t.Fatalf("genesisSuccessResult: %v", err)
+	}
+	data := structuredGenesisData(t, result)
+	candidate := nestedMap(data, "conversation", "declaration_candidate")
+	if candidate["phase"] != "section" || candidate["current_section"] != "boundaries" || candidate["revision"] != int64(6) {
+		t.Fatalf("in-progress review re-edit candidate = %#v", candidate)
+	}
+	guidance := nestedMap(data, "guidance")
+	if guidance["next_tool"] != toolAgentGenesisRead || guidance["forbidden_next_tool"] != toolAgentGenesisAdvance || guidance["wait"] != true {
+		t.Fatalf("in-progress review re-edit guidance is not read-only: %#v", guidance)
+	}
+}
+
+func TestGenesisCandidateSectionReviewReeditAcceptsEveryCurrentSection(t *testing.T) {
+	for _, section := range genesisDeclarationSections {
+		t.Run(section, func(t *testing.T) {
+			raw := genesisReviewReeditConversationResponse("assistant_turn_ready", section)
+			result, err := genesisSuccessResult(toolAgentGenesisRead, "read", raw)
+			if err != nil {
+				t.Fatalf("genesisSuccessResult: %v", err)
+			}
+			data := structuredGenesisData(t, result)
+			candidate := nestedMap(data, "conversation", "declaration_candidate")
+			if candidate["current_section"] != section {
+				t.Fatalf("current_section = %#v, want %q", candidate["current_section"], section)
+			}
+		})
+	}
+}
+
+func TestGenesisCandidateSectionProjectionFailsClosed(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(map[string]any)
+	}{
+		{name: "review present", mutate: func(c map[string]any) {
+			reviewText := "stale review must be absent after edit"
+			c["review"] = map[string]any{
+				"renderer_version":   "hosted-genesis-owner-review.v1",
+				"candidate_revision": c["revision"],
+				"candidate_hash":     c["candidate_hash"],
+				"review_hash":        "sha256:" + sha256Hex([]byte(reviewText)),
+				"review_text":        reviewText,
+			}
+		}},
+		{name: "missing current section", mutate: func(c map[string]any) { delete(c, "current_section") }},
+		{name: "unknown current section", mutate: func(c map[string]any) { c["current_section"] = "capabilities" }},
+		{name: "partial out of order", mutate: func(c map[string]any) { c["completed_sections"] = []any{"identity", "discipline"} }},
+		{name: "partial duplicate", mutate: func(c map[string]any) { c["completed_sections"] = []any{"identity", "identity"} }},
+		{name: "unknown candidate field", mutate: func(c map[string]any) { c["canonical_json"] = `{"private":true}` }},
+		{name: "invalid candidate hash", mutate: func(c map[string]any) { c["candidate_hash"] = "sha256:BAD" }},
+		{name: "invalid revision", mutate: func(c map[string]any) { c["revision"] = float64(-1) }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			raw := genesisReviewReeditConversationResponse("assistant_turn_ready", "boundaries")
+			test.mutate(nestedMap(raw, "conversation", "declaration_candidate"))
+			result, err := genesisSuccessResult(toolAgentGenesisRead, "read", raw)
+			if err != nil {
+				t.Fatalf("genesisSuccessResult: %v", err)
+			}
+			payload := assertToolError(t, result, "host_genesis_projection_invalid", http.StatusBadGateway)
+			encoded, _ := json.Marshal(payload)
+			if strings.Contains(string(encoded), "canonical_json") || strings.Contains(string(encoded), "private") || strings.Contains(string(encoded), "stale review") {
+				t.Fatalf("contract error leaked candidate internals: %s", encoded)
+			}
+		})
+	}
 }
 
 func genesisCandidateConversationResponse(phase string, reviewText string) map[string]any {
@@ -1243,6 +1336,17 @@ func genesisSectionCandidateProjection() map[string]any {
 		"phase":   "section", "current_section": "identity", "completed_sections": []any{},
 		"revision": float64(0), "candidate_hash": "sha256:" + strings.Repeat("0", 64),
 	}
+}
+
+func genesisReviewReeditConversationResponse(status string, currentSection string) map[string]any {
+	raw := genesisConversationResponse(status, "private transcript")
+	candidate := nestedMap(raw, "conversation", "declaration_candidate")
+	candidate["current_section"] = currentSection
+	candidate["completed_sections"] = []any{"identity", "philosophy", "discipline", "boundaries", "soul"}
+	candidate["revision"] = float64(6)
+	candidate["candidate_hash"] = "sha256:" + strings.Repeat("6", 64)
+	delete(candidate, "review")
+	return raw
 }
 
 func genesisFinalizedCandidateProjection(reviewText string) map[string]any {

--- a/internal/ptahserver/testdata/host-contract/pr-978/hosted-genesis-conversation.md
+++ b/internal/ptahserver/testdata/host-contract/pr-978/hosted-genesis-conversation.md
@@ -88,7 +88,9 @@ discipline, boundaries, and soul. Accepted tool submissions are normalized and v
 under tenant/session/turn/candidate guards through TableTheory. Invalid submissions return machine-readable
 section/path/code errors and retry only the current section. Every tool payload must repeat the exact current
 `candidateRevision` and `candidateHash`; missing, stale, mismatched, or unknown payload fields fail closed before any
-candidate mutation. The VM actor never rebuilds the candidate from a transcript.
+candidate mutation. Host rejects section fields above their published limits so provider repair can compress the
+current section; it never silently truncates owner-supplied declaration content. The VM actor never rebuilds the
+candidate from a transcript.
 
 The owner review is rendered deterministically as a stable human header plus a byte-counted, delimited copy of the
 exact canonical JSON. The canonical block is reversible byte-for-byte without a provider and losslessly exposes every
@@ -97,7 +99,9 @@ derived boundaries, refusals, and adversarial-review evidence. `candidate_hash` 
 `review_hash` separately authenticates the complete `review_text`. The full lossless payload is authoritative at
 `declaration_candidate.review.review_text`; clients must not substitute a potentially truncated transcript-message
 projection. Structural affirmation binds the candidate revision/hash and review hash; any edit invalidates the prior
-review and affirmation. Finalization revalidates and publishes the exact canonical candidate bytes. **No provider request occurs after affirmation.**
+review and affirmation, advances the revision, and reopens only the selected section. The revised section regenerates
+the deterministic review and bindings; actions from the prior review fail closed. Finalization revalidates and
+publishes the exact canonical candidate bytes. **No provider request occurs after affirmation.**
 The fifth accepted tool also needs no provider-generated review prose: Host projects the stored deterministic review
 directly, including after process/VM recovery from the accepted review checkpoint.
 When the actor finalizes, it advances the same durable conversation to `declaration_ready` with `produced_declarations`

--- a/internal/ptahserver/testdata/host-contract/pr-978/metadata.json
+++ b/internal/ptahserver/testdata/host-contract/pr-978/metadata.json
@@ -1,8 +1,8 @@
 {
   "source_repository": "equaltoai/lesser-host",
-  "source_pull_request": 978,
+  "source_pull_request": 980,
   "source_issue": 977,
-  "source_head_sha": "2339acffe646c49fb951e7a7164f55174d841770",
+  "source_head_sha": "5f873e184ba70e662ed2c945a71357385ac196bc",
   "schema_version": "soul-five-body-schema.v2",
   "guidance_version": "soul-five-body-guidance.v2",
   "artifacts": [
@@ -24,7 +24,7 @@
     {
       "source_path": "docs/contracts/hosted-genesis-conversation.md",
       "mirror_file": "hosted-genesis-conversation.md",
-      "sha256": "0f6f9f745de7e2438bbab20cc03baee6a9a151d0cc09f7d42747d0d67340a5ff"
+      "sha256": "5bc7b76f9d8fb3bc40c336aef99183980325a35c06309b75534358bcbf878875"
     },
     {
       "source_path": "docs/contracts/openapi.yaml",
@@ -62,5 +62,5 @@
       "sha256": "3ccd491745aabb9fa45b97c36b0c9af18df32f2cd26c1c32ec25630431fe6ba0"
     }
   ],
-  "notes": "Body mirror of Host PR #978 exact accepted head. Refresh every artifact and checksum from Host-owned source; never edit a Body-local declaration protocol."
+  "notes": "Body mirror of the Host PR #978 typed-candidate contract as repaired by authoritative PR #980 at deployed staging merge commit 5f873e184ba70e662ed2c945a71357385ac196bc. Refresh every artifact and checksum from Host-owned source; never edit a Body-local declaration protocol."
 }


### PR DESCRIPTION
## Milestone
Project 48 → Host #940 → Body #452 — repair the live prototype-2 typed-candidate consumer after Host #980.

Refs #452 and parent Host #940. This PR does not close #452.

## Classification
Bug fix / Host contract consumer / MCP tool-response semantic repair.

## Root cause
Host PR #980 intentionally preserves all five canonical `completed_sections` when an exact owner edit reopens one reviewed section. It projects `phase=section`, `current_section=<selected section>`, all five completed sections in canonical order, incremented revision, and no review.

Body's `sanitizeDeclarationCandidate` rejected every section-phase projection with five completed sections. It only accepted a shorter ordered prefix whose `current_section` was the next incomplete section, converting Host's accepted edit into `host_genesis_projection_invalid` / HTTP 502.

## Producer and framework sources inspected
- authoritative Host deployed staging merge: `5f873e184ba70e662ed2c945a71357385ac196bc` (PR #980)
  - `internal/hostedgenesis/candidate.go`: `validateDeclarationCandidateSectionPhase` explicitly accepts all-five completion with any exact declaration section and no review
  - `ApplyDeclarationCandidateAction` preserves completed sections, increments revision, selects the reopened section, and clears review/affirmation
  - Host tests assert the re-edit shape remains section phase with revision 6 and all five completed sections
- current Body framework pins are AppTheory **v1.17.0** and TableTheory **v2.0.3** (the issue prompt's expected v0.22.0 pin is no longer current)
  - inspected AppTheory `runtime/mcp` `ToolDef`, `InputSchema`, `OutputSchema`, `ToolResult.StructuredContent`, and schema/JSON-RPC tests
  - retained the existing framework path unchanged

## Change
- accept both Host-valid section shapes:
  1. ordered construction prefix shorter than five with the next incomplete `current_section`
  2. review re-edit with all five canonical completed sections and any exact five-body `current_section`, review absent
- preserve all existing fail-closed exact-key, enum, order, duplicate, review, revision, and SHA-256 validation
- provide explicit owner-revision guidance naming the exact reopened `current_section`; keep `in_progress` wait/read-only
- synchronize Body's checked Host contract fixture/provenance to PR #980 at deployed merge `5f873e18` after the sibling fixture guard proved the contract bytes had changed

## Invariants preserved
- Host remains the sole candidate/state authority
- no Body-local declaration tool, candidate persistence, TableTheory storage, transcript extraction, compatibility fallback, phrase authority, or local reinterpretation
- no scope/profile, registration, OAuth, JSON-RPC envelope, or AppTheory runtime changes
- no AWS/deploy/release/signing/cloud mutation

## Validation
- regression tests first reproduced the HTTP 502 projection rejection
- `go test ./internal/ptahserver ./internal/hostapi ./internal/instanceapp -count=1`
- `gofmt -l .` (empty)
- `go test ./... -count=1`
- `go vet ./...`
- `go build ./...`
- `bash scripts/build_release_assets.sh v0.0.0-test dist/release-test`
- `bash scripts/verify_release_assets.sh v0.0.0-test dist/release-test`
- representative synth: `cd cdk && CDK_DEFAULT_ACCOUNT=000000000000 CDK_DEFAULT_REGION=us-east-1 npm run synth -- -c app=lesser -c stage=dev -c baseDomain=example.com`
- exact-head `gov_rubric_report.v1` at `b847e35a64da5ea62616b2dbe4dd3f0a0ef9a60d`: **PASS 19/19**, fail 0, blocked 0

## Test coverage
- exact Host all-five/boundaries re-edit shape is sanitized and relayed unchanged
- `assistant_turn_ready` → `agent_genesis_advance` with normal owner revision guidance for `current_section=boundaries`
- identical `in_progress` shape remains wait/read-only
- all five exact `current_section` values accepted in the all-complete re-edit shape
- malformed section projections still rejected: review present, missing/unknown current section, partial out-of-order/duplicate completion, unknown key, invalid hash, invalid revision
- ordinary prefix, review, finalized, no-fallback, and no-phrase-authority tests remain green

## Rollout
PR only to git branch `staging`. No merge or deployment is performed here. Normal lab/dev → staging (if used) → live rollout remains operator-owned.