### PR TITLE
promote: staging → main (ka read payloads for text-only clients)

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1343,11 +1343,21 @@ parameter during the migration. The shared names are:
 - `include_diagnostics` — optional timing/size diagnostics for Ops probes. It defaults to `false` for user-facing
   reads; diagnostics are never emitted by default for large read tools.
 
-Structured-first result shaping is additive. Existing tools that use `content[0].text` as JSON keep their current
-`standard` behavior until explicitly migrated. New compact/summary responses should keep `content[0].text` concise
-(JSON summaries and locators for text-only clients) while preserving authoritative full data in
-`structuredContent.data`. If diagnostics are requested, concise text should point to `structuredContent.diagnostics`
-rather than duplicating timing/size payloads.
+Structured-first result shaping is dual-surface and text-accessible. Existing tools that use `content[0].text` as JSON
+keep their current `standard` behavior until explicitly migrated. Compact/summary tools first build their bounded
+projection, then expose substantive content under `content[0].text` JSON `payload` and the unchanged typed projection
+under `structuredContent.data`. For structured-first social reads, `payload` is a concise newline-delimited rendering
+of stable ids and already-bounded previews; other structured-first tools return the bounded JSON projection there. The
+legacy text `data.location` locator remains, while the sibling `access` field says
+`payload or structuredContent.data`. Schema-capable clients retain the structured shape, and text-only clients no
+longer need to follow the locator. A tool's existing `preview_chars` projection is applied before the result surfaces
+are rendered, and `max_output_bytes` continues to measure the final MCP JSON-RPC envelope. Requested diagnostics appear
+under text JSON `diagnosticPayload` and `structuredContent.diagnostics`, with dual-surface guidance in
+`diagnosticsAccess`.
+
+Expansion metadata preserves the legacy machine-readable `resultPath` for structured clients. Where a text alternative
+is available, additive `textResultPath` and `resultAccess` fields identify the text location and phrase the choice as
+text content or `structuredContent`; clients should prefer `resultAccess` for human/agent guidance.
 
 Project 33 P4.1 compatibility decision: compact defaults remain opt-in for now. `timeline_read`, `post_search`,
 `soul_read`, and `email_read` keep their omitted/default behavior equivalent to `view=standard`; callers must request
@@ -1371,7 +1381,8 @@ index/ref pages and expand only the items they need:
   `notification_get` expansion as the reliable snapshot path.
 - `notifications_read({"actor":"ops","limit":10,"view":"compact"})` is a secondary discovery aid for "things from
   Ops". It filters the normalized notification actor/source after a bounded Lesser over-fetch and declares the strategy
-  under `structuredContent.data.filter`. Use `direct_messages_read(counterpart=...)` as the primary DM retrieval path.
+  at the start of `content[0].text` JSON `payload` or under `structuredContent.data.filter`. Use
+  `direct_messages_read(counterpart=...)` as the primary DM retrieval path.
 - `conversations_read({"limit":10,"view":"compact"})` returns conversation refs with bounded participant and last-post
   metadata. Use `conversation_get({"conversationId":"<conversation-id>","limit":20,"view":"compact"})` to expand one
   conversation into recent message previews. `lastPostRef` can still expand through `post_get` when Lesser supplies a
@@ -1428,7 +1439,7 @@ search:
 - Expand this conversation after a compact result:
 
   ```json
-  {"tool":"conversation_get","arguments":{"conversationId":"<structuredContent.data.id>","limit":20,"view":"compact"}}
+  {"tool":"conversation_get","arguments":{"conversationId":"<id listed in content[0].text JSON payload or structuredContent.data.conversations[].id>","limit":20,"view":"compact"}}
   ```
 
 - Resolve a pending first-contact request as the recipient:
@@ -1440,13 +1451,13 @@ search:
   Then accept the selected request to allow the conversation and subsequent DMs into the inbox:
 
   ```json
-  {"tool":"message_request_accept","arguments":{"conversationId":"<structuredContent.data.requests[].conversationId>"}}
+  {"tool":"message_request_accept","arguments":{"conversationId":"<content[0].text JSON payload.requests[].conversationId or structuredContent.data.requests[].conversationId>"}}
   ```
 
   Or explicitly decline it:
 
   ```json
-  {"tool":"message_request_decline","arguments":{"conversationId":"<structuredContent.data.requests[].conversationId>"}}
+  {"tool":"message_request_decline","arguments":{"conversationId":"<content[0].text JSON payload.requests[].conversationId or structuredContent.data.requests[].conversationId>"}}
   ```
 
 `direct_messages_read` uses Lesser's named counterpart lookup and returns either the focused one-to-one conversation or
@@ -1519,9 +1530,9 @@ When a compact status omits full content, its `omitted[]` record points at `post
 `timeline_read` and `post_search` now advertise opt-in `view=compact` plus `preview_chars` and `max_output_bytes`.
 Their omitted-`view` default and `view=standard` / `view=full` behavior preserves the current upstream-shaped response.
 Compact timeline/search responses return `StatusRef` lists, compact `AccountRef` search account matches, list-level
-omitted-field metadata, and concise structured-first text that points clients to `structuredContent.data` instead of
-duplicating every compact entry in `content[0].text`. The default compact budgets target `timeline_read(limit=5,
-view=compact)` under 6 KB and `post_search(limit=10, view=compact)` under 8 KB as MCP JSON-RPC responses. If a compact
+omitted-field metadata, ids plus bounded content previews in `content[0].text` JSON `payload`, and the unchanged typed
+projection in `structuredContent.data`. The default compact budgets target `timeline_read(limit=5, view=compact)` under
+6 KB and `post_search(limit=10, view=compact)` under 8 KB as final MCP JSON-RPC responses. If the dual-surface compact
 response exceeds its default or caller-supplied `max_output_bytes`, body returns a `response_too_large` tool error with
 measured byte details rather than silently dropping fields.
 
@@ -1561,25 +1572,29 @@ Notes:
   host-backed communication sender metadata (`communication.from.soulAgentId`, `agentId`, `email`/`address`, and
   `identifier` where Lesser/host include it). Because Lesser does not yet expose an upstream actor filter, body
   over-fetches a bounded notification page (`min(limit*4, 80)`) and returns
+  `filter=mcp_side_overfetch` at the start of `content[0].text` JSON `payload`; schema-capable clients also receive
   `structuredContent.data.filter.strategy="mcp_side_overfetch"` with `requestedLimit`, `overFetchLimit`,
   `upstreamCount`, `matchedCount`, `returnedCount`, and `windowOffset`. If an over-fetched page contains more actor
   matches than the requested return `limit`, `nextCursor` is an opaque body actor-filter cursor that re-reads the same
   over-fetch window and returns the remaining matches before advancing to Lesser's upstream cursor. This prevents
-  matched-but-not-returned notifications inside the over-fetch window from becoming unreachable. Actor-filtered compact
-  reads still use the normal compact budget and return `response_too_large` rather than silently dropping fields.
+  matched-but-not-returned notifications inside the over-fetch window from becoming unreachable. Actor-filtered
+  compact reads still use the normal compact budget and return `response_too_large` rather than silently dropping
+  fields.
 - `notifications_read` omits full upstream `raw` notification objects by default and accepts optional
   `include_raw=true`, which returns `_raw` on each notification for expensive audit/debug use. Default notifications
   contain compact `actor`, bounded `targetPost`, optional bounded `communication` summaries, normalized read state
   (`read` when Lesser exposes it, inferred from `unread` where needed), and cursor/since metadata.
   `include_diagnostics=true` adds best-effort timing/size fields for Ops probes; user-facing default reads omit
   diagnostics.
-- `notifications_read(view=compact)` is opt-in and returns compact notification refs under
-  `structuredContent.data.notifications[]` with stable id/type/timestamps/read state, `actorRef`, bounded
+- `notifications_read(view=compact)` is opt-in and returns notification ids plus bounded target previews in
+  `content[0].text` JSON `payload`, and typed compact refs under `structuredContent.data.notifications[]`, with stable
+  id/type/timestamps/read state, `actorRef`, bounded
   `targetPostRef`, optional communication previews, and deterministic expansion metadata. Per-notification
   `expand` points at `notification_get(id, view=standard)`. `targetPostRef.expand` points at `post_get` only when the
   target exposes a direct Lesser status lookup key; remote/generated snapshot-only target ids keep id/url/preview
   metadata but omit `post_get` so clients do not follow an expansion that can only 404. `notifications_read(limit=10,
-  view=compact)` targets an 8 KB MCP JSON-RPC payload budget.
+  view=compact)` uses an 8-rune default target preview so all ten refs remain text-visible within the existing 8 KB
+  final-envelope budget.
   If the compact response exceeds its default or caller-supplied `max_output_bytes`, body returns `response_too_large`
   with measured byte details rather than silently dropping fields. `notification_get(id, view=standard)` returns a
   normalized notification from Lesser's `GET /api/v1/notifications/{id}` route; `notification_get(id, view=full)`
