### PR TITLE
promote: staging → main (CI pull_request-only triggers)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,12 +2,6 @@ name: ci
 
 on:
   pull_request:
-  push:
-    branches:
-      - main
-      # Git branch staging is the source-control integration branch,
-      # not the CDK/release deploy-stage staging.
-      - staging
 
 permissions:
   contents: read


### PR DESCRIPTION
## Promotion: staging → main

Contents beyond current main:
- PR #486 `ci: run verification only on pull requests` (`Closes #485`) — ci.yml now triggers on `pull_request` only; no more post-merge secondary rubric runs.

Already on main via #484: #482 (`Closes #480`, genesis begin schema enum) and #483 (`Closes #481`, human-readable install-pack MCP server names).

After this lands, the release can be re-run on a clean main. Opened by factory via gh (operator-authorized path for promotion PRs; agent routes refuse a staging head).