### PR TITLE
test(mcp): pin review verdict budget fixture at 2 verdicts per review

### DIFF
--- a/internal/mcpserver/article_review_tools_test.go
+++ b/internal/mcpserver/article_review_tools_test.go
@@ -146,7 +146,7 @@ func TestArticleDraftReviewDefaultQueueFitsDefaultBudget(t *testing.T) {
 			}
 			for i := 0; i < tc.count; i++ {
 				queue.Edges = append(queue.Edges, cmsapi.DraftReviewEdge{
-					Node:   realisticDraftReviewFixture(i),
+					Node:   realisticDraftReviewFixture(i, 1),
 					Cursor: fmt.Sprintf("review-queue-cursor-%02d", i),
 				})
 			}
@@ -170,13 +170,64 @@ func TestArticleDraftReviewDefaultQueueFitsDefaultBudget(t *testing.T) {
 	}
 }
 
-func realisticDraftReviewFixture(index int) *cmsapi.DraftReview {
+// Lesser keeps immutable verdict history without a finite record cap. Two pins
+// the first ordinary re-review round without pretending the history is bounded.
+const realisticDraftReviewPinnedVerdictCount = 2
+
+func TestArticleDraftReviewBudgetGuardRejectsPinnedVerdictHistoryDrift(t *testing.T) {
+	queue := &cmsapi.DraftReviewConnection{
+		Edges:      make([]cmsapi.DraftReviewEdge, 0, articleDraftReviewDefaultLimit),
+		TotalCount: articleDraftReviewDefaultLimit,
+	}
+	for i := 0; i < articleDraftReviewDefaultLimit; i++ {
+		queue.Edges = append(queue.Edges, cmsapi.DraftReviewEdge{
+			Node:   realisticDraftReviewFixture(i, realisticDraftReviewPinnedVerdictCount),
+			Cursor: fmt.Sprintf("review-queue-cursor-%02d", i),
+		})
+	}
+
+	result, err := articleDraftReviewQueueResult(queue, articleDraftReviewDefaultLimit, articleDraftReviewBudgetBytes)
+	if err != nil {
+		t.Fatalf("articleDraftReviewQueueResult: %v", err)
+	}
+	if !result.IsError {
+		t.Fatalf("expected pinned %d-verdict history to trip the %d-byte default budget guard", realisticDraftReviewPinnedVerdictCount, articleDraftReviewBudgetBytes)
+	}
+
+	errorPayload, ok := result.StructuredContent["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("budget guard error payload = %+v", result.StructuredContent)
+	}
+	details, ok := errorPayload["details"].(map[string]any)
+	if !ok {
+		t.Fatalf("budget guard details = %+v", errorPayload)
+	}
+	measuredBytes, ok := details["measuredBytes"].(int)
+	if errorPayload["code"] != "response_too_large" || errorPayload["status"] != 413 ||
+		!strings.Contains(fmt.Sprint(errorPayload["message"]), "exceeds max_output_bytes") ||
+		!ok || measuredBytes <= articleDraftReviewBudgetBytes ||
+		details["maxOutputBytes"] != articleDraftReviewBudgetBytes ||
+		details["guidance"] != "reduce queue limit or increase max_output_bytes" {
+		t.Fatalf("budget guard must fail loudly with measured recovery details: %+v", errorPayload)
+	}
+	t.Logf("realistic queue envelope at n=%d with %d verdicts/review: %d bytes (budget %d)", articleDraftReviewDefaultLimit, realisticDraftReviewPinnedVerdictCount, measuredBytes, articleDraftReviewBudgetBytes)
+}
+
+func realisticDraftReviewFixture(index, verdictCount int) *cmsapi.DraftReview {
 	title := fmt.Sprintf("Review-ready architecture note %02d: preserve Lesser authority", index)
 	subtitle := "An agent-generated draft with reviewer attribution and editorial context"
 	excerpt := "Body transports Lesser's caller-authorized review state without creating local review semantics."
 	reviewStatus := cmsapi.DraftReviewVerdictChangesRequested
 	editorNotes := "Clarify the authority boundary and retain the deployment evidence."
 	verdictNotes := "Revise the authority paragraph before requesting publication."
+	verdicts := make([]cmsapi.DraftReviewVerdictRecord, 0, verdictCount)
+	for range verdictCount {
+		verdicts = append(verdicts, cmsapi.DraftReviewVerdictRecord{
+			Verdict:    cmsapi.DraftReviewVerdictChangesRequested,
+			Notes:      &verdictNotes,
+			RecordedAt: "2026-07-31T12:01:00Z",
+		})
+	}
 	return &cmsapi.DraftReview{
 		DraftID:       fmt.Sprintf("draft-realistic-review-%02d", index),
 		Title:         &title,
@@ -191,11 +242,7 @@ func realisticDraftReviewFixture(index int) *cmsapi.DraftReview {
 		ReviewStatus:  &reviewStatus,
 		EditorNotes:   &editorNotes,
 		Grant:         &cmsapi.DraftReviewGrant{GrantedAt: "2026-07-31T11:30:00Z"},
-		Verdicts: []cmsapi.DraftReviewVerdictRecord{{
-			Verdict:    cmsapi.DraftReviewVerdictChangesRequested,
-			Notes:      &verdictNotes,
-			RecordedAt: "2026-07-31T12:01:00Z",
-		}},
+		Verdicts:      verdicts,
 	}
 }
 


### PR DESCRIPTION
## Scope

Follow-up wrap-up batch, stream B — equaltoai/lesser-body#508 (filed from claude's adversarial re-review of #507, finding N1). Refs #508.

**Supersedes #509** — identical head (`e1cd7d5f5694218098bfead1a63cdd46ee23ceb0`), re-branched under the body prefix because `gov-verify-rubric.sh` GOV-3 (pull_request path) allowlists `theorymcp/equaltoai/body/` but not the factory prefix; #509's CI was red on branch authorization alone. The completed cross-client review (pullrequestreview-4834743148 on #509) reviewed this exact SHA and carries.

## Change

`internal/mcpserver/article_review_tools_test.go` only:

- Parameterized the fixture's verdict count.
- Pinned the drift case at **2 verdicts per review** — the narrowest realistic re-review cycle. lesser retains ordered immutable verdict history with **no finite cap** (verified: `ListDraftReviewVerdicts` uses `.All(&rows)`, contract exposes `verdicts` as a plain list, deliberately not a Connection), so 2 pins the smallest count that exercises the drift without asserting a maximum.
- Guard still fails loudly: self-describing `response_too_large`, status 413, measured/max bytes, retry guidance. No truncation.
- No review-tool contract or production behavior changes.

## Measurements (independently reproduced by the reviewer)

| Fixture | Envelope |
|---|---|
| Before: 1 verdict/review, limit 5 | 10,612 B (fits) |
| Pinned: 2 verdicts/review, limit 5 | 12,072 B (**72 B over** → loud rejection) |
| Budget | 12,000 B |

## Validation

- Targeted budget-guard suite, `go build/test/vet ./...`, `gofmt -l` (empty), `git diff --check`, `bash scripts/build.sh` — all pass.
- Rubric local: PASS 19/19 at head (note: GOV-3's branch-prefix rule evaluates only on the pull_request path — the red on #509 was branch authorization, not evidence).

## DCO evidence

```
e1cd7d5f5694218098bfead1a63cdd46ee23ceb0 aron23@gmail.com Aron Price <aron23@gmail.com>
```

## Chain

Implementing client: **codex** (delegate session, brief /tmp/brief-body-508.md, assignment issuecomment-5151546300). Cross-client review: **claude**, pullrequestreview-4834743148 at this SHA — substantive work approved (measurements reproduced, no-cap claim verified against lesser source); three low findings carried as follow-ups (guard hardcodes the budget constant instead of exercising `reviewOutputBudget`; retry guidance non-actionable past ~33 verdicts on one draft — pre-existing; one refuted question). Factory evidence review and merge follow CI.