@@ -1588,7 +1603,8 @@ Notes:
   upstream `_raw` payloads.
 - `conversations_read` defaults to `limit=20` (maximum `80`) and preserves the existing normalized conversation-list
   response unless a view is requested. `conversations_read(view=compact)` is opt-in and returns compact conversation
-  summaries under `structuredContent.data.conversations[]`: stable conversation id, read/unread/update metadata,
+  ids plus bounded last-post previews in `content[0].text` JSON `payload`, and typed summaries under
+  `structuredContent.data.conversations[]`: stable conversation id, read/unread/update metadata,
   `participantRefs`, bounded `lastPostRef` previews, and per-conversation `expand` metadata pointing at
   `conversation_get({"conversationId":"<id>","view":"compact"})`. `lastPostRef.expand`
   uses `post_get(id, view=standard)` when Lesser supplies a stable post/status id; otherwise the ref reports missing
@@ -1600,7 +1616,8 @@ Notes:
 - `conversation_get` defaults to `view=compact`, `limit=20` (maximum `80`), a 160-character message preview budget,
   and a 12 KB compact MCP JSON-RPC payload budget. It calls Lesser's
   `GET /api/v1/conversations/{conversationId}` route with the MCP caller bearer and returns one conversation under
-  `structuredContent.data.conversation`. Compact output contains stable conversation metadata, `participantRefs`,
+  `structuredContent.data.conversation`; `content[0].text` JSON `summary` and `payload` expose the conversation id plus
+  bounded message previews to text-only clients. Compact output contains stable conversation metadata, `participantRefs`,
   bounded `messageRefs` with author refs/timestamps/visibility/content previews, omission metadata, and `post_get`
   expansion metadata when a message id is available. `view=standard` explicitly includes normalized message content;
   `view=full` also includes the upstream Lesser conversation payload under `_raw` for audit/debug. A 404 from Lesser is
@@ -1610,14 +1627,16 @@ Notes:
   `GET /api/v1/conversations/lookup?counterpart=<name>` route with the MCP caller bearer and does **not** fall back to
   notifications, timelines, email, or broad conversation scans. `counterpart` may be a local id, acct, or actor URL
   where Lesser supports that resolution. Compact output returns the matched conversation ref plus top-level compact
-  `messages[]` preview refs under `structuredContent.data`; `view=standard` explicitly includes normalized message
+  message ids plus bounded previews in `content[0].text` JSON `payload`, and typed `messages[]` refs under
+  `structuredContent.data`; `view=standard` explicitly includes normalized message
   content and `view=full` adds the upstream Lesser payload under `_raw` for audit/debug. `unreadOnly=true` returns
   message previews only when the matched conversation is unread; read conversations return zero message previews rather
   than leaking already-read bodies. A Lesser 404 is returned as a `not_found` tool error with suggested fallbacks,
   while Lesser 401/403 responses preserve OAuth reauthorization guidance.
 - `soul_read` advertises `view=summary|standard|full`. Omitted/default and `view=standard` preserve the existing public
   soul bundle shape. `view=summary` is opt-in and returns bounded agent-facing essentials under
