### PR TITLE
test(mcp): bind review budget fixtures to production

### DIFF
--- a/internal/mcpserver/article_review_tools_test.go
+++ b/internal/mcpserver/article_review_tools_test.go
@@ -131,6 +131,7 @@ func TestArticleDraftReviewHandlersDelegateToLesser(t *testing.T) {
 }
 
 func TestArticleDraftReviewDefaultQueueFitsDefaultBudget(t *testing.T) {
+	budget := reviewOutputBudget(0)
 	for _, tc := range []struct {
 		name  string
 		count int
@@ -151,7 +152,7 @@ func TestArticleDraftReviewDefaultQueueFitsDefaultBudget(t *testing.T) {
 				})
 			}
 
-			result, err := articleDraftReviewQueueResult(queue, tc.count, articleDraftReviewBudgetBytes)
+			result, err := articleDraftReviewQueueResult(queue, tc.count, budget)
 			if err != nil {
 				t.Fatalf("articleDraftReviewQueueResult: %v", err)
 			}
@@ -162,8 +163,8 @@ func TestArticleDraftReviewDefaultQueueFitsDefaultBudget(t *testing.T) {
 			if err != nil {
 				t.Fatalf("measureToolResultPayload: %v", err)
 			}
-			if measurement.JSONRPCEnvelopeBytes > articleDraftReviewBudgetBytes {
-				t.Fatalf("realistic queue envelope at n=%d measured %d bytes, budget %d", tc.count, measurement.JSONRPCEnvelopeBytes, articleDraftReviewBudgetBytes)
+			if measurement.JSONRPCEnvelopeBytes > budget {
+				t.Fatalf("realistic queue envelope at n=%d measured %d bytes, budget %d", tc.count, measurement.JSONRPCEnvelopeBytes, budget)
 			}
 			t.Logf("realistic queue envelope at n=%d: %d bytes", tc.count, measurement.JSONRPCEnvelopeBytes)
 		})
@@ -175,6 +176,7 @@ func TestArticleDraftReviewDefaultQueueFitsDefaultBudget(t *testing.T) {
 const realisticDraftReviewPinnedVerdictCount = 2
 
 func TestArticleDraftReviewBudgetGuardRejectsPinnedVerdictHistoryDrift(t *testing.T) {
+	budget := reviewOutputBudget(0)
 	queue := &cmsapi.DraftReviewConnection{
 		Edges:      make([]cmsapi.DraftReviewEdge, 0, articleDraftReviewDefaultLimit),
 		TotalCount: articleDraftReviewDefaultLimit,
@@ -186,12 +188,12 @@ func TestArticleDraftReviewBudgetGuardRejectsPinnedVerdictHistoryDrift(t *testin
 		})
 	}
 
-	result, err := articleDraftReviewQueueResult(queue, articleDraftReviewDefaultLimit, articleDraftReviewBudgetBytes)
+	result, err := articleDraftReviewQueueResult(queue, articleDraftReviewDefaultLimit, budget)
 	if err != nil {
 		t.Fatalf("articleDraftReviewQueueResult: %v", err)
 	}
 	if !result.IsError {
-		t.Fatalf("expected pinned %d-verdict history to trip the %d-byte default budget guard", realisticDraftReviewPinnedVerdictCount, articleDraftReviewBudgetBytes)
+		t.Fatalf("expected pinned %d-verdict history to trip the %d-byte default budget guard", realisticDraftReviewPinnedVerdictCount, budget)
 	}
 
 	errorPayload, ok := result.StructuredContent["error"].(map[string]any)
@@ -205,12 +207,12 @@ func TestArticleDraftReviewBudgetGuardRejectsPinnedVerdictHistoryDrift(t *testin
 	measuredBytes, ok := details["measuredBytes"].(int)
 	if errorPayload["code"] != "response_too_large" || errorPayload["status"] != 413 ||
 		!strings.Contains(fmt.Sprint(errorPayload["message"]), "exceeds max_output_bytes") ||
-		!ok || measuredBytes <= articleDraftReviewBudgetBytes ||
-		details["maxOutputBytes"] != articleDraftReviewBudgetBytes ||
+		!ok || measuredBytes <= budget ||
+		details["maxOutputBytes"] != budget ||
 		details["guidance"] != "reduce queue limit or increase max_output_bytes" {
 		t.Fatalf("budget guard must fail loudly with measured recovery details: %+v", errorPayload)
 	}
-	t.Logf("realistic queue envelope at n=%d with %d verdicts/review: %d bytes (budget %d)", articleDraftReviewDefaultLimit, realisticDraftReviewPinnedVerdictCount, measuredBytes, articleDraftReviewBudgetBytes)
+	t.Logf("realistic queue envelope at n=%d with %d verdicts/review: %d bytes (budget %d)", articleDraftReviewDefaultLimit, realisticDraftReviewPinnedVerdictCount, measuredBytes, budget)
 }
 
 func realisticDraftReviewFixture(index, verdictCount int) *cmsapi.DraftReview {


### PR DESCRIPTION
## Summary

The F1 budget-guard fixtures (from #510) hardcoded the budget via the test-local `articleDraftReviewBudgetBytes` instead of exercising the production `reviewOutputBudget` symbol — zero tests referenced production, so a future budget change would silently leave the guard green against its own copy (the silent-drift class #508 exists to prevent, in the opposite direction).

Both sibling fixtures now derive the boundary from `reviewOutputBudget(0)`; the 2-verdicts-per-review pin from #510 is unchanged; the unbounded `ListDraftReviewVerdicts` shape is untouched (recorded as pre-existing context in the issue).

Closes #511

## Change shape

- `internal/mcpserver/article_review_tools_test.go` only — 10 insertions / 8 deletions, test-only.

## Validation (at head `3dfa1b883e1d9135ad38d046f935f1a62b96057b`)

- Targeted review-budget tests: PASS — under-budget `10,612 < 12,000`; pinned two-verdict case `12,072 > 12,000` (both now measured against the production constant)
- `go test ./...`: PASS; `go vet ./...`: PASS; `gofmt -l .`: clean
- `bash scripts/build.sh`: PASS
- `golangci-lint run --new-from-rev=staging ./...`: 0 issues (full-tree exploratory run reports 46 pre-existing unconfigured findings on unchanged staging — out of scope)
- `cd cdk && npm ci`: PASS, 0 vulnerabilities
- Governance rubric: **PASS — 19/19** at exact HEAD

GPG-signed commit, DCO sign-off matches author, `Refs #511` in body. Implemented in an isolated worktree; the registered checkout's pre-existing materialized `install-marker.json` modification is preserved untouched.

---
**Supersedes #519** — identical head SHA `3dfa1b883e1d9135ad38d046f935f1a62b96057b`, branch renamed to the repo's authorized feature prefix (`theorymcp/equaltoai/body/`) after GOV-3 lineage correctly rejected the misnamed `theorymcp/equaltoai/lesser-body/` source. Naming error was factory's, in the delegate brief.
