### PR TITLE
promote: staging → main (ka usability batch: read polish, describe_interface, schema conformance)

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1529,7 +1529,9 @@ fields (`id`, `acct`, `displayName`, and `url`) and report `missingFields` rathe
 values include `id`, `url`, `authorRef`, `createdAt`, `visibility`, `contentPreview`, and a `contentTruncated` marker.
 When a compact status omits full content, its `omitted[]` record points at `post_get` with the status id and the desired
 `view`. `post_get(id, view=standard)` returns normalized status fields from Lesser's `GET /api/v1/statuses/{id}` route;
-`post_get(id, view=full)` returns the upstream Lesser status payload for audit/debug expansion.
+`post_get(id, view=full)` returns the upstream Lesser status payload for audit/debug expansion. Both views return the
+status exactly once under `status`; `post_get` does not add a duplicate `statusRef` or an expansion that points back at
+`post_get`.
 
 `timeline_read` and `post_search` now advertise opt-in `view=compact` plus `preview_chars` and `max_output_bytes`.
 Their omitted-`view` default and `view=standard` / `view=full` behavior preserves the current upstream-shaped response.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1358,7 +1358,10 @@ under text JSON `diagnosticPayload` and `structuredContent.diagnostics`, with du
 
 Expansion metadata preserves the legacy machine-readable `resultPath` for structured clients. Where a text alternative
 is available, additive `textResultPath` and `resultAccess` fields identify the text location and phrase the choice as
-text content or `structuredContent`; clients should prefer `resultAccess` for human/agent guidance.
+text content or `structuredContent`; clients should prefer `resultAccess` for human/agent guidance. Compact social
+per-item refs use the budget-safe text-path form directly: `expand.resultPath="content[0].text"`. Their expanded tool
+result still retains its unchanged `structuredContent` projection, while the per-item pointer never requires a client
+to expose that surface.
 
 Project 33 P4.1 compatibility decision: compact defaults remain opt-in for now. `timeline_read`, `post_search`,
 `soul_read`, and `email_read` keep their omitted/default behavior equivalent to `view=standard`; callers must request

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1346,8 +1346,9 @@ parameter during the migration. The shared names are:
 Structured-first result shaping is dual-surface and text-accessible. Existing tools that use `content[0].text` as JSON
 keep their current `standard` behavior until explicitly migrated. Compact/summary tools first build their bounded
 projection, then expose substantive content under `content[0].text` JSON `payload` and the unchanged typed projection
-under `structuredContent.data`. For structured-first social reads, `payload` is a concise newline-delimited rendering
-of stable ids and already-bounded previews; other structured-first tools return the bounded JSON projection there. The
+under `structuredContent.data`. `payload` is always a nested JSON value, never a JSON-encoded string. For
+structured-first social reads it is a compact object whose `items[]` strings carry stable ids and already-bounded
+previews; other structured-first tools return the bounded JSON projection there. The
 legacy text `data.location` locator remains, while the sibling `access` field says
 `payload or structuredContent.data`. Schema-capable clients retain the structured shape, and text-only clients no
 longer need to follow the locator. A tool's existing `preview_chars` projection is applied before the result surfaces
@@ -1572,7 +1573,7 @@ Notes:
   host-backed communication sender metadata (`communication.from.soulAgentId`, `agentId`, `email`/`address`, and
   `identifier` where Lesser/host include it). Because Lesser does not yet expose an upstream actor filter, body
   over-fetches a bounded notification page (`min(limit*4, 80)`) and returns
-  `filter=mcp_side_overfetch` at the start of `content[0].text` JSON `payload`; schema-capable clients also receive
+  `content[0].text` JSON `payload.filter="mcp_side_overfetch"`; schema-capable clients also receive
   `structuredContent.data.filter.strategy="mcp_side_overfetch"` with `requestedLimit`, `overFetchLimit`,
   `upstreamCount`, `matchedCount`, `returnedCount`, and `windowOffset`. If an over-fetched page contains more actor
   matches than the requested return `limit`, `nextCursor` is an opaque body actor-filter cursor that re-reads the same

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -634,6 +634,7 @@ Scope key:
 
 | Tool | Scope | Description |
 |------|-------|-------------|
+| `describe_interface` | Read | Bootstrap the authenticated Ka actor in one text result: identity/instance/soul-binding context, the complete tool inventory by domain, recommended workflows, and current bounded read-result conventions. Available in both drone and souled profiles. |
 | `echo` | Read | Echo back the provided message. |
 | `profile_read` | Read | Read the authenticated agent's profile. |
 | `timeline_read` | Read | Read from home, local, or federated timeline; supports opt-in compact `StatusRef` view. |
@@ -685,6 +686,24 @@ Scope key:
 | `soul_read` | Read | Read a public soul identity bundle with opt-in summary/standard/full views and, with explicit self-scope opt-in, bounded private mint-conversation data through Lesser. |
 | `identity_lookup` | Read | Resolve a public soul identity by full agent ID, ENS name, a current-instance local ID such as `medic`, an explicit remote ActivityPub handle such as `@steward@remote.example`, or a canonical actor URL such as `https://remote.example/users/steward`; returns public identity summary plus the current managed `lessersoul.ai` email address when Host publishes one. |
 | `identity_verify` | Read | Verify that a recent communication matches a resolved soul identity using public ENS resolution plus authoritative message provenance. Private email/phone verification fails closed unless Host supplies authoritative sender-identifier provenance. |