-  `structuredContent.data.souls[]`: stable identity/lifecycle fields, public capability names (not full capability
+  `content[0].text` JSON `payload.souls[]` or `structuredContent.data.souls[]`: stable identity/lifecycle fields,
+  public capability names (not full capability
   bodies), public channel availability markers, provenance/source markers, omission metadata, and deterministic
   `soul_read(..., view=standard|full)` expansion refs. `soul_read(self=true, view=summary)` targets an 8 KB MCP
   JSON-RPC payload budget; if a summary still exceeds that budget, body returns `response_too_large` with measured byte

--- a/internal/mcpserver/article_published_tools.go
+++ b/internal/mcpserver/article_published_tools.go
@@ -379,9 +379,11 @@ func compactArticleRef(article *cmsapi.Article, params articleDraftViewParams, f
 		"canonicalUrl":  canonicalArticleURL(article),
 		"contentFormat": strings.TrimSpace(article.ContentFormat),
 		"expand": map[string]any{
-			"tool":       "article_get",
-			"arguments":  map[string]any{"id": strings.TrimSpace(article.ID), "view": readViewStandard},
-			"resultPath": "structuredContent.data.article",
+			"tool":           "article_get",
+			"arguments":      map[string]any{"id": strings.TrimSpace(article.ID), "view": readViewStandard},
+			"resultPath":     "structuredContent.data.article",
+			"textResultPath": "payload.article",
+			"resultAccess":   toolResultAccessPath("payload.article", "data.article"),
 		},
 	}
 	putIfNotEmpty(out, "title", article.Title)

--- a/internal/mcpserver/article_tools.go
+++ b/internal/mcpserver/article_tools.go
@@ -547,9 +547,11 @@ func shapeArticleDraftPreview(preview *cmsapi.DraftPreview, params articleDraftV
 func compactArticleDraftPreview(preview *cmsapi.DraftPreview, params articleDraftViewParams) map[string]any {
 	out := baseArticleDraftPreview(preview)
 	out["expand"] = map[string]any{
-		"tool":       "article_draft_preview",
-		"arguments":  map[string]any{"id": strings.TrimSpace(preview.DraftID), "view": readViewStandard},
-		"resultPath": "structuredContent.data.preview",
+		"tool":           "article_draft_preview",
+		"arguments":      map[string]any{"id": strings.TrimSpace(preview.DraftID), "view": readViewStandard},
+		"resultPath":     "structuredContent.data.preview",
+		"textResultPath": "payload.preview",
+		"resultAccess":   toolResultAccessPath("payload.preview", "data.preview"),
 	}
 	if preview.Success && preview.RenderedHTML != nil && strings.TrimSpace(*preview.RenderedHTML) != "" {
 		renderedPreview, truncated := compactStringWithTruncation(*preview.RenderedHTML, params.PreviewRunes)
@@ -591,9 +593,11 @@ func compactArticleDraftCursorRef(draftID string) map[string]any {
 		"status":       cmsapi.DraftStatusDraft,
 		"depthSafeRef": true,
 		"expand": map[string]any{
-			"tool":       "article_draft_get",
-			"arguments":  map[string]any{"id": draftID, "view": readViewStandard},
-			"resultPath": "structuredContent.data.draft",
+			"tool":           "article_draft_get",
+			"arguments":      map[string]any{"id": draftID, "view": readViewStandard},
+			"resultPath":     "structuredContent.data.draft",
+			"textResultPath": "payload.draft",
+			"resultAccess":   toolResultAccessPath("payload.draft", "data.draft"),
 		},
 	}
 }
@@ -604,9 +608,11 @@ func compactArticleDraftRef(draft *cmsapi.Draft, params articleDraftViewParams, 
 		"status":        strings.TrimSpace(draft.Status),
 		"contentFormat": strings.TrimSpace(draft.ContentFormat),
 		"expand": map[string]any{
-			"tool":       "article_draft_get",
-			"arguments":  map[string]any{"id": strings.TrimSpace(draft.ID), "view": readViewStandard},
-			"resultPath": "structuredContent.data.draft",
+			"tool":           "article_draft_get",
+			"arguments":      map[string]any{"id": strings.TrimSpace(draft.ID), "view": readViewStandard},
+			"resultPath":     "structuredContent.data.draft",
+			"textResultPath": "payload.draft",
+			"resultAccess":   toolResultAccessPath("payload.draft", "data.draft"),
 		},
 	}
 	putIfNotEmpty(out, "title", stringPtrValue(draft.Title))

--- a/internal/mcpserver/message_request_tools.go
+++ b/internal/mcpserver/message_request_tools.go
@@ -107,9 +107,11 @@ func handleMessageRequestAccept(ctx context.Context, args json.RawMessage) (*mcp
 		"requestState":   state,
 		"conversation":   ref,
 		"expand": map[string]any{
-			"tool":       "conversation_get",
-			"arguments":  map[string]any{"conversationId": conversationID, "view": "compact"},
-			"resultPath": "structuredContent.data.conversation",
+			"tool":           "conversation_get",
+			"arguments":      map[string]any{"conversationId": conversationID, "view": "compact"},
+			"resultPath":     "structuredContent.data.conversation",
+			"textResultPath": "payload",
+			"resultAccess":   toolResultAccessPath("payload", "data.conversation"),
 		},
 	}
 	return toolStructuredFirstResult(structuredFirstResultOptions{

--- a/internal/mcpserver/read_params_test.go
+++ b/internal/mcpserver/read_params_test.go
@@ -71,7 +71,7 @@ func TestSharedReadParamSchemaPropertiesAreAdditiveFragments(t *testing.T) {
 	}
 }
 
-func TestToolStructuredFirstResultKeepsFullDataStructured(t *testing.T) {
+func TestToolStructuredFirstResultKeepsDataOnBothSurfaces(t *testing.T) {
 	result, err := toolStructuredFirstResult(structuredFirstResultOptions{
 		Summary: "2 compact posts",
 		Data: map[string]any{
@@ -102,9 +102,18 @@ func TestToolStructuredFirstResultKeepsFullDataStructured(t *testing.T) {
 	if text["summary"] != "2 compact posts" {
 		t.Fatalf("summary = %#v", text["summary"])
 	}
-	dataLocator, _ := text["data"].(map[string]any)
-	if dataLocator["location"] != "structuredContent.data" {
-		t.Fatalf("data locator = %#v", dataLocator)
+	locator, _ := text["data"].(map[string]any)
+	if locator["location"] != "structuredContent.data" {
+		t.Fatalf("data locator must preserve the structured path: %#v", locator)
+	}
+	if text["access"] != "payload or structuredContent.data" {
+		t.Fatalf("text access guidance must name both result surfaces: %#v", text["access"])
+	}
+	textData, _ := text["payload"].(map[string]any)
+	textItems, _ := textData["items"].([]any)
+	textItem, _ := textItems[0].(map[string]any)
+	if textItem["content"] != "full text" {
+		t.Fatalf("text payload must retain substantive data, got %#v", textData)
 	}
 	if _, ok := text["diagnostics"]; ok {
 		t.Fatalf("diagnostics must be opt-in in text payload: %#v", text)
@@ -123,60 +132,64 @@ func TestToolStructuredFirstResultKeepsFullDataStructured(t *testing.T) {
 	}
 }
 
-func TestToolStructuredFirstResultCompactOptInNamesOmissionsAndExpansionRefs(t *testing.T) {
+func TestToolStructuredFirstResultPreservesPreBoundedCompactProjection(t *testing.T) {
 	const heavyPostSentinel = "FULL_HEAVY_POST_BODY_SHOULD_NOT_APPEAR_IN_COMPACT_TEXT"
 	const heavyAccountSentinel = "FULL_HEAVY_ACCOUNT_NOTE_SHOULD_NOT_APPEAR_IN_COMPACT_TEXT"
 
 	fullData := map[string]any{
 		"view": "standard",
-		"items": []any{
-			map[string]any{
-				"id":        "post-1",
-				"postRef":   "post:post-1",
-				"createdAt": "2026-05-17T15:00:00Z",
-				"content":   heavyPostSentinel + " " + strings.Repeat("post body ", 500),
-				"account": map[string]any{
-					"id":         "acct-1",
-					"accountRef": "account:acct-1",
-					"note":       heavyAccountSentinel + " " + strings.Repeat("profile note ", 300),
-				},
+		"items": []any{map[string]any{
+			"id":        "post-1",
+			"postRef":   "post:post-1",
+			"createdAt": "2026-05-17T15:00:00Z",
+			"content":   heavyPostSentinel + " " + strings.Repeat("post body ", 500),
+			"account": map[string]any{
+				"id":         "acct-1",
+				"accountRef": "account:acct-1",
+				"note":       heavyAccountSentinel + " " + strings.Repeat("profile note ", 300),
+			},
+		}},
+		"nextCursor": "cursor-post-1",
+	}
+	compactItem := map[string]any{
+		"postRef":    "post:post-1",
+		"accountRef": "account:acct-1",
+		"createdAt":  "2026-05-17T15:00:00Z",
+		"preview":    "short preview",
+	}
+	compactOmissions := []any{
+		map[string]any{
+			"path":   "items[].content",
+			"reason": "heavy_text",
+			"expand": map[string]any{
+				"ref":      "post:post-1",
+				"location": toolResultAccessPath("payload.items[0].content", "data.items[0].content"),
 			},
 		},
+		map[string]any{
+			"path":   "items[].account.note",
+			"reason": "profile_bio",
+			"expand": map[string]any{
+				"ref":      "account:acct-1",
+				"location": toolResultAccessPath("payload.items[0].account.note", "data.items[0].account.note"),
+			},
+		},
+	}
+	compactData := map[string]any{
+		"view":       readViewCompact,
+		"items":      []any{compactItem},
+		"omitted":    compactOmissions,
 		"nextCursor": "cursor-post-1",
 	}
 	result, err := toolStructuredFirstResult(structuredFirstResultOptions{
 		Summary: "1 compact post",
-		Data:    fullData,
+		Data:    compactData,
 		Text: map[string]any{
-			"view": "compact",
-			"items": []any{
-				map[string]any{
-					"postRef":    "post:post-1",
-					"accountRef": "account:acct-1",
-					"createdAt":  "2026-05-17T15:00:00Z",
-					"preview":    "short preview",
-				},
-			},
-			"omitted": []any{
-				map[string]any{
-					"path":   "items[].content",
-					"reason": "heavy_text",
-					"expand": map[string]any{
-						"ref":      "post:post-1",
-						"location": "structuredContent.data.items[0].content",
-					},
-				},
-				map[string]any{
-					"path":   "items[].account.note",
-					"reason": "profile_bio",
-					"expand": map[string]any{
-						"ref":      "account:acct-1",
-						"location": "structuredContent.data.items[0].account.note",
-					},
-				},
-			},
+			"view":    readViewCompact,
+			"items":   []any{compactItem},
+			"omitted": compactOmissions,
 			"budget": map[string]any{
-				"maxOutputBytes": 2048,
+				"maxOutputBytes": 4096,
 				"enforcement":    "test_gate_only",
 				"truncation":     "none; gate fails instead of silently dropping fields",
 			},
@@ -197,22 +210,20 @@ func TestToolStructuredFirstResultCompactOptInNamesOmissionsAndExpansionRefs(t *
 	if err := json.Unmarshal([]byte(textJSON), &text); err != nil {
 		t.Fatalf("unmarshal compact text: %v", err)
 	}
-	if text["view"] != readViewCompact {
-		t.Fatalf("compact text view = %#v", text["view"])
-	}
-	items, _ := text["items"].([]any)
+	textData, _ := text["payload"].(map[string]any)
+	items, _ := textData["items"].([]any)
 	if len(items) != 1 {
-		t.Fatalf("compact text should retain one item ref, got %#v", text["items"])
+		t.Fatalf("compact text data should retain one item ref, got %#v", textData["items"])
 	}
 	item, _ := items[0].(map[string]any)
-	if item["postRef"] != "post:post-1" || item["accountRef"] != "account:acct-1" {
-		t.Fatalf("compact text lost stable refs: %#v", item)
+	if item["postRef"] != "post:post-1" || item["accountRef"] != "account:acct-1" || item["preview"] != "short preview" {
+		t.Fatalf("compact text data lost substantive refs/preview: %#v", item)
 	}
 	if _, ok := item["content"]; ok {
-		t.Fatalf("compact text item must omit content: %#v", item)
+		t.Fatalf("compact text data must omit full content: %#v", item)
 	}
 	if _, ok := item["account"]; ok {
-		t.Fatalf("compact text item must omit nested account payload: %#v", item)
+		t.Fatalf("compact text data must omit nested account payload: %#v", item)
 	}
 
 	omitted, _ := text["omitted"].([]any)
@@ -220,8 +231,8 @@ func TestToolStructuredFirstResultCompactOptInNamesOmissionsAndExpansionRefs(t *
 		t.Fatalf("expected two omitted-field records, got %#v", text["omitted"])
 	}
 	wantOmitted := map[string]string{
-		"items[].content":      "structuredContent.data.items[0].content",
-		"items[].account.note": "structuredContent.data.items[0].account.note",
+		"items[].content":      toolResultAccessPath("payload.items[0].content", "data.items[0].content"),
+		"items[].account.note": toolResultAccessPath("payload.items[0].account.note", "data.items[0].account.note"),
 	}
 	for _, raw := range omitted {
 		record, _ := raw.(map[string]any)
@@ -238,14 +249,13 @@ func TestToolStructuredFirstResultCompactOptInNamesOmissionsAndExpansionRefs(t *
 	}
 
 	data, _ := result.StructuredContent["data"].(map[string]any)
-	fullItems, _ := data["items"].([]any)
-	fullItem, _ := fullItems[0].(map[string]any)
-	if content, _ := fullItem["content"].(string); !strings.Contains(content, heavyPostSentinel) {
-		t.Fatalf("structuredContent.data must retain full post content, got %#v", fullItem["content"])
+	structuredItems, _ := data["items"].([]any)
+	structuredItem, _ := structuredItems[0].(map[string]any)
+	if structuredItem["preview"] != "short preview" {
+		t.Fatalf("structuredContent.data lost compact preview: %#v", structuredItem)
 	}
-	account, _ := fullItem["account"].(map[string]any)
-	if note, _ := account["note"].(string); !strings.Contains(note, heavyAccountSentinel) {
-		t.Fatalf("structuredContent.data must retain full account note, got %#v", account["note"])
+	if _, ok := structuredItem["content"]; ok {
+		t.Fatalf("pre-bounded compact projection leaked full content: %#v", structuredItem)
 	}
 
 	compactMeasurement, err := measureToolResultPayload(result)
@@ -260,20 +270,12 @@ func TestToolStructuredFirstResultCompactOptInNamesOmissionsAndExpansionRefs(t *
 	if err != nil {
 		t.Fatalf("measure standard result payload: %v", err)
 	}
-	const compactTextBudgetBytes = 2048
-	t.Logf("compact structured-first text bytes=%d, envelope bytes=%d; standard envelope bytes=%d",
-		compactMeasurement.ContentTextBytes,
-		compactMeasurement.JSONRPCEnvelopeBytes,
-		standardMeasurement.JSONRPCEnvelopeBytes,
-	)
+	const compactTextBudgetBytes = 4096
 	if compactMeasurement.ContentTextBytes > compactTextBudgetBytes {
-		t.Fatalf("compact text bytes %d exceed explicit budget %d; do not silently truncate",
-			compactMeasurement.ContentTextBytes,
-			compactTextBudgetBytes,
-		)
+		t.Fatalf("compact text bytes %d exceed explicit budget %d", compactMeasurement.ContentTextBytes, compactTextBudgetBytes)
 	}
 	if compactMeasurement.JSONRPCEnvelopeBytes >= standardMeasurement.JSONRPCEnvelopeBytes {
-		t.Fatalf("compact structured-first envelope must be smaller than standard duplicated JSON: compact=%d standard=%d",
+		t.Fatalf("bounded compact envelope must be smaller than standard response: compact=%d standard=%d",
 			compactMeasurement.JSONRPCEnvelopeBytes,
 			standardMeasurement.JSONRPCEnvelopeBytes,
 		)
@@ -296,9 +298,16 @@ func TestToolStructuredFirstResultCanOptInDiagnostics(t *testing.T) {
 	if err := json.Unmarshal([]byte(result.Content[0].Text), &text); err != nil {
 		t.Fatalf("unmarshal text: %v", err)
 	}
-	diagLocator, _ := text["diagnostics"].(map[string]any)
-	if diagLocator["location"] != "structuredContent.diagnostics" {
-		t.Fatalf("diagnostics locator = %#v", diagLocator)
+	diagnosticsLocator, _ := text["diagnostics"].(map[string]any)
+	if diagnosticsLocator["location"] != "structuredContent.diagnostics" {
+		t.Fatalf("diagnostics locator must preserve the structured path: %#v", diagnosticsLocator)
+	}
+	if text["diagnosticsAccess"] != "diagnosticPayload or structuredContent.diagnostics" {
+		t.Fatalf("diagnostics guidance must name both result surfaces: %#v", text["diagnosticsAccess"])
+	}
+	textDiagnostics, _ := text["diagnosticPayload"].(map[string]any)
+	if textDiagnostics["responseBytes"] != float64(42) {
+		t.Fatalf("diagnostics payload must be available to text-only clients: %#v", textDiagnostics)
 	}
 }
 

--- a/internal/mcpserver/social_refs.go
+++ b/internal/mcpserver/social_refs.go
@@ -26,9 +26,11 @@ type StatusRef struct {
 }
 
 type SocialExpansionRef struct {
-	Tool       string         `json:"tool"`
-	Arguments  map[string]any `json:"arguments"`
-	ResultPath string         `json:"resultPath,omitempty"`
+	Tool           string         `json:"tool"`
+	Arguments      map[string]any `json:"arguments"`
+	ResultPath     string         `json:"resultPath,omitempty"`
+	TextResultPath string         `json:"textResultPath,omitempty"`
+	ResultAccess   string         `json:"resultAccess,omitempty"`
 }
 
 type SocialOmittedRef struct {

--- a/internal/mcpserver/social_tools.go
+++ b/internal/mcpserver/social_tools.go
@@ -34,6 +34,7 @@ const (
 	notificationReadMaxTypes             = 8
 	notificationCompactMaxOutputBytes    = 8000
 	notificationCompactPreviewRunes      = 24
+	notificationCompactListPreviewRunes  = 8
 	notificationContentPreviewRunes      = 500
 	notificationCommPreviewRunes         = 240
 	conversationReadDefaultLimit         = 20
@@ -337,7 +338,7 @@ func socialCompactTimelineResult(timeline string, since string, limit int, raw a
 	}
 
 	previewRunes := socialCompactPreviewRunes(params)
-	statuses, statusIDs, err := compactSocialStatusRefsFromItems(items, previewRunes)
+	statuses, err := compactSocialStatusRefsFromItems(items, previewRunes)
 	if err != nil {
 		return nil, err
 	}
@@ -357,14 +358,7 @@ func socialCompactTimelineResult(timeline string, since string, limit int, raw a
 		payload["limit"] = limit
 	}
 
-	return socialCompactListToolResult("timeline_read", fmt.Sprintf("%d compact %s timeline statuses", len(statuses), timeline), payload, map[string]any{
-		"tool":      "timeline_read",
-		"view":      readViewCompact,
-		"timeline":  timeline,
-		"count":     len(statuses),
-		"statusIds": statusIDs,
-		"omitted":   socialCompactStatusListTextOmissions("statuses"),
-	}, budget)
+	return socialCompactListToolResult("timeline_read", fmt.Sprintf("%d compact %s timeline statuses", len(statuses), timeline), payload, budget)
 }
 
 func socialCompactPostSearchResult(query string, limit int, raw any, params sharedReadParams) (*mcpruntime.ToolResult, error) {
@@ -378,7 +372,7 @@ func socialCompactPostSearchResult(query string, limit int, raw any, params shar
 	}
 
 	previewRunes := socialCompactPreviewRunes(params)
-	statuses, statusIDs, err := compactSocialStatusRefsFromItems(statusesRaw, previewRunes)
+	statuses, err := compactSocialStatusRefsFromItems(statusesRaw, previewRunes)
 	if err != nil {
 		return nil, err
 	}
@@ -401,34 +395,23 @@ func socialCompactPostSearchResult(query string, limit int, raw any, params shar
 		payload["hashtags"] = hashtags
 	}
 
-	return socialCompactListToolResult("post_search", fmt.Sprintf("%d compact post search results", len(statuses)), payload, map[string]any{
-		"tool":      "post_search",
-		"view":      readViewCompact,
-		"query":     query,
-		"count":     len(statuses),
-		"statusIds": statusIDs,
-		"omitted":   socialCompactStatusListTextOmissions("statuses"),
-	}, budget)
+	return socialCompactListToolResult("post_search", fmt.Sprintf("%d compact post search results", len(statuses)), payload, budget)
 }
 
-func compactSocialStatusRefsFromItems(items []any, previewRunes int) ([]any, []string, error) {
+func compactSocialStatusRefsFromItems(items []any, previewRunes int) ([]any, error) {
 	statuses := make([]any, 0, len(items))
-	statusIDs := make([]string, 0, len(items))
 	for _, item := range items {
 		raw, ok := item.(map[string]any)
 		if !ok || raw == nil {
-			return nil, nil, fmt.Errorf("unexpected status item")
+			return nil, fmt.Errorf("unexpected status item")
 		}
 		ref := compactSocialStatusRefWithPreview(raw, previewRunes)
 		if ref == nil {
-			return nil, nil, fmt.Errorf("unexpected empty status item")
+			return nil, fmt.Errorf("unexpected empty status item")
 		}
 		statuses = append(statuses, ref)
-		if strings.TrimSpace(ref.ID) != "" {
-			statusIDs = append(statusIDs, strings.TrimSpace(ref.ID))
-		}
 	}
-	return statuses, statusIDs, nil
+	return statuses, nil
 }
 
 func compactSocialAccountRefsFromItems(raw any) []any {
@@ -511,50 +494,8 @@ func socialCompactStatusListOmissions(statusPath string) []any {
 	}
 }
 
-func socialCompactStatusListTextOmissions(statusPath string) []any {
-	return []any{
-		map[string]any{
-			"path":      statusPath + "[].content",
-			"reason":    "content_preview",
-			"expansion": "structuredContent.data." + statusPath + "[].omitted[].expand",
-		},
-		map[string]any{
-			"path":      statusPath + "[].account",
-			"reason":    "author_ref_only",
-			"expansion": "structuredContent.data." + statusPath + "[].expand with view=full",
-		},
-	}
-}
-
-func socialCompactListToolResult(toolName string, summary string, payload map[string]any, text map[string]any, maxOutputBytes int) (*mcpruntime.ToolResult, error) {
-	result, err := toolStructuredFirstResult(structuredFirstResultOptions{
-		Summary: summary,
-		Data:    payload,
-		Text:    text,
-	})
-	if err != nil {
-		return nil, err
-	}
-	if maxOutputBytes <= 0 {
-		return result, nil
-	}
-	measurement, err := measureToolResultPayload(result)
-	if err != nil {
-		return nil, err
-	}
-	if measurement.JSONRPCEnvelopeBytes <= maxOutputBytes {
-		return result, nil
-	}
-	return toolErrorResult("response_too_large", toolName+" compact response exceeds max_output_bytes", http.StatusRequestEntityTooLarge, map[string]any{
-		"tool":                 toolName,
-		"view":                 readViewCompact,
-		"measuredBytes":        measurement.JSONRPCEnvelopeBytes,
-		"maxOutputBytes":       maxOutputBytes,
-		"contentTextBytes":     measurement.ContentTextBytes,
-		"structuredBytes":      measurement.StructuredContentBytes,
-		"guidance":             "reduce limit or increase max_output_bytes",
-		"omittedFieldMetadata": "available under structuredContent.data.omitted for successful compact responses",
-	})
+func socialCompactListToolResult(toolName string, summary string, payload map[string]any, maxOutputBytes int) (*mcpruntime.ToolResult, error) {
+	return socialStructuredFirstResult(toolName, summary, payload, nil, false, maxOutputBytes)
 }
 
 func handlePostGet(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
@@ -798,12 +739,7 @@ func socialCompactConversationsResult(standardPayload map[string]any, conversati
 		"omitted":       compactConversationListOmissions(),
 		"budget":        socialCompactBudgetMetadata(budget, previewRunes),
 	}
-	text := map[string]any{
-		"tool":  "conversations_read",
-		"view":  readViewCompact,
-		"count": len(refs),
-	}
-	return toolStructuredFirstResultWithBudget("conversations_read", fmt.Sprintf("%d compact conversations", len(refs)), payload, text, nil, false, budget)
+	return toolStructuredFirstResultWithBudget("conversations_read", fmt.Sprintf("%d compact conversations", len(refs)), payload, nil, false, budget)
 }
 
 func handleConversationGet(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
@@ -983,17 +919,8 @@ func validateConversationGetView(view string) error {
 }
 
 func socialConversationGetStructuredResult(payload map[string]any, params sharedReadParams) (*mcpruntime.ToolResult, error) {
-	view := strings.ToLower(strings.TrimSpace(firstNonEmptyStringMap(payload, "view")))
-	if view == "" {
-		view = readViewStandard
-	}
 	budget := params.MaxOutputBytes
-	text := map[string]any{
-		"tool": "conversation_get",
-		"view": view,
-		"id":   firstNonEmptyStringMap(payload, "id"),
-	}
-	return toolStructuredFirstResultWithBudget("conversation_get", "conversation details", payload, text, nil, false, budget)
+	return toolStructuredFirstResultWithBudget("conversation_get", "conversation details", payload, nil, false, budget)
 }
 
 func socialCompactConversationGetResult(standardPayload map[string]any, conversation map[string]any, params sharedReadParams) (*mcpruntime.ToolResult, error) {
@@ -1026,32 +953,16 @@ func socialCompactConversationGetResult(standardPayload map[string]any, conversa
 	if nextCursor, _ := standardPayload["nextCursor"].(string); strings.TrimSpace(nextCursor) != "" {
 		payload["nextCursor"] = strings.TrimSpace(nextCursor)
 	}
-	text := map[string]any{
-		"tool": "conversation_get",
-		"view": readViewCompact,
-		"id":   id,
-	}
 	messageCount := 0
 	if refs, _ := ref["messageRefs"].([]any); len(refs) > 0 {
 		messageCount = len(refs)
 	}
-	return toolStructuredFirstResultWithBudget("conversation_get", fmt.Sprintf("conversation %s with %d compact message previews", id, messageCount), payload, text, nil, false, budget)
+	return toolStructuredFirstResultWithBudget("conversation_get", fmt.Sprintf("conversation %s with %d compact message previews", id, messageCount), payload, nil, false, budget)
 }
 
 func socialDirectMessagesReadStructuredResult(payload map[string]any, params sharedReadParams) (*mcpruntime.ToolResult, error) {
-	view := strings.ToLower(strings.TrimSpace(firstNonEmptyStringMap(payload, "view")))
-	if view == "" {
-		view = readViewStandard
-	}
 	budget := params.MaxOutputBytes
-	text := map[string]any{
-		"tool":        "direct_messages_read",
-		"view":        view,
-		"counterpart": firstNonEmptyStringMap(payload, "counterpart"),
-		"id":          firstNonEmptyStringMap(payload, "id"),
-		"count":       payload["count"],
-	}
-	return toolStructuredFirstResultWithBudget("direct_messages_read", "direct message conversation details", payload, text, nil, false, budget)
+	return toolStructuredFirstResultWithBudget("direct_messages_read", "direct message conversation details", payload, nil, false, budget)
 }
 
 func socialCompactDirectMessagesReadResult(standardPayload map[string]any, conversation map[string]any, params sharedReadParams) (*mcpruntime.ToolResult, error) {
@@ -1099,14 +1010,7 @@ func socialCompactDirectMessagesReadResult(standardPayload map[string]any, conve
 	if nextCursor, _ := standardPayload["nextCursor"].(string); strings.TrimSpace(nextCursor) != "" {
 		payload["nextCursor"] = strings.TrimSpace(nextCursor)
 	}
-	text := map[string]any{
-		"tool":        "direct_messages_read",
-		"view":        readViewCompact,
-		"counterpart": payload["counterpart"],
-		"id":          id,
-		"count":       len(messageRefs),
-	}
-	return toolStructuredFirstResultWithBudget("direct_messages_read", fmt.Sprintf("direct messages with %s: %d compact message previews", payload["counterpart"], len(messageRefs)), payload, text, nil, false, budget)
+	return toolStructuredFirstResultWithBudget("direct_messages_read", fmt.Sprintf("direct messages with %s: %d compact message previews", payload["counterpart"], len(messageRefs)), payload, nil, false, budget)
 }
 
 func conversationGetToolResultFromError(conversationID string, err error) (*mcpruntime.ToolResult, error) {
@@ -1648,7 +1552,7 @@ func validateNotificationReadView(view string) error {
 }
 
 func socialCompactNotificationsResult(standardPayload map[string]any, notifications []any, params sharedReadParams, includeDiagnostics bool) (*mcpruntime.ToolResult, error) {
-	previewRunes := notificationCompactPreviewRunes
+	previewRunes := notificationCompactListPreviewRunes
 	if params.PreviewChars > 0 {
 		previewRunes = params.PreviewChars
 	}
@@ -1694,12 +1598,7 @@ func socialCompactNotificationsResult(standardPayload map[string]any, notificati
 			diagnostics = d
 		}
 	}
-	text := map[string]any{
-		"tool":  "notifications_read",
-		"view":  readViewCompact,
-		"count": len(refs),
-	}
-	return toolStructuredFirstResultWithBudget("notifications_read", fmt.Sprintf("%d compact notifications", len(refs)), payload, text, diagnostics, includeDiagnostics, budget)
+	return toolStructuredFirstResultWithBudget("notifications_read", fmt.Sprintf("%d compact notifications", len(refs)), payload, diagnostics, includeDiagnostics, budget)
 }
 
 func compactSocialNotificationRef(raw map[string]any, previewRunes int) map[string]any {
@@ -1874,11 +1773,15 @@ func compactNotificationListOmissions() []any {
 	}
 }
 
-func toolStructuredFirstResultWithBudget(toolName string, summary string, payload map[string]any, text map[string]any, diagnostics map[string]any, includeDiagnostics bool, maxOutputBytes int) (*mcpruntime.ToolResult, error) {
+func toolStructuredFirstResultWithBudget(toolName string, summary string, payload map[string]any, diagnostics map[string]any, includeDiagnostics bool, maxOutputBytes int) (*mcpruntime.ToolResult, error) {
+	return socialStructuredFirstResult(toolName, summary, payload, diagnostics, includeDiagnostics, maxOutputBytes)
+}
+
+func socialStructuredFirstResult(toolName string, summary string, payload map[string]any, diagnostics map[string]any, includeDiagnostics bool, maxOutputBytes int) (*mcpruntime.ToolResult, error) {
 	result, err := toolStructuredFirstResult(structuredFirstResultOptions{
 		Summary:            summary,
 		Data:               payload,
-		Text:               text,
+		TextPayload:        socialTextAccessibleProjection(toolName, payload),
 		Diagnostics:        diagnostics,
 		IncludeDiagnostics: includeDiagnostics,
 	})
@@ -1905,6 +1808,145 @@ func toolStructuredFirstResultWithBudget(toolName string, summary string, payloa
 		"guidance":             "reduce limit or increase max_output_bytes",
 		"omittedFieldMetadata": "available under structuredContent.data.omitted for successful compact responses",
 	})
+}
+
+func socialTextAccessibleProjection(toolName string, payload map[string]any) string {
+	switch toolName {
+	case "timeline_read", "post_search":
+		if projection := socialTextProjectionFromItems(firstArrayFromAny(payload, "statuses"), "contentPreview", 32, true); projection != "" {
+			return projection
+		}
+	case "conversations_read":
+		if projection := socialTextProjectionFromItems(firstArrayFromAny(payload, "conversations"), "lastPostRef.contentPreview", 20, true); projection != "" {
+			return projection
+		}
+	case "notifications_read":
+		if projection := socialTextProjectionFromItems(firstArrayFromAny(payload, "notifications"), "targetPostRef.contentPreview", notificationCompactListPreviewRunes, true); projection != "" {
+			if filter, _ := payload["filter"].(map[string]any); filter != nil {
+				if strategy := firstNonEmptyStringMap(filter, "strategy"); strategy != "" {
+					return "filter=" + strategy + "\n" + projection
+				}
+			}
+			return projection
+		}
+	case "conversation_get":
+		if conversation, _ := payload["conversation"].(map[string]any); conversation != nil {
+			if projection := socialTextProjectionFromItems(firstArrayFromAny(conversation, "messageRefs"), "contentPreview", 48, true); projection != "" {
+				return projection
+			}
+			messages := firstArrayFromAny(conversation, "messages")
+			if projection := socialTextProjectionFromItems(messages, "contentPreview", 48, true); projection != "" {
+				return projection
+			}
+			if projection := socialTextProjectionFromItems(messages, "content", 96, true); projection != "" {
+				return projection
+			}
+		}
+	case "direct_messages_read":
+		messages := firstArrayFromAny(payload, "messages")
+		if projection := socialTextProjectionFromItems(messages, "contentPreview", 48, true); projection != "" {
+			return projection
+		}
+		if projection := socialTextProjectionFromItems(messages, "content", 96, true); projection != "" {
+			return projection
+		}
+	}
+	return socialTextProjectionFallback(payload, 1024)
+}
+
+func socialTextProjectionFromItems(items []any, previewPath string, previewRunes int, includeID bool) string {
+	lines := make([]string, 0, len(items))
+	for _, item := range items {
+		record, _ := item.(map[string]any)
+		if record == nil {
+			continue
+		}
+		preview := nestedStringMap(record, previewPath)
+		preview, _ = compactStringWithTruncation(preview, previewRunes)
+		if preview == "" {
+			continue
+		}
+		id := firstNonEmptyStringMap(record, "id", "conversationId", "messageId")
+		line := preview
+		if includeID && id != "" {
+			line = id + ": " + preview
+		}
+		if strings.TrimSpace(line) != "" {
+			lines = append(lines, line)
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+func nestedStringMap(record map[string]any, path string) string {
+	parts := strings.Split(strings.TrimSpace(path), ".")
+	var current any = record
+	for _, part := range parts {
+		next, _ := current.(map[string]any)
+		if next == nil {
+			return ""
+		}
+		current = next[part]
+	}
+	value, _ := current.(string)
+	return strings.TrimSpace(value)
+}
+
+func socialTextProjectionFallback(payload map[string]any, maxRunes int) string {
+	values := make([]string, 0)
+	collectSocialTextProjectionValues(payload, "", &values)
+	if len(values) == 0 {
+		b, err := json.Marshal(payload)
+		if err != nil {
+			return ""
+		}
+		return compactString(string(b), maxRunes)
+	}
+	return compactString(strings.Join(values, "\n"), maxRunes)
+}
+
+func collectSocialTextProjectionValues(value any, path string, values *[]string) {
+	switch typed := value.(type) {
+	case map[string]any:
+		keys := make([]string, 0, len(typed))
+		for key := range typed {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			switch strings.ToLower(strings.TrimSpace(key)) {
+			case "budget", "diagnostics", "expand", "omitted", "policy", "_raw":
+				continue
+			}
+			nextPath := key
+			if path != "" {
+				nextPath = path + "." + key
+			}
+			collectSocialTextProjectionValues(typed[key], nextPath, values)
+		}
+	case []any:
+		for index, item := range typed {
+			collectSocialTextProjectionValues(item, fmt.Sprintf("%s[%d]", path, index), values)
+		}
+	case string:
+		if !socialTextProjectionSubstantivePath(path) {
+			return
+		}
+		preview, _ := compactStringWithTruncation(typed, 96)
+		if preview != "" {
+			*values = append(*values, path+"="+preview)
+		}
+	}
+}
+
+func socialTextProjectionSubstantivePath(path string) bool {
+	path = strings.ToLower(path)
+	for _, marker := range []string{"body", "content", "description", "displayname", "marker", "message", "name", "preview", "subject", "summary", "text", "title"} {
+		if strings.Contains(path, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 func handleNotificationDismiss(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {

--- a/internal/mcpserver/soul_read_tools.go
+++ b/internal/mcpserver/soul_read_tools.go
@@ -331,9 +331,11 @@ func soulReadExpansionRef(agentID string, view string, in soulReadInput, accessM
 		args["include_raw"] = true
 	}
 	return &SocialExpansionRef{
-		Tool:       "soul_read",
-		Arguments:  args,
-		ResultPath: "structuredContent.data",
+		Tool:           "soul_read",
+		Arguments:      args,
+		ResultPath:     "structuredContent.data",
+		TextResultPath: "document",
+		ResultAccess:   toolResultAccessPath("document", "data"),
 	}
 }
 

--- a/internal/mcpserver/tool_results.go
+++ b/internal/mcpserver/tool_results.go
@@ -12,6 +12,7 @@ type structuredFirstResultOptions struct {
 	Summary            string
 	Data               any
 	Text               map[string]any
+	TextPayload        any
 	Structured         map[string]any
 	Diagnostics        map[string]any
 	IncludeDiagnostics bool
@@ -49,18 +50,29 @@ func toolStructuredFirstResult(opts structuredFirstResultOptions) (*mcpruntime.T
 	if summary := strings.TrimSpace(opts.Summary); summary != "" {
 		textPayload["summary"] = summary
 	} else {
-		textPayload["summary"] = "Result available in structuredContent.data"
+		textPayload["summary"] = "Result data follows"
 	}
 	for key, value := range opts.Text {
 		key = strings.TrimSpace(key)
-		if key == "" || key == "data" || key == "diagnostics" {
+		if key == "" || key == "access" || key == "data" || key == "payload" ||
+			key == "diagnostics" || key == "diagnosticPayload" || key == "diagnosticsAccess" {
 			continue
 		}
 		textPayload[key] = value
 	}
 	textPayload["data"] = map[string]any{"location": "structuredContent.data"}
+	textData := opts.TextPayload
+	if textData == nil {
+		textData = data
+	}
+	textPayload["payload"] = textData
+	textPayload["access"] = "payload or structuredContent.data"
 	if opts.IncludeDiagnostics && opts.Diagnostics != nil {
-		textPayload["diagnostics"] = map[string]any{"location": "structuredContent.diagnostics"}
+		textPayload["diagnostics"] = map[string]any{
+			"location": "structuredContent.diagnostics",
+		}
+		textPayload["diagnosticPayload"] = opts.Diagnostics
+		textPayload["diagnosticsAccess"] = "diagnosticPayload or structuredContent.diagnostics"
 	}
 
 	b, err := json.Marshal(textPayload)
@@ -74,6 +86,18 @@ func toolStructuredFirstResult(opts structuredFirstResultOptions) (*mcpruntime.T
 		}},
 		StructuredContent: structured,
 	}, nil
+}
+
+func toolResultAccessPath(textPath string, structuredPath string) string {
+	textPath = strings.TrimSpace(textPath)
+	if textPath == "" {
+		textPath = "document"
+	}
+	structuredPath = strings.Trim(strings.TrimSpace(structuredPath), ".")
+	if structuredPath == "" {
+		return fmt.Sprintf("content[0].text JSON %s or structuredContent", textPath)
+	}
+	return fmt.Sprintf("content[0].text JSON %s or structuredContent.%s", textPath, structuredPath)
 }
 
 func measureToolResultPayload(result *mcpruntime.ToolResult) (toolPayloadMeasurement, error) {

--- a/internal/mcpserver/tool_results_accessibility_test.go
+++ b/internal/mcpserver/tool_results_accessibility_test.go
@@ -1,0 +1,235 @@
+package mcpserver
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	mcpruntime "github.com/theory-cloud/apptheory/v2/runtime/mcp"
+)
+
+func TestStructuredFirstReadToolsExposeSubstantiveTextData(t *testing.T) {
+	const sentinel = "ka-data"
+
+	payload := func() map[string]any {
+		return map[string]any{
+			"marker": sentinel,
+			"items":  []any{map[string]any{"id": "item-1", "preview": sentinel}},
+		}
+	}
+	socialPayload := func(name string) map[string]any {
+		data := payload()
+		switch name {
+		case "timeline_read", "post_search":
+			data["statuses"] = []any{map[string]any{"id": "status-1", "contentPreview": sentinel}}
+		case "conversations_read":
+			data["conversations"] = []any{map[string]any{
+				"id":          "conversation-1",
+				"lastPostRef": map[string]any{"contentPreview": sentinel},
+			}}
+		case "conversation_get":
+			data["conversation"] = map[string]any{
+				"messageRefs": []any{map[string]any{"id": "message-1", "contentPreview": sentinel}},
+			}
+		case "direct_messages_read":
+			data["messages"] = []any{map[string]any{"id": "message-1", "contentPreview": sentinel}}
+		case "notifications_read":
+			data["notifications"] = []any{map[string]any{
+				"id":            "notification-1",
+				"targetPostRef": map[string]any{"contentPreview": sentinel},
+			}}
+		}
+		return data
+	}
+	structuredFirst := func(name string) func() (*mcpruntime.ToolResult, error) {
+		return func() (*mcpruntime.ToolResult, error) {
+			return toolStructuredFirstResult(structuredFirstResultOptions{
+				Summary: name + " result",
+				Data:    payload(),
+				Text:    map[string]any{"tool": name},
+			})
+		}
+	}
+	socialBudgeted := func(name string) func() (*mcpruntime.ToolResult, error) {
+		return func() (*mcpruntime.ToolResult, error) {
+			return toolStructuredFirstResultWithBudget(name, name+" result", socialPayload(name), nil, false, 64*1024)
+		}
+	}
+	articleBudgeted := func(name string) func() (*mcpruntime.ToolResult, error) {
+		return func() (*mcpruntime.ToolResult, error) {
+			return articleDraftStructuredResult(name, readViewCompact, name+" result", payload(), map[string]any{"tool": name}, 64*1024)
+		}
+	}
+
+	tests := []struct {
+		name  string
+		build func() (*mcpruntime.ToolResult, error)
+	}{
+		{name: "timeline_read", build: func() (*mcpruntime.ToolResult, error) {
+			return socialCompactListToolResult("timeline_read", "timeline result", socialPayload("timeline_read"), 64*1024)
+		}},
+		{name: "post_search", build: func() (*mcpruntime.ToolResult, error) {
+			return socialCompactListToolResult("post_search", "search result", socialPayload("post_search"), 64*1024)
+		}},
+		{name: "conversations_read", build: socialBudgeted("conversations_read")},
+		{name: "conversation_get", build: socialBudgeted("conversation_get")},
+		{name: "direct_messages_read", build: socialBudgeted("direct_messages_read")},
+		{name: "notifications_read", build: socialBudgeted("notifications_read")},
+		{name: "article_draft_get", build: articleBudgeted("article_draft_get")},
+		{name: "article_draft_list", build: articleBudgeted("article_draft_list")},
+		{name: "article_draft_preview", build: articleBudgeted("article_draft_preview")},
+		{name: "article_get", build: articleBudgeted("article_get")},
+		{name: "article_list", build: articleBudgeted("article_list")},
+		{name: "message_requests_list", build: structuredFirst("message_requests_list")},
+		{name: "soul_read", build: func() (*mcpruntime.ToolResult, error) {
+			data := payload()
+			data["souls"] = []any{map[string]any{"agentId": "agent-1"}}
+			data["count"] = 1
+			return soulReadSummaryToolResult(data)
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scopes := RequiredScopesForTool(tt.name)
+			if len(scopes) != 1 || scopes[0] != ScopeRead {
+				t.Fatalf("%s is not a registered read tool: scopes=%v", tt.name, scopes)
+			}
+			result, err := tt.build()
+			if err != nil {
+				t.Fatalf("build result: %v", err)
+			}
+			if result.IsError {
+				t.Fatalf("unexpected tool error: %+v", result)
+			}
+			text := toolResultTextJSON(t, result)
+			if !strings.Contains(result.Content[0].Text, sentinel) {
+				t.Fatalf("text block omitted substantive sentinel: %s", result.Content[0].Text)
+			}
+			locator, ok := text["data"].(map[string]any)
+			if !ok ||
+				locator["location"] != "structuredContent.data" {
+				t.Fatalf("text data locator must preserve the legacy location: %#v", locator)
+			}
+			if text["access"] != "payload or structuredContent.data" {
+				t.Fatalf("text guidance must name both result surfaces: %#v", text["access"])
+			}
+			structuredData, _ := result.StructuredContent["data"].(map[string]any)
+			if structuredData["marker"] != sentinel {
+				t.Fatalf("structuredContent.data changed: %#v", result.StructuredContent)
+			}
+		})
+	}
+}
+
+func TestStructuredFirstBudgetMeasuresSubstantiveTextPayload(t *testing.T) {
+	payload := map[string]any{
+		"items": []any{map[string]any{
+			"id":      "item-1",
+			"preview": strings.Repeat("bounded payload ", 64),
+		}},
+	}
+	result, err := socialCompactListToolResult("timeline_read", "bounded timeline", payload, 0)
+	if err != nil {
+		t.Fatalf("build unbounded result: %v", err)
+	}
+	if !strings.Contains(result.Content[0].Text, "bounded payload") {
+		t.Fatalf("text payload is not substantive: %s", result.Content[0].Text)
+	}
+	measurement, err := measureToolResultPayload(result)
+	if err != nil {
+		t.Fatalf("measure result: %v", err)
+	}
+
+	atBudget, err := socialCompactListToolResult("timeline_read", "bounded timeline", payload, measurement.JSONRPCEnvelopeBytes)
+	if err != nil {
+		t.Fatalf("build result at budget: %v", err)
+	}
+	if atBudget.IsError {
+		t.Fatalf("result at exact budget rejected: %+v", atBudget)
+	}
+
+	overBudget, err := socialCompactListToolResult("timeline_read", "bounded timeline", payload, measurement.JSONRPCEnvelopeBytes-1)
+	if err != nil {
+		t.Fatalf("build result over budget: %v", err)
+	}
+	if !overBudget.IsError {
+		t.Fatalf("expected response_too_large when substantive dual-surface result exceeds max_output_bytes")
+	}
+}
+
+func TestCompactTimelineTextHonorsPreviewChars(t *testing.T) {
+	const fullContent = "abcdefghijklmno"
+	result, err := socialCompactTimelineResult("home", "", 1, []any{
+		map[string]any{
+			"id":      "post-1",
+			"content": fullContent,
+			"account": map[string]any{"id": "account-1"},
+		},
+	}, sharedReadParams{
+		View:           readViewCompact,
+		PreviewChars:   8,
+		MaxOutputBytes: 64 * 1024,
+	})
+	if err != nil {
+		t.Fatalf("compact timeline result: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected tool error: %+v", result)
+	}
+	text := toolResultTextJSON(t, result)
+	textPayload, _ := text["payload"].(string)
+	if !strings.Contains(textPayload, "abcdefg…") {
+		t.Fatalf("preview_chars was not preserved in text payload: %q", textPayload)
+	}
+	if strings.Contains(result.Content[0].Text, fullContent) {
+		t.Fatalf("text data leaked content beyond preview_chars: %s", result.Content[0].Text)
+	}
+}
+
+func TestStructuredFirstGuidanceNeverNamesStructuredContentAsSoleAccessPath(t *testing.T) {
+	result, err := toolStructuredFirstResult(structuredFirstResultOptions{
+		Data: map[string]any{"content": "readable"},
+	})
+	if err != nil {
+		t.Fatalf("structured-first result: %v", err)
+	}
+	text := toolResultTextJSON(t, result)
+	if text["access"] != "payload or structuredContent.data" {
+		t.Fatalf("result guidance names only one surface: %#v", text)
+	}
+
+	diagnosticResult, err := toolStructuredFirstResult(structuredFirstResultOptions{
+		Data:               map[string]any{"content": "readable"},
+		Diagnostics:        map[string]any{"responseBytes": 42},
+		IncludeDiagnostics: true,
+	})
+	if err != nil {
+		t.Fatalf("structured-first diagnostic result: %v", err)
+	}
+	diagnosticText := toolResultTextJSON(t, diagnosticResult)
+	if diagnosticText["diagnosticsAccess"] != "diagnosticPayload or structuredContent.diagnostics" {
+		t.Fatalf("diagnostic guidance names only one surface: %#v", diagnosticText)
+	}
+
+	soulExpansion := soulReadExpansionRef("agent-1", readViewStandard, soulReadInput{}, "public")
+	if soulExpansion == nil ||
+		soulExpansion.ResultPath != "structuredContent.data" ||
+		soulExpansion.TextResultPath != "document" ||
+		!strings.Contains(soulExpansion.ResultAccess, "content[0].text") ||
+		!strings.Contains(soulExpansion.ResultAccess, " or structuredContent.data") {
+		t.Fatalf("soul summary expansion must name text and structured access paths: %+v", soulExpansion)
+	}
+}
+
+func toolResultTextJSON(t *testing.T, result *mcpruntime.ToolResult) map[string]any {
+	t.Helper()
+	if result == nil || len(result.Content) != 1 || result.Content[0].Type != "text" {
+		t.Fatalf("unexpected tool result content: %+v", result)
+	}
+	var text map[string]any
+	if err := json.Unmarshal([]byte(result.Content[0].Text), &text); err != nil {
+		t.Fatalf("text content is not JSON: %v", err)
+	}
+	return text
+}


### PR DESCRIPTION
## Promotion: staging → main

Contents beyond current main:
- PR #489 `fix(mcp): expose read payloads to text-only clients` (`Closes #488`) — ka read tools now carry bounded substantive content in the text block (payload + dual-surface access guidance); structuredContent preserved for schema clients. Fixes research-team confusion and kimi-harness inaccessibility.

Opened by factory via gh (operator-authorized path for promotion PRs; agent routes refuse a staging head).