+
+### Ka interface bootstrap
+
+Call `describe_interface({})` at the start of a fresh Ka MCP session when the client does not surface MCP resources,
+prompts, server instructions, or a usable `tools/list` presentation. The tool is read-scoped, side-effect free, and
+available in both drone and souled runtime profiles. Its single text block provides:
+
+- the authenticated actor, configured instance domain, resolved runtime profile, and soul-binding state;
+- every statically registered Ka tool grouped into bootstrap, social, Articles, DMs/notifications, memory, skills,
+  soul, and souled-only communication domains, with one line describing when to use each tool;
+- the compact-list-to-detail workflows for timelines, conversations, and notifications, plus the explicit
+  Article draft → preview → publish workflow; and
+- the current dual-surface `view` / `preview_chars` / `max_output_bytes` and expansion-metadata contract described in
+  [Shared read-tool shaping parameters](#shared-read-tool-shaping-parameters).
+
+The inventory is intentionally guarded against registration drift: tests fail when a tool registered by
+`registerTools()` is absent from the bootstrap text or when the bootstrap catalog retains a tool that is no longer
+registered.
 
 ### Instance-plane Ptah tools
 

--- a/internal/mcpapp/social_tools_test.go
+++ b/internal/mcpapp/social_tools_test.go
@@ -838,7 +838,7 @@ func TestM5_PostGetExpandsStatusRefViaLesserRoute(t *testing.T) {
 	}
 	expand, _ := statusRef["expand"].(map[string]any)
 	expandArgs, _ := expand["arguments"].(map[string]any)
-	if expand["tool"] != "post_get" || expandArgs["id"] != "post-1" || expandArgs["view"] != "standard" || expand["resultPath"] != "structuredContent.data.status" {
+	if expand["tool"] != "post_get" || expandArgs["id"] != "post-1" || expandArgs["view"] != "standard" || expand["resultPath"] != "content[0].text" {
 		t.Fatalf("unexpected statusRef expansion metadata: %+v", expand)
 	}
 	omitted, _ := statusRef["omitted"].([]any)
@@ -847,7 +847,7 @@ func TestM5_PostGetExpandsStatusRefViaLesserRoute(t *testing.T) {
 	}
 	omittedRecord, _ := omitted[0].(map[string]any)
 	omittedExpand, _ := omittedRecord["expand"].(map[string]any)
-	if omittedRecord["path"] != "content" || omittedExpand["tool"] != "post_get" || omittedExpand["resultPath"] != "structuredContent.data.status.content" {
+	if omittedRecord["path"] != "content" || omittedExpand["tool"] != "post_get" || omittedExpand["resultPath"] != "content[0].text" {
 		t.Fatalf("unexpected omitted expansion metadata: %+v", omittedRecord)
 	}
 
@@ -947,7 +947,7 @@ func TestM5_TimelineReadCompactUsesStatusRefsAndPayloadBudget(t *testing.T) {
 	}
 	omittedRecord, _ := omitted[0].(map[string]any)
 	omittedExpand, _ := omittedRecord["expand"].(map[string]any)
-	if omittedRecord["path"] != "content" || omittedExpand["tool"] != "post_get" || omittedExpand["resultPath"] != "structuredContent.data.status.content" {
+	if omittedRecord["path"] != "content" || omittedExpand["tool"] != "post_get" || omittedExpand["resultPath"] != "content[0].text" {
 		t.Fatalf("unexpected omitted metadata: %+v", omittedRecord)
 	}
 	topOmitted, _ := data["omitted"].([]any)
@@ -1322,7 +1322,7 @@ func TestM5_ConversationsReadCompactRefsAdvertiseConversationGet(t *testing.T) {
 	}
 	convExpand, _ := first["expand"].(map[string]any)
 	convArgs, _ := convExpand["arguments"].(map[string]any)
-	if convExpand["tool"] != "conversation_get" || convArgs["conversationId"] != "conv-1" || convArgs["view"] != "compact" || convExpand["resultPath"] != "structuredContent.data.conversation" {
+	if convExpand["tool"] != "conversation_get" || convArgs["conversationId"] != "conv-1" || convArgs["view"] != "compact" || convExpand["resultPath"] != "content[0].text" {
 		t.Fatalf("expected conversation_get expansion metadata, got %+v", convExpand)
 	}
 	participantRefs, _ := first["participantRefs"].([]any)

--- a/internal/mcpapp/social_tools_test.go
+++ b/internal/mcpapp/social_tools_test.go
@@ -734,7 +734,7 @@ func TestM5_ToolsProxyToLesserAPI(t *testing.T) {
 	}
 }
 
-func TestM5_PostGetExpandsStatusRefViaLesserRoute(t *testing.T) {
+func TestM5_PostGetReturnsStatusOnceViaLesserRoute(t *testing.T) {
 	t.Setenv("MCP_SESSION_TABLE", "")
 	t.Setenv("JWT_SECRET", "test")
 	auth.ResetForTests()
@@ -829,26 +829,8 @@ func TestM5_PostGetExpandsStatusRefViaLesserRoute(t *testing.T) {
 	if authorRef["id"] != "acct-1" || authorRef["acct"] != "alice@example.com" || authorRef["displayName"] != "Alice" || authorRef["url"] != "https://example.com/@alice" {
 		t.Fatalf("standard post_get author ref = %+v", authorRef)
 	}
-	statusRef, _ := standard["statusRef"].(map[string]any)
-	if statusRef["id"] != "post-1" || statusRef["contentTruncated"] != true {
-		t.Fatalf("expected compact statusRef with truncation marker, got %+v", statusRef)
-	}
-	if preview, _ := statusRef["contentPreview"].(string); preview == "" || len([]rune(preview)) > 500 {
-		t.Fatalf("expected bounded contentPreview, got %d runes", len([]rune(preview)))
-	}
-	expand, _ := statusRef["expand"].(map[string]any)
-	expandArgs, _ := expand["arguments"].(map[string]any)
-	if expand["tool"] != "post_get" || expandArgs["id"] != "post-1" || expandArgs["view"] != "standard" || expand["resultPath"] != "content[0].text" {
-		t.Fatalf("unexpected statusRef expansion metadata: %+v", expand)
-	}
-	omitted, _ := statusRef["omitted"].([]any)
-	if len(omitted) != 1 {
-		t.Fatalf("expected compact statusRef omitted metadata, got %+v", statusRef["omitted"])
-	}
-	omittedRecord, _ := omitted[0].(map[string]any)
-	omittedExpand, _ := omittedRecord["expand"].(map[string]any)
-	if omittedRecord["path"] != "content" || omittedExpand["tool"] != "post_get" || omittedExpand["resultPath"] != "content[0].text" {
-		t.Fatalf("unexpected omitted expansion metadata: %+v", omittedRecord)
+	if _, ok := standard["statusRef"]; ok {
+		t.Fatalf("post_get must return the status once without a circular statusRef: %+v", standard)
 	}
 
 	full := call(3, map[string]any{"id": "post-1", "view": "full"})

--- a/internal/mcpapp/tool_output_schema_test.go
+++ b/internal/mcpapp/tool_output_schema_test.go
@@ -41,7 +41,12 @@ func TestReadToolOutputSchemasAdvertisedInToolsListAndDiscovery(t *testing.T) {
 	}
 	assertSchemaPropertyType(t, matchItemSchema, "email", "object")
 	assertSchemaPropertyType(t, nestedOutputSchemaObject(t, toolsByName["identity_verify"], "data"), "verified", "boolean")
-	assertSchemaPropertyType(t, nestedOutputSchemaObject(t, toolsByName["post_get"], "data"), "statusRef", "object")
+	postGetDataSchema := nestedOutputSchemaObject(t, toolsByName["post_get"], "data")
+	assertSchemaPropertyType(t, postGetDataSchema, "status", "object")
+	postGetProperties, _ := postGetDataSchema["properties"].(map[string]any)
+	if _, ok := postGetProperties["statusRef"]; ok {
+		t.Fatalf("post_get output schema must not advertise duplicate statusRef: %+v", postGetProperties)
+	}
 	assertSchemaPropertyType(t, nestedOutputSchemaObject(t, toolsByName["notification_get"], "data"), "notificationRef", "object")
 	assertSchemaPropertyType(t, nestedOutputSchemaObject(t, toolsByName["conversation_get"], "data"), "conversation", "object")
 	assertSchemaPropertyType(t, nestedOutputSchemaObject(t, toolsByName["direct_messages_read"], "data"), "messages", "array")

--- a/internal/mcpserver/article_published_tools.go
+++ b/internal/mcpserver/article_published_tools.go
@@ -441,7 +441,7 @@ func standardArticle(article *cmsapi.Article) map[string]any {
 
 func articleOmissions(view string, list bool) []any {
 	if view == readViewStandard {
-		return nil
+		return []any{}
 	}
 	path := "article.content"
 	if list {

--- a/internal/mcpserver/article_tools.go
+++ b/internal/mcpserver/article_tools.go
@@ -661,7 +661,7 @@ func stringPtrValue(value *string) string {
 
 func articleDraftOmissions(view string, list bool) []any {
 	if view == readViewStandard {
-		return nil
+		return []any{}
 	}
 	path := "draft.content"
 	if list {
@@ -693,7 +693,7 @@ func articleDraftListOmissions() []any {
 
 func articleDraftPreviewOmissions(preview *cmsapi.DraftPreview, view string) []any {
 	if view == readViewStandard || preview == nil || !preview.Success || preview.RenderedHTML == nil {
-		return nil
+		return []any{}
 	}
 	return []any{
 		map[string]any{

--- a/internal/mcpserver/describe_interface.go
+++ b/internal/mcpserver/describe_interface.go
@@ -1,0 +1,273 @@
+package mcpserver
+
+import (
+	"context"
+	"encoding/json"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/equaltoai/lesser-body/internal/auth"
+	"github.com/equaltoai/lesser-body/internal/runtimepolicy"
+	mcpruntime "github.com/theory-cloud/apptheory/v2/runtime/mcp"
+)
+
+type describeInterfaceTool struct {
+	Name string
+	Use  string
+}
+
+type describeInterfaceDomain struct {
+	Name  string
+	Tools []describeInterfaceTool
+}
+
+var describeInterfaceDomains = []describeInterfaceDomain{
+	{
+		Name: "bootstrap",
+		Tools: []describeInterfaceTool{
+			{Name: "describe_interface", Use: "Start here to orient to this actor, the Ka tool surface, response budgets, and common workflows."},
+			{Name: "echo", Use: "Check that the MCP connection can invoke a simple read-only tool and return text."},
+		},
+	},
+	{
+		Name: "social",
+		Tools: []describeInterfaceTool{
+			{Name: "profile_read", Use: "Read the authenticated actor's Lesser profile."},
+			{Name: "profile_update", Use: "Change the authenticated actor's display name, bio, or avatar."},
+			{Name: "timeline_read", Use: "Browse home, local, or federated timelines; prefer compact view for discovery."},
+			{Name: "post_search", Use: "Find posts by query; prefer compact view before expanding a match."},
+			{Name: "post_get", Use: "Expand one status ID from a compact timeline, search, notification, or conversation ref."},
+			{Name: "followers_list", Use: "List accounts following the authenticated actor."},
+			{Name: "following_list", Use: "List accounts the authenticated actor follows."},
+			{Name: "post_create", Use: "Create a public, unlisted, private, or direct post, including replies."},
+			{Name: "post_boost", Use: "Boost or reblog an existing post."},
+			{Name: "post_favorite", Use: "Favorite an existing post."},
+			{Name: "follow", Use: "Follow an account."},
+			{Name: "unfollow", Use: "Stop following an account."},
+		},
+	},
+	{
+		Name: "articles",
+		Tools: []describeInterfaceTool{
+			{Name: "article_draft_create", Use: "Create an owner-scoped unpublished Article draft without publishing it."},
+			{Name: "article_draft_update", Use: "Revise an owner-scoped unpublished Article draft."},
+			{Name: "article_draft_get", Use: "Expand one owner-scoped draft when compact metadata is insufficient."},
+			{Name: "article_draft_list", Use: "List the authenticated actor's unpublished Article drafts."},
+			{Name: "article_draft_preview", Use: "Render a draft through Lesser's canonical sanitizer before publishing."},
+			{Name: "article_draft_publish", Use: "Explicitly publish a reviewed owner-scoped draft."},
+			{Name: "article_update", Use: "Update bounded content fields on a published Article."},
+			{Name: "article_get", Use: "Read one published Article by canonical ID, URL, or slug."},
+			{Name: "article_list", Use: "List the authenticated actor's published Articles."},
+		},
+	},
+	{
+		Name: "DMs and notifications",
+		Tools: []describeInterfaceTool{
+			{Name: "conversations_read", Use: "List direct-message conversations; use compact view as an index."},
+			{Name: "conversation_get", Use: "Expand one conversation into bounded recent message previews or explicit full content."},
+			{Name: "direct_messages_read", Use: "Read a focused one-to-one DM thread by named counterpart without a broad scan."},
+			{Name: "message_requests_list", Use: "List pending recipient-owned DM requests with bounded previews."},
+			{Name: "message_request_accept", Use: "Accept a pending DM request into the inbox."},
+			{Name: "message_request_decline", Use: "Decline a pending DM request."},
+			{Name: "notifications_read", Use: "List recent notifications; use compact view before expanding one item."},
+			{Name: "notification_get", Use: "Expand one notification ID from a compact notification ref."},
+			{Name: "notification_dismiss", Use: "Mark one notification, or all notifications, as read."},
+		},
+	},
+	{
+		Name: "memory",
+		Tools: []describeInterfaceTool{
+			{Name: "memory_query", Use: "Read actor-scoped memory events using bounded filters."},
+			{Name: "memory_append", Use: "Append a durable actor-scoped memory event when the lesson is worth retaining."},
+		},
+	},
+	{
+		Name: "skills",
+		Tools: []describeInterfaceTool{
+			{Name: "skills_catalog", Use: "Discover approved skill bundles and their provenance before selecting one."},
+			{Name: "skill_bundle_get", Use: "Fetch and optionally verify one selected approved skill bundle."},
+		},
+	},
+	{
+		Name: "soul",
+		Tools: []describeInterfaceTool{
+			{Name: "soul_read", Use: "Read a public soul bundle; summary view is the bounded orientation path."},
+			{Name: "identity_whoami", Use: "On a souled runtime, read the authenticated soul identity and its private channel preferences."},
+			{Name: "identity_lookup", Use: "On a souled runtime, resolve a public identity by agent ID, local ID, ENS name, handle, or actor URL."},
+			{Name: "identity_verify", Use: "On a souled runtime, verify communication provenance against a resolved soul identity."},
+		},
+	},
+	{
+		Name: "comms (souled runtime only)",
+		Tools: []describeInterfaceTool{
+			{Name: "email_read", Use: "List bounded email metadata and previews; compact view is the mailbox index."},
+			{Name: "email_get", Use: "Read canonical metadata and state for one mailbox message reference."},
+			{Name: "email_get_content", Use: "Explicitly fetch the full body of one mailbox email."},
+			{Name: "email_search", Use: "Search bounded email metadata and previews."},
+			{Name: "email_send", Use: "Send a new email through lesser-host; use email_reply for an existing thread."},
+			{Name: "email_reply", Use: "Reply to one mailbox message while lesser-host preserves thread and recipient context."},
+			{Name: "email_delete", Use: "Archive or soft-delete one mailbox email."},
+			{Name: "email_mark_read", Use: "Mark one mailbox email as read."},
+			{Name: "email_mark_unread", Use: "Mark one mailbox email as unread."},
+			{Name: "sms_read", Use: "List bounded inbound SMS metadata and previews."},
+			{Name: "sms_send", Use: "Send or reply to an SMS through lesser-host with idempotency metadata."},
+			{Name: "voicemail_read", Use: "List bounded inbound voicemail metadata and previews."},
+		},
+	},
+}
+
+func describeInterfaceDef() mcpruntime.ToolDef {
+	return mcpruntime.ToolDef{
+		Name:        "describe_interface",
+		Description: "Orient to the authenticated Ka actor, every registered tool, recommended workflows, and bounded read-result conventions.",
+		Annotations: readOnlyToolAnnotations(),
+		InputSchema: json.RawMessage(`{
+			"type":"object",
+			"properties":{},
+			"additionalProperties":false
+		}`),
+	}
+}
+
+func handleDescribeInterface(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolResult, error) {
+	var in map[string]json.RawMessage
+	raw := strings.TrimSpace(string(args))
+	if raw != "" && raw != "null" {
+		if err := json.Unmarshal(args, &in); err != nil {
+			return nil, invalidParams("invalid args: " + err.Error())
+		}
+		if len(in) != 0 {
+			return nil, invalidParams("describe_interface accepts no arguments")
+		}
+	}
+
+	return &mcpruntime.ToolResult{
+		Content: []mcpruntime.ContentBlock{{
+			Type: "text",
+			Text: renderDescribeInterface(ctx),
+		}},
+	}, nil
+}
+
+func renderDescribeInterface(ctx context.Context) string {
+	identity := describeInterfaceIdentity(ctx)
+
+	var out strings.Builder
+	out.WriteString("# Ka MCP interface\n\n")
+	out.WriteString("## Identity context\n")
+	out.WriteString("- actor: `" + describeInterfaceValue(identity.Actor) + "`\n")
+	out.WriteString("- instance: `" + describeInterfaceValue(identity.Instance) + "`\n")
+	out.WriteString("- runtime_profile: `" + describeInterfaceValue(identity.Profile) + "`\n")
+	out.WriteString("- soul_binding: `" + describeInterfaceValue(identity.SoulBinding) + "`\n")
+	if identity.SoulAgentID != "" {
+		out.WriteString("- soul_agent_id: `" + describeInterfaceValue(identity.SoulAgentID) + "`\n")
+	}
+
+	out.WriteString("\n## Tool inventory\n")
+	out.WriteString("Read-scoped tools have no side effects; write-scoped tools mutate actor state or delegate a side effect. ")
+	out.WriteString("Comms and the noted identity tools require a souled runtime.\n")
+	for _, domain := range describeInterfaceDomains {
+		out.WriteString("\n### " + domain.Name + "\n")
+		for _, tool := range domain.Tools {
+			out.WriteString("- `" + tool.Name + "` — " + tool.Use + "\n")
+		}
+	}
+
+	out.WriteString("\n## Recommended workflows\n")
+	out.WriteString("- Timeline discovery: `timeline_read({\"timeline\":\"home\",\"limit\":5,\"view\":\"compact\"})` → select a stable status ID → `post_get({\"id\":\"<status-id>\",\"view\":\"standard\"})`.\n")
+	out.WriteString("- Conversation discovery: `conversations_read({\"limit\":10,\"view\":\"compact\"})` → select a conversation ID → `conversation_get({\"conversationId\":\"<conversation-id>\",\"limit\":20,\"view\":\"compact\"})`.\n")
+	out.WriteString("- Notification discovery: `notifications_read({\"limit\":10,\"view\":\"compact\"})` → select a notification ID → `notification_get({\"id\":\"<notification-id>\",\"view\":\"standard\"})`.\n")
+	out.WriteString("- Article publication: `article_draft_create` or `article_draft_update` → `article_draft_preview` → inspect the rendered result → `article_draft_publish`.\n")
+
+	out.WriteString("\n## Read-result budgeting and expansion\n")
+	out.WriteString("- When advertised by a tool, `view` selects the projection: `standard` preserves the compatibility shape, `compact`/`summary` bounds discovery context, and `full` is explicit audit/debug expansion.\n")
+	out.WriteString("- `preview_chars` bounds previews before result surfaces are rendered; `0` means the tool's documented default.\n")
+	out.WriteString("- `max_output_bytes` budgets the final MCP JSON-RPC envelope. An over-budget result returns `response_too_large` with measured details instead of silently dropping fields.\n")
+	out.WriteString("- Structured-first compact/summary reads are dual-surface: `content[0].text` JSON contains substantive bounded data in a nested `payload` value (never a JSON-encoded string), while the typed projection remains at `structuredContent.data`. The legacy `data.location` locator remains for compatibility.\n")
+	out.WriteString("- Follow compact refs through `expand.tool` and `expand.arguments`. Budget-safe compact social refs use `expand.resultPath=\"content[0].text\"`; expanded results still retain `structuredContent`. Where present, prefer additive `resultAccess`/`textResultPath` guidance.\n")
+	out.WriteString("- Expand only selected refs. In particular, `post_get` returns the status once and does not point back to itself.\n")
+
+	return out.String()
+}
+
+type describeInterfaceIdentityContext struct {
+	Actor       string
+	Instance    string
+	Profile     string
+	SoulBinding string
+	SoulAgentID string
+}
+
+func describeInterfaceIdentity(ctx context.Context) describeInterfaceIdentityContext {
+	identity := describeInterfaceIdentityContext{
+		Actor:       describeInterfaceActor(ctx),
+		Instance:    describeInterfaceInstance(),
+		Profile:     "unknown",
+		SoulBinding: "unknown",
+	}
+
+	if resolved, ok := runtimepolicy.FromContext(ctx); ok {
+		identity.Profile = strings.TrimSpace(string(resolved.Profile))
+		switch {
+		case resolved.BoundSoul:
+			identity.SoulBinding = "bound"
+			identity.SoulAgentID = strings.TrimSpace(resolved.SoulAgentID)
+		case resolved.Determined:
+			identity.SoulBinding = "unbound"
+		default:
+			identity.SoulBinding = "undetermined"
+		}
+	}
+
+	return identity
+}
+
+func describeInterfaceActor(ctx context.Context) string {
+	principal := auth.PrincipalFromToolContext(ctx)
+	if principal == nil {
+		return ""
+	}
+	if principal.Type == auth.PrincipalTypeX402Grant && principal.X402Grant != nil {
+		if actor := strings.TrimSpace(principal.X402Grant.Actor); actor != "" {
+			return actor
+		}
+	}
+	if actor := strings.TrimSpace(principal.Identity); actor != "" {
+		return actor
+	}
+	if principal.Claims != nil {
+		return strings.TrimSpace(principal.Claims.GetUsername())
+	}
+	return ""
+}
+
+func describeInterfaceInstance() string {
+	raw := strings.TrimSpace(os.Getenv("MCP_ENDPOINT"))
+	if raw == "" {
+		return ""
+	}
+	parsed, err := url.Parse(strings.ReplaceAll(raw, "{actor}", "actor"))
+	if err != nil {
+		return ""
+	}
+	host := strings.ToLower(strings.TrimSpace(parsed.Hostname()))
+	if strings.HasPrefix(host, "api.") {
+		host = strings.TrimPrefix(host, "api.")
+	}
+	return host
+}
+
+func describeInterfaceValue(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "unknown"
+	}
+	value = strings.NewReplacer(
+		"`", "'",
+		"\r", " ",
+		"\n", " ",
+		"\t", " ",
+	).Replace(value)
+	return strings.Join(strings.Fields(value), " ")
+}

--- a/internal/mcpserver/describe_interface_test.go
+++ b/internal/mcpserver/describe_interface_test.go
@@ -1,0 +1,137 @@
+package mcpserver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/equaltoai/lesser-body/internal/auth"
+	"github.com/equaltoai/lesser-body/internal/runtimepolicy"
+)
+
+func TestDescribeInterfaceCoversEveryRegisteredTool(t *testing.T) {
+	registered := make(map[string]struct{})
+	for _, def := range registeredToolDefsForTest(t) {
+		registered[def.Name] = struct{}{}
+	}
+
+	catalog := make(map[string]struct{})
+	var duplicates []string
+	for _, domain := range describeInterfaceDomains {
+		if strings.TrimSpace(domain.Name) == "" {
+			t.Fatal("describe_interface domain name must not be empty")
+		}
+		for _, tool := range domain.Tools {
+			if strings.TrimSpace(tool.Name) == "" || strings.TrimSpace(tool.Use) == "" {
+				t.Fatalf("describe_interface domain %q has an incomplete tool entry: %+v", domain.Name, tool)
+			}
+			if _, ok := catalog[tool.Name]; ok {
+				duplicates = append(duplicates, tool.Name)
+			}
+			catalog[tool.Name] = struct{}{}
+		}
+	}
+	sort.Strings(duplicates)
+	if len(duplicates) > 0 {
+		t.Fatalf("describe_interface catalog contains duplicate tools: %v", duplicates)
+	}
+
+	var missing, stale, absentFromText []string
+	text := renderDescribeInterface(context.Background())
+	for name := range registered {
+		if _, ok := catalog[name]; !ok {
+			missing = append(missing, name)
+		}
+		if !strings.Contains(text, fmt.Sprintf("- `%s` —", name)) {
+			absentFromText = append(absentFromText, name)
+		}
+	}
+	for name := range catalog {
+		if _, ok := registered[name]; !ok {
+			stale = append(stale, name)
+		}
+	}
+	sort.Strings(missing)
+	sort.Strings(stale)
+	sort.Strings(absentFromText)
+	if len(missing) > 0 || len(stale) > 0 || len(absentFromText) > 0 {
+		t.Fatalf("describe_interface drift: missing=%v stale=%v absent_from_text=%v", missing, stale, absentFromText)
+	}
+	if got, max := len([]byte(text)), 16*1024; got > max {
+		t.Fatalf("describe_interface text is too large for a bootstrap result: got %d bytes, max %d", got, max)
+	}
+}
+
+func TestDescribeInterfaceReturnsIdentityAndCurrentReadGuidanceInText(t *testing.T) {
+	t.Setenv("MCP_ENDPOINT", "https://api.dev.example.com/mcp/{actor}")
+
+	ctx := auth.InjectToolContext(context.Background(), &auth.Principal{
+		Type:     auth.PrincipalTypeOAuthToken,
+		Identity: "agent1",
+	}, "")
+	ctx = runtimepolicy.WithContext(ctx, runtimepolicy.Resolved{
+		Profile:             runtimepolicy.ProfileSouled,
+		Determined:          true,
+		DeterminationSource: "soulbinding_present",
+		BoundSoul:           true,
+		SoulAgentID:         "agent1.dev.example.com",
+	})
+
+	result, err := handleDescribeInterface(ctx, json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("handleDescribeInterface: %v", err)
+	}
+	if result == nil || len(result.Content) != 1 || result.Content[0].Type != "text" {
+		t.Fatalf("describe_interface must return one text block, got %+v", result)
+	}
+
+	text := result.Content[0].Text
+	for _, want := range []string{
+		"actor: `agent1`",
+		"instance: `dev.example.com`",
+		"runtime_profile: `souled`",
+		"soul_binding: `bound`",
+		"soul_agent_id: `agent1.dev.example.com`",
+		"`timeline_read({\"timeline\":\"home\",\"limit\":5,\"view\":\"compact\"})`",
+		"`post_get({\"id\":\"<status-id>\",\"view\":\"standard\"})`",
+		"`conversations_read({\"limit\":10,\"view\":\"compact\"})`",
+		"`conversation_get({\"conversationId\":\"<conversation-id>\",\"limit\":20,\"view\":\"compact\"})`",
+		"`notifications_read({\"limit\":10,\"view\":\"compact\"})`",
+		"`notification_get({\"id\":\"<notification-id>\",\"view\":\"standard\"})`",
+		"`article_draft_preview`",
+		"`article_draft_publish`",
+		"`preview_chars`",
+		"`max_output_bytes`",
+		"nested `payload` value (never a JSON-encoded string)",
+		"`structuredContent.data`",
+		"`expand.resultPath=\"content[0].text\"`",
+	} {
+		if !strings.Contains(text, want) {
+			t.Errorf("describe_interface text missing %q", want)
+		}
+	}
+}
+
+func TestDescribeInterfaceIsReadOnlyAndAvailableToBothProfiles(t *testing.T) {
+	def := describeInterfaceDef()
+	if def.Annotations == nil || def.Annotations.ReadOnlyHint == nil || !*def.Annotations.ReadOnlyHint {
+		t.Fatalf("describe_interface must carry an explicit read-only annotation: %+v", def.Annotations)
+	}
+	if got := RequiredScopesForTool(def.Name); len(got) != 1 || got[0] != ScopeRead {
+		t.Fatalf("describe_interface scope = %v, want [%s]", got, ScopeRead)
+	}
+	for _, profile := range []runtimepolicy.Profile{runtimepolicy.ProfileDrone, runtimepolicy.ProfileSouled} {
+		if !runtimepolicy.ToolAllowed(profile, def.Name) {
+			t.Errorf("describe_interface must be available to %s profile", profile)
+		}
+	}
+}
+
+func TestDescribeInterfaceRejectsArguments(t *testing.T) {
+	if _, err := handleDescribeInterface(context.Background(), json.RawMessage(`{"view":"compact"}`)); err == nil {
+		t.Fatal("describe_interface should reject unexpected arguments")
+	}
+}

--- a/internal/mcpserver/ka_schema_conformance_test.go
+++ b/internal/mcpserver/ka_schema_conformance_test.go
@@ -1,0 +1,793 @@
+package mcpserver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/equaltoai/lesser-body/internal/cmsapi"
+	"github.com/equaltoai/lesser-body/internal/lesserapi"
+	"github.com/equaltoai/lesser-body/internal/memory"
+	mcpruntime "github.com/theory-cloud/apptheory/v2/runtime/mcp"
+)
+
+// Strict MCP clients validate tools/call structuredContent against the tool's
+// declared OutputSchema. Keep the test validator deliberately scoped to the
+// JSON Schema vocabulary used by Ka's output schemas: type, required,
+// properties, additionalProperties, items, and enum.
+func assertKaResultMatchesDeclaredOutputSchema(t *testing.T, label string, schema json.RawMessage, result *mcpruntime.ToolResult) {
+	t.Helper()
+	if result == nil {
+		t.Fatalf("%s: handler returned a nil result", label)
+	}
+	if result.IsError {
+		t.Fatalf("%s: representative success fixture returned a tool error: %#v", label, result.StructuredContent)
+	}
+	if len(schema) == 0 {
+		t.Fatalf("%s: registered tool has no declared output schema", label)
+	}
+
+	var declared any
+	if err := json.Unmarshal(schema, &declared); err != nil {
+		t.Fatalf("%s: declared output schema is invalid JSON: %v", label, err)
+	}
+	var unsupported []string
+	validateKaOutputSchemaVocabulary("outputSchema", declared, &unsupported)
+	if len(unsupported) > 0 {
+		sort.Strings(unsupported)
+		t.Fatalf("%s: declared output schema uses vocabulary the conformance guard does not validate:\n  %s",
+			label, strings.Join(unsupported, "\n  "))
+	}
+	encoded, err := json.Marshal(result.StructuredContent)
+	if err != nil {
+		t.Fatalf("%s: structuredContent is not JSON-encodable: %v", label, err)
+	}
+	var produced any
+	if err := json.Unmarshal(encoded, &produced); err != nil {
+		t.Fatalf("%s: structuredContent did not round-trip through JSON: %v", label, err)
+	}
+
+	var violations []string
+	validateKaOutputSchema("structuredContent", declared, produced, &violations)
+	if len(violations) == 0 {
+		return
+	}
+	sort.Strings(violations)
+	t.Fatalf("%s: structuredContent does not match the declared output schema:\n  %s\nproduced: %s",
+		label, strings.Join(violations, "\n  "), string(encoded))
+}
+
+func validateKaOutputSchemaVocabulary(path string, schema any, unsupported *[]string) {
+	node, ok := schema.(map[string]any)
+	if !ok {
+		*unsupported = append(*unsupported, fmt.Sprintf("%s: schema node is %T, want object", path, schema))
+		return
+	}
+
+	for keyword, value := range node {
+		switch keyword {
+		case "type":
+			if _, ok := value.(string); !ok {
+				*unsupported = append(*unsupported, fmt.Sprintf("%s.type: %T is not supported", path, value))
+			}
+		case "required":
+			if _, ok := value.([]any); !ok {
+				*unsupported = append(*unsupported, fmt.Sprintf("%s.required: %T is not supported", path, value))
+			}
+		case "properties":
+			properties, ok := value.(map[string]any)
+			if !ok {
+				*unsupported = append(*unsupported, fmt.Sprintf("%s.properties: %T is not supported", path, value))
+				continue
+			}
+			for name, child := range properties {
+				validateKaOutputSchemaVocabulary(path+".properties."+name, child, unsupported)
+			}
+		case "additionalProperties":
+			if child, ok := value.(map[string]any); ok {
+				validateKaOutputSchemaVocabulary(path+".additionalProperties", child, unsupported)
+				continue
+			}
+			if _, ok := value.(bool); !ok {
+				*unsupported = append(*unsupported, fmt.Sprintf("%s.additionalProperties: %T is not supported", path, value))
+			}
+		case "items":
+			validateKaOutputSchemaVocabulary(path+".items", value, unsupported)
+		case "enum":
+			if _, ok := value.([]any); !ok {
+				*unsupported = append(*unsupported, fmt.Sprintf("%s.enum: %T is not supported", path, value))
+			}
+		default:
+			*unsupported = append(*unsupported, fmt.Sprintf("%s.%s: unsupported JSON Schema keyword", path, keyword))
+		}
+	}
+}
+
+func validateKaOutputSchema(path string, schema any, value any, violations *[]string) {
+	node, ok := schema.(map[string]any)
+	if !ok {
+		return
+	}
+
+	if allowed, ok := node["enum"].([]any); ok {
+		matched := false
+		for _, candidate := range allowed {
+			if reflect.DeepEqual(candidate, value) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			*violations = append(*violations, fmt.Sprintf("%s: value %#v is outside the declared enum %v", path, value, allowed))
+		}
+	}
+
+	if want, ok := node["type"].(string); ok && !kaJSONTypeMatches(want, value) {
+		*violations = append(*violations, fmt.Sprintf("%s: value has JSON type %s, want %s", path, kaJSONType(value), want))
+		return
+	}
+
+	switch typed := value.(type) {
+	case map[string]any:
+		properties, _ := node["properties"].(map[string]any)
+		if required, ok := node["required"].([]any); ok {
+			for _, raw := range required {
+				key, ok := raw.(string)
+				if !ok {
+					*violations = append(*violations, fmt.Sprintf("%s: declared required member %#v is not a string", path, raw))
+					continue
+				}
+				if _, present := typed[key]; !present {
+					*violations = append(*violations, fmt.Sprintf("%s.%s: missing required property", path, key))
+				}
+			}
+		}
+		for key, child := range typed {
+			if childSchema, present := properties[key]; present {
+				validateKaOutputSchema(path+"."+key, childSchema, child, violations)
+				continue
+			}
+			switch additional := node["additionalProperties"].(type) {
+			case bool:
+				if !additional {
+					*violations = append(*violations, fmt.Sprintf("%s.%s: undeclared key under additionalProperties:false", path, key))
+				}
+			case map[string]any:
+				validateKaOutputSchema(path+"."+key, additional, child, violations)
+			}
+		}
+	case []any:
+		items, ok := node["items"]
+		if !ok {
+			return
+		}
+		for i, child := range typed {
+			validateKaOutputSchema(fmt.Sprintf("%s[%d]", path, i), items, child, violations)
+		}
+	}
+}
+
+func kaJSONTypeMatches(want string, value any) bool {
+	switch want {
+	case "object":
+		_, ok := value.(map[string]any)
+		return ok
+	case "array":
+		_, ok := value.([]any)
+		return ok
+	case "string":
+		_, ok := value.(string)
+		return ok
+	case "boolean":
+		_, ok := value.(bool)
+		return ok
+	case "number":
+		_, ok := value.(float64)
+		return ok
+	case "integer":
+		number, ok := value.(float64)
+		return ok && !math.IsNaN(number) && !math.IsInf(number, 0) && math.Trunc(number) == number
+	case "null":
+		return value == nil
+	default:
+		return false
+	}
+}
+
+func kaJSONType(value any) string {
+	switch typed := value.(type) {
+	case nil:
+		return "null"
+	case map[string]any:
+		return "object"
+	case []any:
+		return "array"
+	case string:
+		return "string"
+	case bool:
+		return "boolean"
+	case float64:
+		if math.Trunc(typed) == typed {
+			return "integer"
+		}
+		return "number"
+	default:
+		return fmt.Sprintf("%T", value)
+	}
+}
+
+type kaOutputSchemaFixture struct {
+	name  string
+	build func(*testing.T) *mcpruntime.ToolResult
+}
+
+// Every registered Ka tool is accounted for here. Tools that do not publish an
+// output schema are pinned separately because there is no client-side schema
+// contract to validate. Every schema-bearing tool must have one or more
+// representative success results, and adding a tool or adding/removing its
+// output schema fails this guard until its coverage is explicit.
+func TestEveryRegisteredKaToolResultMatchesDeclaredOutputSchema(t *testing.T) {
+	fixtures := kaOutputSchemaFixtures()
+	withoutOutputSchema := map[string]struct{}{
+		"describe_interface": {},
+		"echo":               {},
+		"profile_read":       {},
+		"timeline_read":      {},
+		"post_search":        {},
+		"followers_list":     {},
+		"following_list":     {},
+		"conversations_read": {},
+		"notifications_read": {},
+	}
+
+	registered := map[string]struct{}{}
+	for _, def := range registeredToolDefsForTest(t) {
+		registered[def.Name] = struct{}{}
+		cases, hasFixtures := fixtures[def.Name]
+		_, intentionallyUnschematized := withoutOutputSchema[def.Name]
+
+		if len(def.OutputSchema) == 0 {
+			if !intentionallyUnschematized {
+				t.Errorf("%s: registered tool has no output schema and is not pinned in withoutOutputSchema", def.Name)
+			}
+			if hasFixtures {
+				t.Errorf("%s: has conformance fixtures but no declared output schema", def.Name)
+			}
+			continue
+		}
+		if intentionallyUnschematized {
+			t.Errorf("%s: now declares an output schema but remains pinned in withoutOutputSchema", def.Name)
+		}
+		if !hasFixtures || len(cases) == 0 {
+			t.Errorf("%s: registered schema-bearing tool has no representative result fixture", def.Name)
+			continue
+		}
+		for _, fixture := range cases {
+			fixture := fixture
+			t.Run(def.Name+"/"+fixture.name, func(t *testing.T) {
+				if fixture.build == nil {
+					t.Fatal("fixture has no result builder")
+				}
+				assertKaResultMatchesDeclaredOutputSchema(t, def.Name+"/"+fixture.name, def.OutputSchema, fixture.build(t))
+			})
+		}
+	}
+
+	for name := range fixtures {
+		if _, ok := registered[name]; !ok {
+			t.Errorf("%s: output-schema fixtures are stale; tool is not registered", name)
+		}
+	}
+	for name := range withoutOutputSchema {
+		if _, ok := registered[name]; !ok {
+			t.Errorf("%s: withoutOutputSchema entry is stale; tool is not registered", name)
+		}
+	}
+}
+
+func kaOutputSchemaFixtures() map[string][]kaOutputSchemaFixture {
+	fixtures := map[string][]kaOutputSchemaFixture{}
+	add := func(tool string, name string, build func(*testing.T) *mcpruntime.ToolResult) {
+		fixtures[tool] = append(fixtures[tool], kaOutputSchemaFixture{name: name, build: build})
+	}
+
+	for _, tool := range []string{
+		"notification_dismiss",
+		"post_create",
+		"post_boost",
+		"post_favorite",
+		"follow",
+		"unfollow",
+		"profile_update",
+	} {
+		add(tool, "success", func(t *testing.T) *mcpruntime.ToolResult {
+			return mustKaToolResult(toolJSONResult(map[string]any{"id": "fixture-id"}, nil))
+		})
+	}
+
+	add("post_get", "standard", func(t *testing.T) *mcpruntime.ToolResult {
+		return mustKaToolResult(toolJSONResult(map[string]any{
+			"id":     "post-1",
+			"view":   readViewStandard,
+			"source": "lesser-api",
+			"status": map[string]any{"id": "post-1"},
+		}, nil))
+	})
+	add("notification_get", "standard", func(t *testing.T) *mcpruntime.ToolResult {
+		return mustKaToolResult(toolJSONResult(map[string]any{
+			"id":              "notification-1",
+			"view":            readViewStandard,
+			"source":          "lesser-api",
+			"notification":    map[string]any{"id": "notification-1"},
+			"notificationRef": map[string]any{"id": "notification-1"},
+		}, nil))
+	})
+	add("conversation_get", "standard", func(t *testing.T) *mcpruntime.ToolResult {
+		return mustKaToolResult(socialConversationGetStructuredResult(map[string]any{
+			"id":           "conversation-1",
+			"view":         readViewStandard,
+			"source":       "lesser-api",
+			"conversation": map[string]any{"id": "conversation-1"},
+			"limit":        20,
+		}, sharedReadParams{View: readViewStandard}))
+	})
+	add("conversation_get", "compact", func(t *testing.T) *mcpruntime.ToolResult {
+		conversation := map[string]any{"id": "conversation-1", "messages": []any{}}
+		return mustKaToolResult(socialCompactConversationGetResult(map[string]any{
+			"id":           "conversation-1",
+			"source":       "lesser-api",
+			"conversation": conversation,
+			"limit":        20,
+		}, conversation, sharedReadParams{View: readViewCompact}))
+	})
+	add("direct_messages_read", "standard", func(t *testing.T) *mcpruntime.ToolResult {
+		return mustKaToolResult(socialDirectMessagesReadStructuredResult(map[string]any{
+			"counterpart":  "counterpart",
+			"id":           "conversation-1",
+			"view":         readViewStandard,
+			"source":       "lesser-api",
+			"conversation": map[string]any{"id": "conversation-1"},
+			"messages":     []any{},
+			"count":        0,
+			"limit":        20,
+			"unreadOnly":   false,
+		}, sharedReadParams{View: readViewStandard}))
+	})
+	add("direct_messages_read", "compact", func(t *testing.T) *mcpruntime.ToolResult {
+		conversation := map[string]any{"id": "conversation-1", "messages": []any{}}
+		return mustKaToolResult(socialCompactDirectMessagesReadResult(map[string]any{
+			"counterpart":  "counterpart",
+			"id":           "conversation-1",
+			"source":       "lesser-api",
+			"conversation": conversation,
+			"limit":        20,
+			"unreadOnly":   false,
+		}, conversation, sharedReadParams{View: readViewCompact}))
+	})
+
+	add("message_requests_list", "requests", func(t *testing.T) *mcpruntime.ToolResult {
+		return callMessageRequestHandlerForSchema(t, "BodyMessageRequests",
+			`{"data":{"conversations":[{"id":"conversation-1","unread":true,"accounts":[],"viewerMetadata":{"requestState":"PENDING"}}]}}`,
+			handleMessageRequestsList, `{}`)
+	})
+	add("message_request_accept", "accepted_enum_members", func(t *testing.T) *mcpruntime.ToolResult {
+		return callMessageRequestHandlerForSchema(t, "BodyAcceptMessageRequest",
+			`{"data":{"acceptMessageRequest":{"id":"conversation-1","unread":true,"accounts":[],"viewerMetadata":{"requestState":"ACCEPTED"}}}}`,
+			handleMessageRequestAccept, `{"conversationId":"conversation-1"}`)
+	})
+	add("message_request_decline", "declined_enum_members", func(t *testing.T) *mcpruntime.ToolResult {
+		return callMessageRequestHandlerForSchema(t, "BodyDeclineMessageRequest",
+			`{"data":{"declineMessageRequest":true}}`,
+			handleMessageRequestDecline, `{"conversationId":"conversation-1"}`)
+	})
+
+	draftFixture := func() *cmsapi.Draft {
+		title := "Draft title"
+		slug := "draft-title"
+		return &cmsapi.Draft{
+			ID:            "draft-1",
+			Title:         &title,
+			Slug:          &slug,
+			ContentType:   cmsapi.ObjectTypeArticle,
+			Content:       "Draft body",
+			ContentFormat: cmsapi.ContentFormatMarkdown,
+			Status:        cmsapi.DraftStatusDraft,
+		}
+	}
+	for tool, operation := range map[string]string{
+		"article_draft_create": "created",
+		"article_draft_update": "updated",
+		"article_draft_get":    "read",
+	} {
+		tool, operation := tool, operation
+		add(tool, "compact", func(t *testing.T) *mcpruntime.ToolResult {
+			return mustKaToolResult(articleDraftSingleResult(tool, operation, draftFixture(), articleDraftViewParams{
+				View:         readViewCompact,
+				PreviewRunes: articleDraftPreviewRunes,
+			}, nil))
+		})
+		add(tool, "standard", func(t *testing.T) *mcpruntime.ToolResult {
+			return mustKaToolResult(articleDraftSingleResult(tool, operation, draftFixture(), articleDraftViewParams{
+				View:         readViewStandard,
+				PreviewRunes: articleDraftPreviewRunes,
+			}, nil))
+		})
+	}
+	add("article_draft_list", "compact", func(t *testing.T) *mcpruntime.ToolResult {
+		return mustKaToolResult(articleDraftListResult(&cmsapi.DraftConnection{}, 20, articleDraftViewParams{
+			View:         readViewCompact,
+			PreviewRunes: articleDraftPreviewRunes,
+		}))
+	})
+	add("article_draft_list", "standard", func(t *testing.T) *mcpruntime.ToolResult {
+		return mustKaToolResult(articleDraftListResult(&cmsapi.DraftConnection{}, 20, articleDraftViewParams{
+			View:         readViewStandard,
+			PreviewRunes: articleDraftPreviewRunes,
+		}))
+	})
+	for _, fixture := range articleDraftPreviewOutputSchemaFixtures() {
+		fixture := fixture
+		add("article_draft_preview", fixture.name, fixture.build)
+	}
+
+	articleFixture := func() *cmsapi.Article {
+		return &cmsapi.Article{
+			ID:            "https://example.com/articles/article-1",
+			Slug:          "article-1",
+			Title:         "Article title",
+			Content:       "Article body",
+			ContentFormat: cmsapi.ContentFormatMarkdown,
+		}
+	}
+	for tool, operation := range map[string]string{
+		"article_draft_publish": "published",
+		"article_update":        "updated",
+		"article_get":           "read",
+	} {
+		tool, operation := tool, operation
+		add(tool, "compact", func(t *testing.T) *mcpruntime.ToolResult {
+			return mustKaToolResult(articleSingleResult(tool, operation, articleFixture(), articleDraftViewParams{
+				View:         readViewCompact,
+				PreviewRunes: articleDraftPreviewRunes,
+			}, nil))
+		})
+		add(tool, "standard", func(t *testing.T) *mcpruntime.ToolResult {
+			return mustKaToolResult(articleSingleResult(tool, operation, articleFixture(), articleDraftViewParams{
+				View:         readViewStandard,
+				PreviewRunes: articleDraftPreviewRunes,
+			}, nil))
+		})
+	}
+	add("article_list", "compact", func(t *testing.T) *mcpruntime.ToolResult {
+		return mustKaToolResult(articleListResult(&cmsapi.ArticleConnection{}, 20, "actor-1", articleDraftViewParams{
+			View:         readViewCompact,
+			PreviewRunes: articleDraftPreviewRunes,
+		}))
+	})
+	add("article_list", "standard", func(t *testing.T) *mcpruntime.ToolResult {
+		return mustKaToolResult(articleListResult(&cmsapi.ArticleConnection{}, 20, "actor-1", articleDraftViewParams{
+			View:         readViewStandard,
+			PreviewRunes: articleDraftPreviewRunes,
+		}))
+	})
+
+	add("memory_append", "created", func(t *testing.T) *mcpruntime.ToolResult {
+		payload := &memory.AppendResult{
+			Event: memory.Event{
+				EventID:    "01J00000000000000000000000",
+				OccurredAt: time.Date(2026, time.July, 28, 12, 0, 0, 0, time.UTC),
+				Content:    "remembered",
+				Tags:       []string{"schema"},
+			},
+			Created: true,
+		}
+		structured, err := toolStructuredContent(payload)
+		if err != nil {
+			t.Fatalf("toolStructuredContent: %v", err)
+		}
+		return mustKaToolResult(toolJSONResult(payload, structured))
+	})
+	add("memory_query", "events", func(t *testing.T) *mcpruntime.ToolResult {
+		payload := &memory.QueryResult{
+			Events: []memory.Event{{
+				EventID:    "01J00000000000000000000000",
+				OccurredAt: time.Date(2026, time.July, 28, 12, 0, 0, 0, time.UTC),
+				Content:    "remembered",
+			}},
+			NextCursor: "next",
+		}
+		structured, err := toolStructuredContent(payload)
+		if err != nil {
+			t.Fatalf("toolStructuredContent: %v", err)
+		}
+		return mustKaToolResult(toolJSONResult(payload, structured))
+	})
+
+	add("skills_catalog", "catalog", func(t *testing.T) *mcpruntime.ToolResult {
+		return mustKaToolResult(toolJSONResult(map[string]any{
+			"authority":  map[string]any{"source": "lesser"},
+			"items":      []any{map[string]any{"skill_id": "skill-1"}},
+			"bundles":    []any{map[string]any{"bundle_id": "bundle-1"}},
+			"nextCursor": "next",
+		}, nil))
+	})
+	add("skill_bundle_get", "bundle", func(t *testing.T) *mcpruntime.ToolResult {
+		return mustKaToolResult(toolJSONResult(map[string]any{
+			"authority":    map[string]any{"source": "lesser"},
+			"bundle":       map[string]any{"bundle_id": "bundle-1"},
+			"content":      map[string]any{"mode": "metadata"},
+			"verification": map[string]any{"state": skillInstallStateNotInstalled},
+		}, nil))
+	})
+
+	for _, tool := range []string{"email_send", "email_reply", "sms_send"} {
+		add(tool, "queued", func(t *testing.T) *mcpruntime.ToolResult {
+			payload := normalizeCommSendResult(map[string]any{
+				"messageRef": "message-1",
+				"status":     "queued",
+				"channel":    "fixture",
+			}, nil)
+			payload["idempotencyKey"] = "idempotency-1"
+			return mustKaToolResult(toolJSONResult(payload, nil))
+		})
+	}
+
+	mailboxRaw := func() map[string]any {
+		return map[string]any{
+			"messages": []any{map[string]any{
+				"messageRef":  "message-1",
+				"channelType": "email",
+				"direction":   "inbound",
+				"status":      "received",
+				"preview":     "bounded preview",
+				"state":       map[string]any{"read": false},
+				"content":     map[string]any{"available": true},
+				"createdAt":   "2026-07-28T12:00:00Z",
+			}},
+			"count":      1,
+			"hasMore":    false,
+			"nextCursor": "next",
+		}
+	}
+	mailboxStandardResult := func(t *testing.T) *mcpruntime.ToolResult {
+		payload := normalizeMailboxListResult(mailboxRaw(), false)
+		return mustKaToolResult(toolJSONResult(payload, payload))
+	}
+	for _, tool := range []string{"email_read", "email_search", "sms_read", "voicemail_read"} {
+		add(tool, "standard", mailboxStandardResult)
+	}
+	add("email_read", "compact", func(t *testing.T) *mcpruntime.ToolResult {
+		payload := mailboxCompactListResult(normalizeMailboxListResult(mailboxRaw(), false))
+		return mustKaToolResult(compactMailboxListToolResult("email_read", payload))
+	})
+	add("email_get", "message", func(t *testing.T) *mcpruntime.ToolResult {
+		payload := map[string]any{
+			"message": normalizeMailboxMessage(mailboxRaw()["messages"].([]any)[0], false),
+			"source":  "lesser-host-mailbox",
+		}
+		return mustKaToolResult(toolJSONResult(payload, payload))
+	})
+	add("email_get_content", "content", func(t *testing.T) *mcpruntime.ToolResult {
+		payload := normalizeMailboxContentResult(map[string]any{
+			"messageRef":  "message-1",
+			"contentType": "text/plain",
+			"bytes":       12,
+			"body":        "full content",
+		})
+		return mustKaToolResult(toolJSONResult(payload, payload))
+	})
+	for _, tool := range []string{"email_delete", "email_mark_read", "email_mark_unread"} {
+		tool := tool
+		add(tool, "mutation", func(t *testing.T) *mcpruntime.ToolResult {
+			action := "read"
+			if tool == "email_delete" {
+				action = "archive"
+			} else if tool == "email_mark_unread" {
+				action = "unread"
+			}
+			message := normalizeMailboxMessage(mailboxRaw()["messages"].([]any)[0], false)
+			payload := map[string]any{
+				"messageId":  "message-1",
+				"messageRef": "message-1",
+				"action":     action,
+				"message":    message,
+				"state":      message["state"],
+				"source":     "lesser-host-mailbox",
+			}
+			return mustKaToolResult(toolJSONResult(payload, payload))
+		})
+	}
+
+	add("identity_whoami", "identity", func(t *testing.T) *mcpruntime.ToolResult {
+		return mustKaToolResult(toolJSONResult(map[string]any{
+			"agentId":            "agent-1",
+			"domain":             "example.com",
+			"localId":            "actor",
+			"status":             "active",
+			"channels":           map[string]any{},
+			"contactPreferences": map[string]any{},
+		}, nil))
+	})
+	add("soul_read", "souls", func(t *testing.T) *mcpruntime.ToolResult {
+		return mustKaToolResult(soulReadToolResult(map[string]any{
+			"query":  "agent-1",
+			"count":  1,
+			"access": map[string]any{"mode": "public"},
+			"souls":  []any{map[string]any{"agentId": "agent-1"}},
+		}, soulReadPrivateRequest{}))
+	})
+	add("identity_lookup", "matches", func(t *testing.T) *mcpruntime.ToolResult {
+		return mustKaToolResult(toolJSONResult(map[string]any{
+			"query":   "agent-1",
+			"matches": []any{map[string]any{"agentId": "agent-1"}},
+			"count":   1,
+		}, nil))
+	})
+	add("identity_verify", "verified", func(t *testing.T) *mcpruntime.ToolResult {
+		return mustKaToolResult(toolJSONResult(map[string]any{
+			"channel":           "ens",
+			"identifier":        "agent.eth",
+			"verificationScope": "identifier",
+			"identityResolved":  true,
+			"verified":          true,
+			"agent":             map[string]any{"agentId": "agent-1"},
+		}, nil))
+	})
+
+	return fixtures
+}
+
+func mustKaToolResult(result *mcpruntime.ToolResult, err error) *mcpruntime.ToolResult {
+	if err != nil {
+		panic(fmt.Sprintf("build representative tool result: %v", err))
+	}
+	if result == nil {
+		panic("build representative tool result: nil result")
+	}
+	return result
+}
+
+func callMessageRequestHandlerForSchema(
+	t *testing.T,
+	wantOperation string,
+	response string,
+	handler func(context.Context, json.RawMessage) (*mcpruntime.ToolResult, error),
+	args string,
+) *mcpruntime.ToolResult {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/graphql" {
+			t.Fatalf("message-request handler request = %s %s, want POST /api/graphql", r.Method, r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Fatalf("message-request handler Authorization = %q, want bearer passthrough", got)
+		}
+		var request struct {
+			OperationName string `json:"operationName"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Fatalf("decode message-request GraphQL operation: %v", err)
+		}
+		if request.OperationName != wantOperation {
+			t.Fatalf("message-request GraphQL operation = %q, want %q", request.OperationName, wantOperation)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(response))
+	}))
+	t.Cleanup(func() {
+		server.Close()
+		lesserapi.ResetForTests()
+	})
+	t.Setenv("LESSER_API_BASE_URL", server.URL)
+	lesserapi.ResetForTests()
+
+	result, err := handler(articleDraftTestContext(), json.RawMessage(args))
+	if err != nil {
+		t.Fatalf("%s handler: %v", wantOperation, err)
+	}
+	if result == nil {
+		t.Fatalf("%s handler returned a nil result", wantOperation)
+	}
+	return result
+}
+
+func articleDraftPreviewOutputSchemaFixtures() []kaOutputSchemaFixture {
+	rendered := "<article><p>rendered preview</p></article>"
+	cases := []struct {
+		name    string
+		view    string
+		preview *cmsapi.DraftPreview
+	}{
+		{
+			name: "compact_success",
+			view: readViewCompact,
+			preview: &cmsapi.DraftPreview{
+				DraftID:       "draft-1",
+				Success:       true,
+				RenderedHTML:  &rendered,
+				SourceFormat:  cmsapi.ContentFormatMarkdown,
+				SourceBytes:   12,
+				RenderedBytes: len(rendered),
+			},
+		},
+		{
+			name: "compact_render_failure",
+			view: readViewCompact,
+			preview: &cmsapi.DraftPreview{
+				DraftID:      "draft-1",
+				Success:      false,
+				SourceFormat: cmsapi.ContentFormatMarkdown,
+				SourceBytes:  12,
+				Errors:       []string{"renderer rejected the draft"},
+			},
+		},
+		{
+			name: "standard_success",
+			view: readViewStandard,
+			preview: &cmsapi.DraftPreview{
+				DraftID:       "draft-1",
+				Success:       true,
+				RenderedHTML:  &rendered,
+				SourceFormat:  cmsapi.ContentFormatMarkdown,
+				SourceBytes:   12,
+				RenderedBytes: len(rendered),
+			},
+		},
+	}
+	fixtures := make([]kaOutputSchemaFixture, 0, len(cases))
+	for _, tc := range cases {
+		tc := tc
+		fixtures = append(fixtures, kaOutputSchemaFixture{
+			name: tc.name,
+			build: func(t *testing.T) *mcpruntime.ToolResult {
+				return mustKaToolResult(articleDraftPreviewResult(tc.preview, articleDraftViewParams{
+					View:         tc.view,
+					PreviewRunes: articleDraftPreviewRunes,
+				}))
+			},
+		})
+	}
+	return fixtures
+}
+
+func TestArticleDraftPreviewResultMatchesDeclaredOutputSchema(t *testing.T) {
+	t.Run("handler_compact_without_rendered_html", func(t *testing.T) {
+		newArticleDraftGraphQLTestServer(t, cmsapi.Draft{
+			ID:            "draft-1",
+			AuthorID:      "alice",
+			ContentType:   cmsapi.ObjectTypeArticle,
+			Content:       "Draft body",
+			ContentFormat: cmsapi.ContentFormatMarkdown,
+			Status:        cmsapi.DraftStatusDraft,
+		})
+		result, err := handleArticleDraftPreview(
+			articleDraftTestContext(),
+			json.RawMessage(`{"id":"draft-1","view":"compact"}`),
+		)
+		if err != nil {
+			t.Fatalf("article_draft_preview handler: %v", err)
+		}
+		assertKaResultMatchesDeclaredOutputSchema(
+			t,
+			"article_draft_preview/handler_compact_without_rendered_html",
+			articleDraftPreviewDef().OutputSchema,
+			result,
+		)
+	})
+
+	for _, fixture := range articleDraftPreviewOutputSchemaFixtures() {
+		fixture := fixture
+		t.Run(fixture.name, func(t *testing.T) {
+			assertKaResultMatchesDeclaredOutputSchema(t, fixture.name, articleDraftPreviewDef().OutputSchema, fixture.build(t))
+		})
+	}
+}

--- a/internal/mcpserver/mailbox_host_tools.go
+++ b/internal/mcpserver/mailbox_host_tools.go
@@ -438,6 +438,11 @@ func mailboxCompactListResult(standard map[string]any) map[string]any {
 		messages = append(messages, compactMailboxMessage(message))
 	}
 
+	notes := mailboxListNotes()
+	notes["messageRef"] = "messageRef is the canonical opaque host reference for email_get, email_get_content, state, and reply calls"
+	notes["preview"] = "compact preview is not duplicated into body; call email_get_content for full content when content.available is true"
+	notes["standardView"] = "call email_read with view=standard for compatibility aliases and repeated legacy notes"
+
 	out := map[string]any{
 		"source":     standard["source"],
 		"view":       readViewCompact,
@@ -445,14 +450,10 @@ func mailboxCompactListResult(standard map[string]any) map[string]any {
 		"count":      standard["count"],
 		"hasMore":    standard["hasMore"],
 		"nextCursor": standard["nextCursor"],
+		"nextSince":  standard["nextSince"],
 		"filters":    mailboxCompactFilters(standard),
-		"notes": map[string]any{
-			"authority":    "lesser-host Soul Comm Mailbox",
-			"messageRef":   "messageRef is the canonical opaque host reference for email_get, email_get_content, state, and reply calls",
-			"preview":      "compact preview is not duplicated into body; call email_get_content for full content when content.available is true",
-			"standardView": "call email_read with view=standard for compatibility aliases and repeated legacy notes",
-		},
-		"omitted": compactMailboxListOmissions(),
+		"notes":      notes,
+		"omitted":    compactMailboxListOmissions(),
 	}
 	if v := strings.TrimSpace(stringFromMap(standard, "folder")); v != "" {
 		out["folder"] = v

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -167,6 +167,10 @@ func registerTools(r *mcpruntime.ToolRegistry) error {
 		return fmt.Errorf("tool registry is nil")
 	}
 
+	if err := r.RegisterTool(describeInterfaceDef(), handleDescribeInterface); err != nil {
+		return err
+	}
+
 	if err := r.RegisterTool(mcpruntime.ToolDef{
 		Name:        "echo",
 		Description: "Echo back the provided message.",

--- a/internal/mcpserver/output_schemas.go
+++ b/internal/mcpserver/output_schemas.go
@@ -108,10 +108,9 @@ func postGetOutputSchema() json.RawMessage {
 					"id":{"type":"string"},
 					"view":{"type":"string"},
 					"source":{"type":"string"},
-					"status":{"type":"object","additionalProperties":true},
-					"statusRef":{"type":"object","additionalProperties":true}
+					"status":{"type":"object","additionalProperties":true}
 				},
-				"required":["id","view","source","status","statusRef"],
+				"required":["id","view","source","status"],
 				"additionalProperties":true
 			}
 		},

--- a/internal/mcpserver/post_get_test.go
+++ b/internal/mcpserver/post_get_test.go
@@ -1,0 +1,120 @@
+package mcpserver
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/equaltoai/lesser-body/internal/auth"
+	"github.com/equaltoai/lesser-body/internal/lesserapi"
+)
+
+func TestPostGetReturnsStatusOnceWithoutSelfExpansion(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/api/v1/statuses/post-1" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"post-1",
+			"url":"https://example.com/@alice/post-1",
+			"created_at":"2026-05-17T17:00:00Z",
+			"visibility":"public",
+			"content":"full status content",
+			"account":{"id":"acct-1","acct":"alice@example.com"}
+		}`))
+	}))
+	defer server.Close()
+
+	t.Setenv("LESSER_API_BASE_URL", server.URL)
+	lesserapi.ResetForTests()
+	t.Cleanup(lesserapi.ResetForTests)
+
+	ctx := auth.InjectToolContext(
+		context.Background(),
+		&auth.Principal{Type: auth.PrincipalTypeOAuthToken, Identity: "alice"},
+		"oauth-token",
+	)
+	result, err := handlePostGet(ctx, json.RawMessage(`{"id":"post-1","view":"standard"}`))
+	if err != nil {
+		t.Fatalf("handlePostGet: %v", err)
+	}
+	if result == nil || result.IsError {
+		t.Fatalf("unexpected post_get result: %+v", result)
+	}
+
+	data := normalizedToolResultData(t, result.StructuredContent)
+	if _, ok := data["statusRef"]; ok {
+		t.Fatalf("post_get must not duplicate status as statusRef: %+v", data)
+	}
+	status, ok := data["status"].(map[string]any)
+	if !ok || status["id"] != "post-1" || status["content"] != "full status content" {
+		t.Fatalf("post_get status = %+v", data["status"])
+	}
+	if containsPostGetExpansion(data) {
+		t.Fatalf("post_get must not point back at itself: %+v", data)
+	}
+
+	text := toolResultTextJSON(t, result)
+	if _, ok := text["statusRef"]; ok || containsPostGetExpansion(text) {
+		t.Fatalf("post_get text result contains duplicate/self expansion: %+v", text)
+	}
+}
+
+func TestPostGetOutputSchemaAdvertisesStatusOnce(t *testing.T) {
+	var schema map[string]any
+	if err := json.Unmarshal(postGetOutputSchema(), &schema); err != nil {
+		t.Fatalf("unmarshal post_get output schema: %v", err)
+	}
+	properties, _ := schema["properties"].(map[string]any)
+	dataSchema, _ := properties["data"].(map[string]any)
+	dataProperties, _ := dataSchema["properties"].(map[string]any)
+	if _, ok := dataProperties["status"]; !ok {
+		t.Fatalf("post_get schema must advertise status: %+v", dataProperties)
+	}
+	if _, ok := dataProperties["statusRef"]; ok {
+		t.Fatalf("post_get schema must not advertise duplicate statusRef: %+v", dataProperties)
+	}
+	required, _ := dataSchema["required"].([]any)
+	for _, name := range required {
+		if name == "statusRef" {
+			t.Fatalf("post_get schema still requires statusRef: %+v", required)
+		}
+	}
+}
+
+func normalizedToolResultData(t *testing.T, structured map[string]any) map[string]any {
+	t.Helper()
+	b, err := json.Marshal(structured["data"])
+	if err != nil {
+		t.Fatalf("marshal structured data: %v", err)
+	}
+	var data map[string]any
+	if err := json.Unmarshal(b, &data); err != nil {
+		t.Fatalf("unmarshal structured data: %v", err)
+	}
+	return data
+}
+
+func containsPostGetExpansion(value any) bool {
+	switch typed := value.(type) {
+	case map[string]any:
+		if typed["tool"] == "post_get" {
+			return true
+		}
+		for _, child := range typed {
+			if containsPostGetExpansion(child) {
+				return true
+			}
+		}
+	case []any:
+		for _, child := range typed {
+			if containsPostGetExpansion(child) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/mcpserver/social_refs.go
+++ b/internal/mcpserver/social_refs.go
@@ -3,6 +3,7 @@ package mcpserver
 import "strings"
 
 const socialStatusContentPreviewRunes = 500
+const socialExpansionResultPath = "content[0].text"
 
 type AccountRef struct {
 	ID            string   `json:"id,omitempty"`
@@ -97,12 +98,12 @@ func compactSocialStatusRefWithPreview(raw map[string]any, previewRunes int) *St
 		"visibility": ref.Visibility,
 	})
 	if id != "" {
-		ref.Expand = socialPostGetExpansion(id, readViewStandard, "structuredContent.data.status")
+		ref.Expand = socialPostGetExpansion(id, readViewStandard)
 		if content != "" {
 			ref.Omitted = []SocialOmittedRef{{
 				Path:   "content",
 				Reason: "content_preview",
-				Expand: *socialPostGetExpansion(id, readViewStandard, "structuredContent.data.status.content"),
+				Expand: *socialPostGetExpansion(id, readViewStandard),
 			}}
 		}
 	}
@@ -141,7 +142,7 @@ func socialStatusStandardPayload(raw map[string]any) map[string]any {
 	return status
 }
 
-func socialPostGetExpansion(id string, view string, resultPath string) *SocialExpansionRef {
+func socialPostGetExpansion(id string, view string) *SocialExpansionRef {
 	id = strings.TrimSpace(id)
 	if id == "" {
 		return nil
@@ -156,11 +157,11 @@ func socialPostGetExpansion(id string, view string, resultPath string) *SocialEx
 			"id":   id,
 			"view": view,
 		},
-		ResultPath: strings.TrimSpace(resultPath),
+		ResultPath: socialExpansionResultPath,
 	}
 }
 
-func socialConversationGetExpansion(conversationID string, view string, resultPath string) *SocialExpansionRef {
+func socialConversationGetExpansion(conversationID string, view string) *SocialExpansionRef {
 	conversationID = strings.TrimSpace(conversationID)
 	if conversationID == "" {
 		return nil
@@ -175,7 +176,7 @@ func socialConversationGetExpansion(conversationID string, view string, resultPa
 			"conversationId": conversationID,
 			"view":           view,
 		},
-		ResultPath: strings.TrimSpace(resultPath),
+		ResultPath: socialExpansionResultPath,
 	}
 }
 

--- a/internal/mcpserver/social_refs_test.go
+++ b/internal/mcpserver/social_refs_test.go
@@ -81,7 +81,7 @@ func TestCompactSocialStatusRefNamesOmissionsAndExpansionPath(t *testing.T) {
 	if omitted.Path != "content" || omitted.Reason != "content_preview" {
 		t.Fatalf("unexpected omitted metadata: %+v", omitted)
 	}
-	if omitted.Expand.Tool != "post_get" || omitted.Expand.Arguments["id"] != "post-1" || omitted.Expand.ResultPath != "structuredContent.data.status.content" {
+	if omitted.Expand.Tool != "post_get" || omitted.Expand.Arguments["id"] != "post-1" || omitted.Expand.ResultPath != socialExpansionResultPath {
 		t.Fatalf("unexpected omitted expansion path: %+v", omitted.Expand)
 	}
 
@@ -118,5 +118,41 @@ func TestSocialStatusStandardPayloadIncludesFullContentForExpansion(t *testing.T
 	author, _ := status["authorRef"].(*AccountRef)
 	if author == nil || author.ID != "acct-2" || author.Acct != "bob@example.com" {
 		t.Fatalf("expected standard expansion author ref, got %+v", status["authorRef"])
+	}
+}
+
+func TestSocialPerItemExpansionsPointAtTextResultSurface(t *testing.T) {
+	tests := []struct {
+		name      string
+		expansion *SocialExpansionRef
+	}{
+		{
+			name:      "post",
+			expansion: socialPostGetExpansion("post-1", readViewStandard),
+		},
+		{
+			name:      "post content",
+			expansion: socialPostGetExpansion("post-1", readViewStandard),
+		},
+		{
+			name:      "conversation",
+			expansion: socialConversationGetExpansion("conversation-1", readViewCompact),
+		},
+		{
+			name:      "notification",
+			expansion: socialNotificationGetExpansion("notification-1", readViewStandard),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.expansion == nil {
+				t.Fatal("expected expansion metadata")
+			}
+			if tt.expansion.ResultPath != socialExpansionResultPath ||
+				strings.Contains(tt.expansion.ResultPath, "structuredContent") {
+				t.Fatalf("per-item expansion is structuredContent-only: %+v", tt.expansion)
+			}
+		})
 	}
 }

--- a/internal/mcpserver/social_tools.go
+++ b/internal/mcpserver/social_tools.go
@@ -1060,7 +1060,7 @@ func compactSocialConversationRef(raw map[string]any, previewRunes int) map[stri
 	ref := map[string]any{}
 	putIfNotEmpty(ref, "id", id)
 	if id != "" {
-		ref["expand"] = socialConversationGetExpansion(id, readViewCompact, "structuredContent.data.conversation")
+		ref["expand"] = socialConversationGetExpansion(id, readViewCompact)
 	}
 	if unread, ok := firstBoolMap(raw, "unread", "is_unread", "isUnread"); ok {
 		ref["unread"] = unread
@@ -1202,7 +1202,7 @@ func compactConversationLastPostRef(raw map[string]any, previewRunes int) map[st
 	putIfNotEmpty(ref, "contentPreview", preview)
 	ref["contentTruncated"] = truncated
 	if id != "" {
-		ref["expand"] = socialPostGetExpansion(id, readViewStandard, "structuredContent.data.status")
+		ref["expand"] = socialPostGetExpansion(id, readViewStandard)
 	} else if content != "" {
 		ref["missingFields"] = []string{"id"}
 		ref["omitted"] = []map[string]any{{
@@ -1636,7 +1636,7 @@ func compactSocialNotificationRef(raw map[string]any, previewRunes int) map[stri
 		ref["missingFields"] = missing
 	}
 	if id != "" {
-		ref["expand"] = socialNotificationGetExpansion(id, readViewStandard, "structuredContent.data.notification")
+		ref["expand"] = socialNotificationGetExpansion(id, readViewStandard)
 	}
 	if len(ref) == 0 {
 		return nil
@@ -1662,7 +1662,7 @@ func compactNotificationStatusRef(raw map[string]any, previewRunes int) map[stri
 	putIfNotEmpty(ref, "contentPreview", preview)
 	ref["contentTruncated"] = truncated
 	if expandID := compactNotificationStatusPostGetID(raw); expandID != "" {
-		ref["expand"] = socialPostGetExpansion(expandID, readViewStandard, "structuredContent.data.status")
+		ref["expand"] = socialPostGetExpansion(expandID, readViewStandard)
 	}
 	if len(ref) == 1 {
 		return nil
@@ -1732,7 +1732,7 @@ func compactSocialNotificationCommunicationRef(raw map[string]any) map[string]an
 	return out
 }
 
-func socialNotificationGetExpansion(id string, view string, resultPath string) *SocialExpansionRef {
+func socialNotificationGetExpansion(id string, view string) *SocialExpansionRef {
 	id = strings.TrimSpace(id)
 	if id == "" {
 		return nil
@@ -1747,7 +1747,7 @@ func socialNotificationGetExpansion(id string, view string, resultPath string) *
 			"id":   id,
 			"view": view,
 		},
-		ResultPath: strings.TrimSpace(resultPath),
+		ResultPath: socialExpansionResultPath,
 	}
 }
 
@@ -1763,7 +1763,7 @@ func compactNotificationListOmissions() []any {
 			"reason":                "debug_payload",
 			"expansionTool":         "notification_get",
 			"expansionArgsTemplate": map[string]any{"id": "structuredContent.data.notifications[].id", "view": readViewFull},
-			"resultPath":            "structuredContent.data.notification",
+			"resultPath":            socialExpansionResultPath,
 		},
 		map[string]any{
 			"path":      "notifications[].targetPost.content",

--- a/internal/mcpserver/social_tools.go
+++ b/internal/mcpserver/social_tools.go
@@ -1810,54 +1810,55 @@ func socialStructuredFirstResult(toolName string, summary string, payload map[st
 	})
 }
 
-func socialTextAccessibleProjection(toolName string, payload map[string]any) string {
+func socialTextAccessibleProjection(toolName string, payload map[string]any) map[string]any {
 	switch toolName {
 	case "timeline_read", "post_search":
-		if projection := socialTextProjectionFromItems(firstArrayFromAny(payload, "statuses"), "contentPreview", 32, true); projection != "" {
-			return projection
+		if projection := socialTextProjectionFromItems(firstArrayFromAny(payload, "statuses"), "contentPreview", 32, true); len(projection) > 0 {
+			return map[string]any{"items": projection}
 		}
 	case "conversations_read":
-		if projection := socialTextProjectionFromItems(firstArrayFromAny(payload, "conversations"), "lastPostRef.contentPreview", 20, true); projection != "" {
-			return projection
+		if projection := socialTextProjectionFromItems(firstArrayFromAny(payload, "conversations"), "lastPostRef.contentPreview", 20, true); len(projection) > 0 {
+			return map[string]any{"items": projection}
 		}
 	case "notifications_read":
-		if projection := socialTextProjectionFromItems(firstArrayFromAny(payload, "notifications"), "targetPostRef.contentPreview", notificationCompactListPreviewRunes, true); projection != "" {
+		if projection := socialTextProjectionFromItems(firstArrayFromAny(payload, "notifications"), "targetPostRef.contentPreview", notificationCompactListPreviewRunes, true); len(projection) > 0 {
+			textPayload := map[string]any{"items": projection}
 			if filter, _ := payload["filter"].(map[string]any); filter != nil {
 				if strategy := firstNonEmptyStringMap(filter, "strategy"); strategy != "" {
-					return "filter=" + strategy + "\n" + projection
+					textPayload["filter"] = strategy
 				}
 			}
-			return projection
+			return textPayload
 		}
 	case "conversation_get":
 		if conversation, _ := payload["conversation"].(map[string]any); conversation != nil {
-			if projection := socialTextProjectionFromItems(firstArrayFromAny(conversation, "messageRefs"), "contentPreview", 48, true); projection != "" {
-				return projection
+			if projection := socialTextProjectionFromItems(firstArrayFromAny(conversation, "messageRefs"), "contentPreview", 48, true); len(projection) > 0 {
+				return map[string]any{"items": projection}
 			}
 			messages := firstArrayFromAny(conversation, "messages")
-			if projection := socialTextProjectionFromItems(messages, "contentPreview", 48, true); projection != "" {
-				return projection
+			if projection := socialTextProjectionFromItems(messages, "contentPreview", 48, true); len(projection) > 0 {
+				return map[string]any{"items": projection}
 			}
-			if projection := socialTextProjectionFromItems(messages, "content", 96, true); projection != "" {
-				return projection
+			if projection := socialTextProjectionFromItems(messages, "content", 96, true); len(projection) > 0 {
+				return map[string]any{"items": projection}
 			}
 		}
 	case "direct_messages_read":
 		messages := firstArrayFromAny(payload, "messages")
-		if projection := socialTextProjectionFromItems(messages, "contentPreview", 48, true); projection != "" {
-			return projection
+		if projection := socialTextProjectionFromItems(messages, "contentPreview", 48, true); len(projection) > 0 {
+			return map[string]any{"items": projection}
 		}
-		if projection := socialTextProjectionFromItems(messages, "content", 96, true); projection != "" {
-			return projection
+		if projection := socialTextProjectionFromItems(messages, "content", 96, true); len(projection) > 0 {
+			return map[string]any{"items": projection}
 		}
 	}
 	return socialTextProjectionFallback(payload, 1024)
 }
 
-func socialTextProjectionFromItems(items []any, previewPath string, previewRunes int, includeID bool) string {
+func socialTextProjectionFromItems(items []any, previewPath string, previewRunes int, includeID bool) []string {
 	lines := make([]string, 0, len(items))
 	for _, item := range items {
-		record, _ := item.(map[string]any)
+		record := socialTextProjectionRecord(item)
 		if record == nil {
 			continue
 		}
@@ -1869,13 +1870,28 @@ func socialTextProjectionFromItems(items []any, previewPath string, previewRunes
 		id := firstNonEmptyStringMap(record, "id", "conversationId", "messageId")
 		line := preview
 		if includeID && id != "" {
-			line = id + ": " + preview
+			line = id + ":" + preview
 		}
 		if strings.TrimSpace(line) != "" {
 			lines = append(lines, line)
 		}
 	}
-	return strings.Join(lines, "\n")
+	return lines
+}
+
+func socialTextProjectionRecord(item any) map[string]any {
+	if record, ok := item.(map[string]any); ok {
+		return record
+	}
+	b, err := json.Marshal(item)
+	if err != nil {
+		return nil
+	}
+	var record map[string]any
+	if err := json.Unmarshal(b, &record); err != nil {
+		return nil
+	}
+	return record
 }
 
 func nestedStringMap(record map[string]any, path string) string {
@@ -1892,17 +1908,14 @@ func nestedStringMap(record map[string]any, path string) string {
 	return strings.TrimSpace(value)
 }
 
-func socialTextProjectionFallback(payload map[string]any, maxRunes int) string {
+func socialTextProjectionFallback(payload map[string]any, maxRunes int) map[string]any {
 	values := make([]string, 0)
 	collectSocialTextProjectionValues(payload, "", &values)
 	if len(values) == 0 {
-		b, err := json.Marshal(payload)
-		if err != nil {
-			return ""
-		}
-		return compactString(string(b), maxRunes)
+		return map[string]any{"items": []string{}}
 	}
-	return compactString(strings.Join(values, "\n"), maxRunes)
+	rendered := compactString(strings.Join(values, "\n"), maxRunes)
+	return map[string]any{"items": strings.Split(rendered, "\n")}
 }
 
 func collectSocialTextProjectionValues(value any, path string, values *[]string) {

--- a/internal/mcpserver/social_tools.go
+++ b/internal/mcpserver/social_tools.go
@@ -543,10 +543,9 @@ func handlePostGet(ctx context.Context, args json.RawMessage) (*mcpruntime.ToolR
 		statusID = in.ID
 	}
 	payload := map[string]any{
-		"id":        statusID,
-		"view":      view,
-		"source":    "lesser-api",
-		"statusRef": compactSocialStatusRef(status),
+		"id":     statusID,
+		"view":   view,
+		"source": "lesser-api",
 	}
 	if view == readViewFull {
 		payload["status"] = status

--- a/internal/mcpserver/tool_results_accessibility_test.go
+++ b/internal/mcpserver/tool_results_accessibility_test.go
@@ -114,6 +114,9 @@ func TestStructuredFirstReadToolsExposeSubstantiveTextData(t *testing.T) {
 			if text["access"] != "payload or structuredContent.data" {
 				t.Fatalf("text guidance must name both result surfaces: %#v", text["access"])
 			}
+			if _, stringEncoded := text["payload"].(string); stringEncoded {
+				t.Fatalf("text payload must be a nested JSON value, not a string: %#v", text["payload"])
+			}
 			structuredData, _ := result.StructuredContent["data"].(map[string]any)
 			if structuredData["marker"] != sentinel {
 				t.Fatalf("structuredContent.data changed: %#v", result.StructuredContent)
@@ -178,9 +181,12 @@ func TestCompactTimelineTextHonorsPreviewChars(t *testing.T) {
 		t.Fatalf("unexpected tool error: %+v", result)
 	}
 	text := toolResultTextJSON(t, result)
-	textPayload, _ := text["payload"].(string)
-	if !strings.Contains(textPayload, "abcdefg…") {
-		t.Fatalf("preview_chars was not preserved in text payload: %q", textPayload)
+	textPayload, ok := text["payload"].(map[string]any)
+	if !ok {
+		t.Fatalf("text payload must be a nested JSON object, got %#v", text["payload"])
+	}
+	if !strings.Contains(result.Content[0].Text, "abcdefg…") {
+		t.Fatalf("preview_chars was not preserved in text payload: %#v", textPayload)
 	}
 	if strings.Contains(result.Content[0].Text, fullContent) {
 		t.Fatalf("text data leaked content beyond preview_chars: %s", result.Content[0].Text)

--- a/internal/mcpserver/tool_scopes.go
+++ b/internal/mcpserver/tool_scopes.go
@@ -29,8 +29,9 @@ const StrictestToolScope = ScopeAdmin
 // registered tool. Adding a tool without adding it here is a test failure, not a
 // silent read-scope grant.
 var toolScopes = map[string][]string{
-	// Diagnostics.
-	"echo": {ScopeRead},
+	// Bootstrap and diagnostics.
+	"describe_interface": {ScopeRead},
+	"echo":               {ScopeRead},
 
 	// Social reads.
 	"profile_read":          {ScopeRead},

--- a/internal/runtimepolicy/runtimepolicy.go
+++ b/internal/runtimepolicy/runtimepolicy.go
@@ -53,6 +53,7 @@ var profileContracts = map[Profile]Contract{
 		CommunicationsEnabled: false,
 		WalletAccessEnabled:   false,
 		Tools: []string{
+			"describe_interface",
 			"echo",
 			"profile_read",
 			"timeline_read",
@@ -115,6 +116,7 @@ var profileContracts = map[Profile]Contract{
 		CommunicationsEnabled: true,
 		WalletAccessEnabled:   true,
 		Tools: []string{
+			"describe_interface",
 			"echo",
 			"profile_read",
 			"timeline_read",


### PR DESCRIPTION
## Promotion: staging → main

ka usability batch from the ka↔theorymcp exploration (research-team feedback):

- PR #494 `fix(mcp): ka read polish` (`Closes #491`) — nested `payload` objects (no more double-encoded JSON), per-item expansion paths point at `content[0].text`, circular `post_get` statusRef removed. **Consumer note:** clients hardcoded to string-valued `payload` or `statusRef` must adapt.
- PR #495 `feat(mcp): add describe_interface bootstrap` (`Closes #492`) — one-call onboarding: grouped tool inventory, recommended workflows, budgeting/expansion conventions, identity context; 52-tool drift guard.
- PR #496 `fix(mcp): enforce ka output schema conformance` (`Closes #493`) — fixes the research team's `article_draft_preview` failure (`omitted: null` vs array), a latent `email_read` compact-field drop, and adds a ka-wide conformance guard over all 52 registered tools.

Opened by factory via gh (operator-authorized path for promotion PRs; agent routes refuse a staging head).