### PR TITLE
fix(mcp): prevent pre-dispatch concurrency failures

### DIFF
--- a/docs/investigation-silas-mcp-read-failures-2026-08-10.md
+++ b/docs/investigation-silas-mcp-read-failures-2026-08-10.md
@@ -1,0 +1,81 @@
+# Investigation: Silas MCP read failures (2026-08-10)
+
+## Reported symptom
+
+> Inbox-wide `conversations_read` fails with `-32603 Internal error`. Incoming-notifications read fails with the same
+> error. Only the Della-specific lookup completed normally, returning `404 conversation not found`.
+
+## Dimensions
+
+- Surface: authenticated Ka JSON-RPC at `POST /mcp/{actor}`.
+- Tools: `conversations_read`, `notifications_read`, and `direct_messages_read`; all are read-scoped social tools.
+- Caller: reported as Silas Vane on TheoryLive, souled profile. The client-side correlation ids were not available.
+- Deployment: TheoryLive Body `v1.6.12`, deployed at 2026-08-10 14:51 UTC.
+
+## Verified evidence
+
+- The Silas Lesser soul/body binding exists and maps `silas-vane` to its bound agent id.
+- At 15:51:27, 15:51:34, 15:51:47, and 15:51:50 UTC, API Gateway returned HTTP 502 for Ka POST requests before
+  tool dispatch.
+- Matching Body cold starts panicked while synchronously probing
+  `/.well-known/oauth-authorization-server`; the probe received HTTP 503 from the saturated Lesser API.
+- The AWS account concurrency quota is 10. Body reached 10 concurrent executions in the same window and Lambda
+  throttled additional requests. Seven long-lived initial Ka GET listeners were consuming most of that pool for about
+  25 seconds at a time.
+- No failed broad read reached Body's tool-call audit boundary or Lesser's `/api/v1/conversations` or
+  `/api/v1/notifications` handlers. The failure therefore preceded tool behavior and did not depend on Silas's social
+  content.
+- The only correlated focused lookup in that window reached Lesser as `della-marlowe` and returned the expected 404.
+  Without the client's correlation id, that request cannot be proven to be the exact lookup described in the report.
+
+## Fix-locus verdict
+
+Fix in Body. Two Body availability choices combined into a feedback loop:
+
+1. Actor Lambda process startup depended on a public OAuth metadata request through the same constrained Lambda pool.
+2. Body opted AppTheory's otherwise optional idle session listener into a 25-second hold, allowing connected clients to
+   consume nearly the entire stage concurrency pool.
+
+The social read handlers and Lesser response normalizers are not the fix locus for this incident.
+
+## MCP contract audit
+
+- `.well-known/mcp.json`: unchanged.
+- OAuth protected-resource metadata: response shape, per-actor resource identifier, issuer, scopes, and cache contract
+  remain unchanged on success. Issuer resolution moves from process startup to the metadata request. A temporary
+  authorization-server failure now returns sanitized HTTP 503 with `Cache-Control: no-store` rather than crashing the
+  entire Ka process.
+- JSON-RPC request/response shapes: unchanged.
+- Initial session GET: remains a successful `text/event-stream` response with a keepalive, but closes immediately as
+  MCP permits. Resumable GET requests carrying `Last-Event-ID` still reach AppTheory's durable stream replay path.
+- Compatibility: semantic availability refinement; no endpoint, schema, scope, profile, or protocol version changes.
+  Claude/Codex, AgentCore, and other conforming Streamable HTTP clients may reconnect after the server closes the
+  optional idle stream. POST request/response streaming and resumability are retained.
+
+## Lesser-integration audit
+
+- JWT validation and shared-secret handling: unchanged.
+- Lesser DynamoDB access: only the existing read-only trust configuration load remains; no new access pattern or write.
+- Lesser REST API: social endpoint requests and response shapes are unchanged.
+- SSM exports, `soulEnabled`, and first-deploy order: unchanged.
+- Coordination implication: Lesser need not change. Its OAuth metadata can be temporarily unavailable without taking
+  authenticated Body tool calls down; the protected-resource route still fails closed until the authoritative issuer is
+  resolved.
+
+## Enumerated changes
+
+1. Resolve and cache the authoritative OAuth issuer on the protected-resource request instead of during Lambda startup;
+   cover transient dependency failure and cache reuse with regression tests.
+2. Remove Body's opt-in 25-second idle listener budget so AppTheory emits one keepalive and closes immediately; retain
+   `Last-Event-ID` replay and cover the short-lived listener behavior with an integration test.
+   Documentation and operator diagnostics ride with the two behavior changes above.
+
+## Rollout and verification
+
+- Merge through a feature PR to git branch `staging`.
+- Deploy and soak in lab/dev before promotion.
+- Canary authenticated initialize, `conversations_read`, `notifications_read`, and `direct_messages_read`.
+- Open multiple actor clients and verify Body concurrency returns to baseline between requests, with no cold-start OAuth
+  probe panics, API Gateway integration throttles, or JSON-RPC `-32603` failures.
+- Roll back if OAuth metadata returns an incorrect issuer, `Last-Event-ID` replay regresses, or clients fail to reconnect
+  after the short-lived idle GET response.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -10,6 +10,8 @@
 - OAuth protected-resource metadata: `GET /.well-known/oauth-protected-resource/mcp/{actor}`
 - MCP (authenticated): `POST /mcp/{actor}`
   - `GET /mcp/{actor}` and `DELETE /mcp/{actor}` are also supported for MCP Streamable HTTP compatibility.
+  - An initial session `GET` without `Last-Event-ID` emits one SSE keepalive and closes immediately so idle listeners do
+    not retain Lambda concurrency. A resumable `GET` carrying `Last-Event-ID` still uses AppTheory's durable replay path.
 - Shared compatibility endpoint: `GET|POST|DELETE /mcp`
   - Returns HTTP `410 Gone` with migration guidance. It no longer serves MCP traffic.
 - Instance-plane Ptah OAuth protected-resource metadata:

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -40,6 +40,10 @@ Protected-resource discovery depends on Lesser OAuth metadata being reachable at
 
 - `https://api.<stageDomain>/.well-known/oauth-authorization-server`
 
+Body resolves and caches the authoritative issuer when its protected-resource metadata route is requested, not during
+Lambda process startup. A temporary Lesser OAuth metadata failure returns HTTP `503` with `Cache-Control: no-store` on
+that discovery request; it does not prevent already-authorized MCP tool calls from reaching the Ka runtime.
+
 ## Authentication
 
 All `/mcp/{actor}` requests require authentication and Streamable HTTP transport headers:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,5 +1,29 @@
 # Troubleshooting
 
+## Several connected actors see MCP internal errors at once
+
+**Symptoms**
+
+- Multiple actor clients report JSON-RPC `-32603`, HTTP `500`, or HTTP `502` in the same short window.
+- Body tool-call audit events are absent for the failed calls.
+- API Gateway reports Lambda integration `429`, or Body concurrency reaches the account quota.
+
+**Checks**
+
+1. Compare API Gateway failures with Body Lambda `Throttles` and `ConcurrentExecutions`.
+2. Confirm initial `GET /mcp/{actor}` listeners complete quickly instead of holding executions near the Lambda timeout.
+3. Search Body cold-start logs for OAuth metadata reachability panics. Releases containing the 2026-08-10 availability
+   fix must not probe the public authorization-server endpoint during process startup.
+4. Correlate by request id before attributing the failure to `conversations_read`, `notifications_read`, or Lesser data;
+   a request that never reaches Body's tool-call audit boundary did not execute the social handler.
+
+**Resolution**
+
+- Upgrade Body to a release that resolves the OAuth issuer on the protected-resource request and uses AppTheory's
+  short-lived initial session listener behavior.
+- Independently ensure the AWS account Lambda concurrency quota is appropriate for the complete Lesser stage. A larger
+  quota is operational headroom, not a substitute for removing idle Body concurrency retention.
+
 <!-- AI Training: Common failures and fixes for lesser-body -->
 
 ## 401 `app.unauthorized`

--- a/gov-infra/evidence/CDK-SYNTH-output.log
+++ b/gov-infra/evidence/CDK-SYNTH-output.log
@@ -57,12 +57,12 @@ Resources:
                   - ""
                   - - "arn:"
                     - Ref: AWS::Partition
-                    - :secretsmanager:us-east-1:111111111111:secret:lesser/instance-key*
+                    - :secretsmanager:us-east-1:000000000000:secret:lesser/instance-key*
               - Fn::Join:
                   - ""
                   - - "arn:"
                     - Ref: AWS::Partition
-                    - :secretsmanager:us-east-1:111111111111:secret:lesser-host/lab/instances/lesser/instance-key*
+                    - :secretsmanager:us-east-1:000000000000:secret:lesser-host/lab/instances/lesser/instance-key*
           - Action:
               - ssm:GetParameter
               - ssm:GetParameters
@@ -73,12 +73,12 @@ Resources:
                   - ""
                   - - "arn:"
                     - Ref: AWS::Partition
-                    - :ssm:us-east-1:111111111111:parameter/lesser/dev/lesser/exports/v1/*
+                    - :ssm:us-east-1:000000000000:parameter/lesser/dev/lesser/exports/v1/*
               - Fn::Join:
                   - ""
                   - - "arn:"
                     - Ref: AWS::Partition
-                    - :ssm:us-east-1:111111111111:parameter/lesser/dev/lesser-soul/exports/v1/*
+                    - :ssm:us-east-1:000000000000:parameter/lesser/dev/lesser-soul/exports/v1/*
           - Action:
               - dynamodb:BatchGetItem
               - dynamodb:Query
@@ -180,7 +180,7 @@ Resources:
                 - ""
                 - - "arn:"
                   - Ref: AWS::Partition
-                  - :dynamodb:us-east-1:111111111111:table/
+                  - :dynamodb:us-east-1:000000000000:table/
                   - Ref: LesserTableNameParamLookupParameter
           - Action:
               - dynamodb:Query
@@ -197,7 +197,7 @@ Resources:
                 - ""
                 - - "arn:"
                   - Ref: AWS::Partition
-                  - :dynamodb:us-east-1:111111111111:table/
+                  - :dynamodb:us-east-1:000000000000:table/
                   - Ref: LesserTableNameParamLookupParameter
           - Action: dynamodb:PutItem
             Condition:
@@ -210,7 +210,7 @@ Resources:
                 - ""
                 - - "arn:"
                   - Ref: AWS::Partition
-                  - :dynamodb:us-east-1:111111111111:table/
+                  - :dynamodb:us-east-1:000000000000:table/
                   - Ref: LesserTableNameParamLookupParameter
           - Action:
               - dynamodb:GetItem
@@ -238,8 +238,8 @@ Resources:
       Architectures:
         - arm64
       Code:
-        S3Bucket: cdk-hnb659fds-assets-111111111111-us-east-1
-        S3Key: cf8c04b7875bab34d8abcdf1f3682ffa223791166796a8da830c4ec10b151b5e.zip
+        S3Bucket: cdk-hnb659fds-assets-000000000000-us-east-1
+        S3Key: a11d925ee81d434bbd9cea53d511ee26c8de641c72f16399249fccce2b8f71de.zip
       Environment:
         Variables:
           SERVICE_VERSION: dev
@@ -285,7 +285,7 @@ Resources:
       - McpHandlerServiceRole4A94FED3
     Metadata:
       aws:cdk:path: lesser-dev-lesser-body/McpHandler/Resource
-      aws:asset:path: asset.cf8c04b7875bab34d8abcdf1f3682ffa223791166796a8da830c4ec10b151b5e.zip
+      aws:asset:path: asset.a11d925ee81d434bbd9cea53d511ee26c8de641c72f16399249fccce2b8f71de.zip
       aws:asset:is-bundled: false
       aws:asset:property: Code
   McpServerApiAccessLogs6D5B26D2:
@@ -420,7 +420,7 @@ Resources:
           - ""
           - - "arn:"
             - Ref: AWS::Partition
-            - ":execute-api:us-east-1:111111111111:"
+            - ":execute-api:us-east-1:000000000000:"
             - Ref: McpServerApi1485EE7E
             - /
             - Ref: McpServerApiDeploymentStagedev2141D90C
@@ -441,7 +441,7 @@ Resources:
           - ""
           - - "arn:"
             - Ref: AWS::Partition
-            - ":execute-api:us-east-1:111111111111:"
+            - ":execute-api:us-east-1:000000000000:"
             - Ref: McpServerApi1485EE7E
             - /test-invoke-stage/POST/mcp/*
     Metadata:
@@ -526,7 +526,7 @@ Resources:
           - ""
           - - "arn:"
             - Ref: AWS::Partition
-            - ":execute-api:us-east-1:111111111111:"
+            - ":execute-api:us-east-1:000000000000:"
             - Ref: McpServerApi1485EE7E
             - /
             - Ref: McpServerApiDeploymentStagedev2141D90C
@@ -547,7 +547,7 @@ Resources:
           - ""
           - - "arn:"
             - Ref: AWS::Partition
-            - ":execute-api:us-east-1:111111111111:"
+            - ":execute-api:us-east-1:000000000000:"
             - Ref: McpServerApi1485EE7E
             - /test-invoke-stage/GET/mcp/*
     Metadata:
@@ -600,7 +600,7 @@ Resources:
           - ""
           - - "arn:"
             - Ref: AWS::Partition
-            - ":execute-api:us-east-1:111111111111:"
+            - ":execute-api:us-east-1:000000000000:"
             - Ref: McpServerApi1485EE7E
             - /
             - Ref: McpServerApiDeploymentStagedev2141D90C
@@ -621,7 +621,7 @@ Resources:
           - ""
           - - "arn:"
             - Ref: AWS::Partition
-            - ":execute-api:us-east-1:111111111111:"
+            - ":execute-api:us-east-1:000000000000:"
             - Ref: McpServerApi1485EE7E
             - /test-invoke-stage/DELETE/mcp/*
     Metadata:
@@ -713,7 +713,7 @@ Resources:
           - ""
           - - "arn:"
             - Ref: AWS::Partition
-            - ":execute-api:us-east-1:111111111111:"
+            - ":execute-api:us-east-1:000000000000:"
             - Ref: McpServerApi1485EE7E
             - /
             - Ref: McpServerApiDeploymentStagedev2141D90C
@@ -734,7 +734,7 @@ Resources:
           - ""
           - - "arn:"
             - Ref: AWS::Partition
-            - ":execute-api:us-east-1:111111111111:"
+            - ":execute-api:us-east-1:000000000000:"
             - Ref: McpServerApi1485EE7E
             - /test-invoke-stage/GET/.well-known/oauth-protected-resource/mcp/*
     Metadata:
@@ -826,7 +826,7 @@ Resources:
           - ""
           - - "arn:"
             - Ref: AWS::Partition
-            - ":execute-api:us-east-1:111111111111:"
+            - ":execute-api:us-east-1:000000000000:"
             - Ref: McpServerApi1485EE7E
             - /
             - Ref: McpServerApiDeploymentStagedev2141D90C
@@ -847,7 +847,7 @@ Resources:
           - ""
           - - "arn:"
             - Ref: AWS::Partition
-            - ":execute-api:us-east-1:111111111111:"
+            - ":execute-api:us-east-1:000000000000:"
             - Ref: McpServerApi1485EE7E
             - /test-invoke-stage/GET/.well-known/mcp.json
     Metadata:
@@ -1093,7 +1093,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Code:
-        S3Bucket: cdk-hnb659fds-assets-111111111111-us-east-1
+        S3Bucket: cdk-hnb659fds-assets-000000000000-us-east-1
         S3Key: faa95a81ae7d7373f3e1f242268f904eb748d8d0fdd306e8a6fe515a1905a7d6.zip
       Timeout: 900
       MemorySize: 128
@@ -1296,12 +1296,12 @@ Resources:
                   - ""
                   - - "arn:"
                     - Ref: AWS::Partition
-                    - :secretsmanager:us-east-1:111111111111:secret:lesser/instance-key*
+                    - :secretsmanager:us-east-1:000000000000:secret:lesser/instance-key*
               - Fn::Join:
                   - ""
                   - - "arn:"
                     - Ref: AWS::Partition
-                    - :secretsmanager:us-east-1:111111111111:secret:lesser-host/lab/instances/lesser/instance-key*
+                    - :secretsmanager:us-east-1:000000000000:secret:lesser-host/lab/instances/lesser/instance-key*
           - Action: dynamodb:DescribeTable
             Effect: Allow
             Resource:
@@ -1309,7 +1309,7 @@ Resources:
                 - ""
                 - - "arn:"
                   - Ref: AWS::Partition
-                  - :dynamodb:us-east-1:111111111111:table/
+                  - :dynamodb:us-east-1:000000000000:table/
                   - Ref: LesserTableNameParamLookupParameter
           - Action:
               - dynamodb:Query
@@ -1325,7 +1325,7 @@ Resources:
                 - ""
                 - - "arn:"
                   - Ref: AWS::Partition
-                  - :dynamodb:us-east-1:111111111111:table/
+                  - :dynamodb:us-east-1:000000000000:table/
                   - Ref: LesserTableNameParamLookupParameter
           - Action:
               - dynamodb:BatchGetItem
@@ -1363,8 +1363,8 @@ Resources:
       Architectures:
         - arm64
       Code:
-        S3Bucket: cdk-hnb659fds-assets-111111111111-us-east-1
-        S3Key: 2c4c5e57de1b53cef6aa7d92f5caa27452e9bc908786e39be6adf16343feb416.zip
+        S3Bucket: cdk-hnb659fds-assets-000000000000-us-east-1
+        S3Key: ec5594daa694f8e87450650d50c6df596adda0aba64d32c0d7c54298a37daa86.zip
       Environment:
         Variables:
           SERVICE_VERSION: dev
@@ -1400,7 +1400,7 @@ Resources:
       - InstanceMcpHandlerServiceRoleF472AD79
     Metadata:
       aws:cdk:path: lesser-dev-lesser-body/InstanceMcpHandler/Resource
-      aws:asset:path: asset.2c4c5e57de1b53cef6aa7d92f5caa27452e9bc908786e39be6adf16343feb416.zip
+      aws:asset:path: asset.ec5594daa694f8e87450650d50c6df596adda0aba64d32c0d7c54298a37daa86.zip
       aws:asset:is-bundled: false
       aws:asset:property: Code
   InstanceMcpLambdaArnParam:

--- a/gov-infra/evidence/CDK-TEST-output.log
+++ b/gov-infra/evidence/CDK-TEST-output.log
@@ -7,23 +7,23 @@ $ cd cdk && npm test
 > lesser-body-cdk@0.0.0 build
 > tsc
 
-✔ secret read policy includes legacy and managed instance-key patterns (673.086871ms)
-✔ managed template supports an exact lesser-host instance key ARN (150.706792ms)
-✔ managed template declares the Ptah and Ba soul-binding bearer prerequisite (115.59247ms)
-✔ managed template requires app-scoped Lesser parameter paths (103.162129ms)
-✔ lesser table policy uses least-privilege primary table access (78.997552ms)
-✔ managed template pins MCP table logical IDs (97.086545ms)
-✔ every MCP-serving lambda uses the 24-hour session TTL (167.925587ms)
-✔ runtime stack uses AppTheory durable stream table schema (78.001761ms)
-✔ runtime stack provisions internal MCP task storage without SSM export (78.051948ms)
-✔ remote MCP server uses actor-path wiring (79.33457ms)
-✔ runtime stack preserves named MCP table fingerprints (74.929163ms)
-✔ stream table export name stays stable across baseline reset (75.635268ms)
-✔ runtime stack provisions instance-plane lambda with owned tables (73.527978ms)
-✔ Ka self-recovery receives only the Body content and registry tables (72.721681ms)
-✔ instance-plane lambda receives managed Lesser/Host genesis configuration (89.923379ms)
-✔ instance-plane Lesser table read includes binding lookup without memory access (89.234467ms)
-✔ runtime stack publishes additive instance-plane SSM exports (77.879311ms)
+✔ secret read policy includes legacy and managed instance-key patterns (692.075683ms)
+✔ managed template supports an exact lesser-host instance key ARN (143.933315ms)
+✔ managed template declares the Ptah and Ba soul-binding bearer prerequisite (97.200969ms)
+✔ managed template requires app-scoped Lesser parameter paths (99.271619ms)
+✔ lesser table policy uses least-privilege primary table access (78.594602ms)
+✔ managed template pins MCP table logical IDs (94.655635ms)
+✔ every MCP-serving lambda uses the 24-hour session TTL (168.294611ms)
+✔ runtime stack uses AppTheory durable stream table schema (76.86275ms)
+✔ runtime stack provisions internal MCP task storage without SSM export (75.142008ms)
+✔ remote MCP server uses actor-path wiring (77.564101ms)
+✔ runtime stack preserves named MCP table fingerprints (75.660756ms)
+✔ stream table export name stays stable across baseline reset (76.097378ms)
+✔ runtime stack provisions instance-plane lambda with owned tables (73.981622ms)
+✔ Ka self-recovery receives only the Body content and registry tables (74.16591ms)
+✔ instance-plane lambda receives managed Lesser/Host genesis configuration (90.065308ms)
+✔ instance-plane Lesser table read includes binding lookup without memory access (88.703984ms)
+✔ runtime stack publishes additive instance-plane SSM exports (75.518217ms)
 ℹ tests 17
 ℹ suites 0
 ℹ pass 17
@@ -31,4 +31,4 @@ $ cd cdk && npm test
 ℹ cancelled 0
 ℹ skipped 0
 ℹ todo 0
-ℹ duration_ms 2227.991906
+ℹ duration_ms 2212.065954

--- a/gov-infra/evidence/GOV-3-output.log
+++ b/gov-infra/evidence/GOV-3-output.log
@@ -1,4 +1,4 @@
 context=local
-HEAD=026321309bb2494a1c0f18f23a2bc532c3ae02f9
-origin/staging=40123d4cdb6db4bf1e1c6b902ba66cf3fb42ebba
+HEAD=bee78204c407c48abea47ccfb37675e267b62d62
+origin/staging=e09bfba58f55a52a47a2147a3cd5c4da0830d576
 local current-staging lineage PASS

--- a/gov-infra/evidence/RELEASE-ASSETS-output.log
+++ b/gov-infra/evidence/RELEASE-ASSETS-output.log
@@ -34,5 +34,5 @@ lesser-body-managed-live.template.json: OK
 deploy-lesser-body-from-release.sh: OK
 lesser-body-release.json: OK
 apptheory-s3-auto-delete-objects-provider-faa95a81ae7d7373f3e1f242268f904eb748d8d0fdd306e8a6fe515a1905a7d6.zip: OK
-cdk-file-asset-2c4c5e57de1b53ce.zip: OK
+cdk-file-asset-ec5594daa694f8e8.zip: OK
 Verified release assets in dist/release-test

--- a/gov-infra/evidence/gov-rubric-report.json
+++ b/gov-infra/evidence/gov-rubric-report.json
@@ -16,12 +16,12 @@
     "reject_relationship": "abandoned_sibling_or_non_ancestor",
     "required_relationship_to_review_head": "ancestor_or_equal"
   },
-  "generated_at": "2026-08-10T14:37:28.430904Z",
+  "generated_at": "2026-08-10T17:16:56.337396Z",
   "git": {
-    "head": "026321309bb2494a1c0f18f23a2bc532c3ae02f9",
-    "head_tree": "979f83ef70cf1c93aeef4f2bc24fbd7ee78f0ac9",
-    "merge_base_origin_staging": "40123d4cdb6db4bf1e1c6b902ba66cf3fb42ebba",
-    "ref": "theorymcp/equaltoai/body/fix-describe-interface-comms-status-v2",
+    "head": "bee78204c407c48abea47ccfb37675e267b62d62",
+    "head_tree": "329d414c1bc6e4f7f19f9cab925f6bd69d3655fc",
+    "merge_base_origin_staging": "e09bfba58f55a52a47a2147a3cd5c4da0830d576",
+    "ref": "fix/mcp-cold-start-concurrency",
     "working_tree_after_run": "5 changed paths after verifier run"
   },
   "namespace_genome": {

--- a/internal/mcpapp/app.go
+++ b/internal/mcpapp/app.go
@@ -11,7 +11,8 @@ import (
 )
 
 func New(name, version string) (*apptheory.App, error) {
-	if err := validateDiscoveryStartupConfig(context.Background()); err != nil {
+	probeAuthorizationServerIssuer, err := validateDiscoveryStartupConfig(context.Background())
+	if err != nil {
 		return nil, err
 	}
 
@@ -26,7 +27,7 @@ func New(name, version string) (*apptheory.App, error) {
 	)
 
 	app.Get("/.well-known/mcp.json", WithBrowserCORS(WellKnownMcpHandler(srv, name, version)))
-	app.Get("/.well-known/oauth-protected-resource/mcp/{actor}", WithBrowserCORS(WellKnownOAuthProtectedResourceHandler(cachedAuthorizationServerIssuer())))
+	app.Get("/.well-known/oauth-protected-resource/mcp/{actor}", WithBrowserCORS(WellKnownOAuthProtectedResourceHandler(probeAuthorizationServerIssuer)))
 
 	rootHandler := WithBrowserCORS(SharedMcpRetiredHandler())
 	runtimeHandler := withActorOAuthSessionRecovery(srv.Handler())

--- a/internal/mcpapp/discovery_validation.go
+++ b/internal/mcpapp/discovery_validation.go
@@ -43,10 +43,11 @@ var probeAuthorizationServerMetadata = defaultProbeAuthorizationServerMetadata
 
 var authorizationServerIssuerCache struct {
 	mu     sync.RWMutex
+	probe  sync.Mutex
 	issuer string
 }
 
-func validateDiscoveryStartupConfig(ctx context.Context) error {
+func validateDiscoveryStartupConfig(ctx context.Context) (bool, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -57,44 +58,61 @@ func validateDiscoveryStartupConfig(ctx context.Context) error {
 		var err error
 		validatedEndpoint, err = validatedMcpEndpoint(raw)
 		if err != nil {
-			return fmt.Errorf("validate MCP_ENDPOINT: %w", err)
+			return false, fmt.Errorf("validate MCP_ENDPOINT: %w", err)
 		}
 	}
 
 	cfg, err := loadEffectiveTrustConfig(ctx)
 	if err != nil {
-		return fmt.Errorf("load trust config: %w", err)
+		return false, fmt.Errorf("load trust config: %w", err)
 	}
 	if cfg == nil || !cfg.Present {
-		return nil
+		return false, nil
 	}
 
 	trustBaseURL := strings.TrimSpace(cfg.TrustBaseURL)
 	if trustBaseURL == "" {
-		return fmt.Errorf("TRUST_CONFIG.TrustBaseURL is required for OAuth discovery")
+		return false, fmt.Errorf("TRUST_CONFIG.TrustBaseURL is required for OAuth discovery")
 	}
 	if _, err := validatedPublicBaseURL(trustBaseURL); err != nil {
-		return fmt.Errorf("validate TRUST_CONFIG.TrustBaseURL: %w", err)
+		return false, fmt.Errorf("validate TRUST_CONFIG.TrustBaseURL: %w", err)
 	}
 
 	if validatedEndpoint == "" {
-		return nil
+		return false, nil
 	}
 
-	metadataURL, err := oauthAuthorizationServerMetadataURLForMcpEndpoint(validatedEndpoint)
+	// Reachability is deliberately not part of process startup. The Lesser OAuth
+	// metadata endpoint shares the stage's Lambda concurrency pool; making a cold
+	// start depend on that endpoint creates a circular outage during saturation.
+	// The protected-resource route resolves and caches the issuer on demand.
+	return true, nil
+}
+
+func authorizationServerIssuerForMcpEndpoint(ctx context.Context, mcpEndpoint string) (string, error) {
+	if issuer := cachedAuthorizationServerIssuer(); issuer != "" {
+		return issuer, nil
+	}
+
+	authorizationServerIssuerCache.probe.Lock()
+	defer authorizationServerIssuerCache.probe.Unlock()
+	if issuer := cachedAuthorizationServerIssuer(); issuer != "" {
+		return issuer, nil
+	}
+
+	metadataURL, err := oauthAuthorizationServerMetadataURLForMcpEndpoint(mcpEndpoint)
 	if err != nil {
-		return fmt.Errorf("validate MCP_ENDPOINT: %w", err)
+		return "", fmt.Errorf("derive authorization server metadata URL: %w", err)
 	}
 	issuer, err := probeAuthorizationServerMetadata(ctx, metadataURL)
 	if err != nil {
-		return fmt.Errorf("validate MCP_ENDPOINT reachability via %s: %w", metadataURL, err)
+		return "", fmt.Errorf("probe authorization server metadata: %w", err)
 	}
 	if _, err := validatedPublicBaseURL(issuer); err != nil {
-		return fmt.Errorf("validate authorization server issuer %q: %w", issuer, err)
+		return "", fmt.Errorf("validate authorization server issuer: %w", err)
 	}
 	setAuthorizationServerIssuer(issuer)
-
-	return nil
+	return strings.TrimSpace(issuer), nil
 }
 
 func validatedMcpEndpointForRequest(ctx *apptheory.Context) (string, error) {

--- a/internal/mcpapp/discovery_validation_test.go
+++ b/internal/mcpapp/discovery_validation_test.go
@@ -32,7 +32,7 @@ func TestValidatedMcpEndpoint_AcceptsActorTemplate(t *testing.T) {
 	}
 }
 
-func TestNew_ValidatesAuthorizationServerMetadataReachabilityFromMCPEndpoint(t *testing.T) {
+func TestNew_DoesNotDependOnAuthorizationServerMetadataReachability(t *testing.T) {
 	t.Setenv("MCP_SESSION_TABLE", "")
 	t.Setenv("MCP_ENDPOINT", "https://api.example.com/mcp/{actor}")
 
@@ -48,21 +48,20 @@ func TestNew_ValidatesAuthorizationServerMetadataReachabilityFromMCPEndpoint(t *
 	})
 
 	previousProbe := probeAuthorizationServerMetadata
-	probedURL := ""
+	probeCalled := false
 	probeAuthorizationServerMetadata = func(_ context.Context, metadataURL string) (string, error) {
-		probedURL = metadataURL
+		probeCalled = true
 		return "", errors.New("dial tcp: i/o timeout")
 	}
 	t.Cleanup(func() {
 		probeAuthorizationServerMetadata = previousProbe
 	})
 
-	_, err := New("test", "dev")
-	if err == nil || !strings.Contains(err.Error(), "MCP_ENDPOINT") {
-		t.Fatalf("expected MCP_ENDPOINT validation error, got %v", err)
+	if _, err := New("test", "dev"); err != nil {
+		t.Fatalf("new app must not fail on authorization-server reachability: %v", err)
 	}
-	if want := "https://api.example.com/.well-known/oauth-authorization-server"; probedURL != want {
-		t.Fatalf("unexpected metadata probe url: got %q want %q", probedURL, want)
+	if probeCalled {
+		t.Fatal("New must not probe the authorization server during process startup")
 	}
 }
 
@@ -87,7 +86,54 @@ func TestValidatedMcpEndpointForRequest_ResolvesActorTemplate(t *testing.T) {
 	}
 }
 
-func TestNew_CachesAuthorizationServerIssuerFromMetadataProbe(t *testing.T) {
+func TestWellKnownOAuthProtectedResource_CachesAuthorizationServerIssuer(t *testing.T) {
+	t.Setenv("MCP_SESSION_TABLE", "")
+	t.Setenv("MCP_ENDPOINT", "https://api.example.com/mcp/{actor}")
+
+	previousLoader := loadEffectiveTrustConfig
+	loadEffectiveTrustConfig = func(context.Context) (*trustconfig.Effective, error) {
+		return &trustconfig.Effective{
+			TrustBaseURL: "https://lesser.example",
+			Present:      true,
+		}, nil
+	}
+	t.Cleanup(func() {
+		loadEffectiveTrustConfig = previousLoader
+	})
+
+	previousProbe := probeAuthorizationServerMetadata
+	probeCalls := 0
+	probeAuthorizationServerMetadata = func(context.Context, string) (string, error) {
+		probeCalls++
+		return "https://issuer.example", nil
+	}
+	t.Cleanup(func() {
+		probeAuthorizationServerMetadata = previousProbe
+	})
+
+	app, err := New("test", "dev")
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+	env := testkit.New()
+	for range 2 {
+		resp := env.Invoke(context.Background(), app, apptheory.Request{
+			Method: "GET",
+			Path:   "/.well-known/oauth-protected-resource/mcp/agent1",
+		})
+		if resp.Status != 200 {
+			t.Fatalf("metadata status = %d, want 200; body = %s", resp.Status, string(resp.Body))
+		}
+	}
+	if got := cachedAuthorizationServerIssuer(); got != "https://issuer.example" {
+		t.Fatalf("unexpected cached issuer: got %q want %q", got, "https://issuer.example")
+	}
+	if probeCalls != 1 {
+		t.Fatalf("metadata probe calls = %d, want 1", probeCalls)
+	}
+}
+
+func TestWellKnownOAuthProtectedResource_ProbeFailureIsUnavailable(t *testing.T) {
 	t.Setenv("MCP_SESSION_TABLE", "")
 	t.Setenv("MCP_ENDPOINT", "https://api.example.com/mcp/{actor}")
 
@@ -104,17 +150,28 @@ func TestNew_CachesAuthorizationServerIssuerFromMetadataProbe(t *testing.T) {
 
 	previousProbe := probeAuthorizationServerMetadata
 	probeAuthorizationServerMetadata = func(context.Context, string) (string, error) {
-		return "https://issuer.example", nil
+		return "", errors.New("temporary upstream failure")
 	}
 	t.Cleanup(func() {
 		probeAuthorizationServerMetadata = previousProbe
 	})
 
-	if _, err := New("test", "dev"); err != nil {
+	app, err := New("test", "dev")
+	if err != nil {
 		t.Fatalf("new app: %v", err)
 	}
-	if got := cachedAuthorizationServerIssuer(); got != "https://issuer.example" {
-		t.Fatalf("unexpected cached issuer: got %q want %q", got, "https://issuer.example")
+	resp := testkit.New().Invoke(context.Background(), app, apptheory.Request{
+		Method: "GET",
+		Path:   "/.well-known/oauth-protected-resource/mcp/agent1",
+	})
+	if resp.Status != 503 {
+		t.Fatalf("metadata status = %d, want 503; body = %s", resp.Status, string(resp.Body))
+	}
+	if got := firstHeaderValue(resp.Headers, "cache-control"); got != "no-store" {
+		t.Fatalf("cache-control = %q, want no-store", got)
+	}
+	if strings.Contains(string(resp.Body), "temporary upstream failure") {
+		t.Fatalf("metadata response leaked upstream error: %s", string(resp.Body))
 	}
 }
 

--- a/internal/mcpapp/session_listener_integration_test.go
+++ b/internal/mcpapp/session_listener_integration_test.go
@@ -2,13 +2,12 @@ package mcpapp_test
 
 import (
 	"context"
-	"encoding/json"
 	"io"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/aws/aws-lambda-go/events"
+	apptheory "github.com/theory-cloud/apptheory/v3/runtime"
 	mcpruntime "github.com/theory-cloud/apptheory/v3/runtime/mcp"
 	"github.com/theory-cloud/apptheory/v3/testkit"
 
@@ -18,7 +17,7 @@ import (
 
 const testMCPProtocolVersion = "2025-11-25"
 
-func TestInitialSessionListenerGETClosesOnLambdaBudget(t *testing.T) {
+func TestInitialSessionListenerGETClosesAfterKeepalive(t *testing.T) {
 	t.Setenv("MCP_SESSION_TABLE", "")
 	t.Setenv("MCP_ENDPOINT", "https://api.example.com/mcp/{actor}")
 	t.Setenv("JWT_SECRET", "test")
@@ -42,71 +41,31 @@ func TestInitialSessionListenerGETClosesOnLambdaBudget(t *testing.T) {
 	}
 	sessionID := initResp.Headers["mcp-session-id"][0]
 
-	event := events.APIGatewayProxyRequest{
-		Resource:   "/mcp/{actor}",
-		HTTPMethod: "GET",
-		Path:       "/mcp/agent1",
-		Headers: map[string]string{
-			"authorization":        authHeader,
-			"mcp-session-id":       sessionID,
-			"mcp-protocol-version": testMCPProtocolVersion,
-			"accept":               "text/event-stream",
+	startedAt := time.Now()
+	resp := env.Invoke(context.Background(), app, apptheory.Request{
+		Method: "GET",
+		Path:   "/mcp/agent1",
+		Headers: map[string][]string{
+			"authorization":        {authHeader},
+			"mcp-session-id":       {sessionID},
+			"mcp-protocol-version": {testMCPProtocolVersion},
+			"accept":               {"text/event-stream"},
 		},
-		StageVariables: streamingStageVariables("GET", "/mcp/{actor}"),
+	})
+	if resp.Status != 200 {
+		t.Fatalf("listener GET: status=%d, want 200; body=%s", resp.Status, string(resp.Body))
 	}
-	eventBody, err := json.Marshal(event)
-	if err != nil {
-		t.Fatalf("marshal event: %v", err)
+	if resp.BodyReader == nil {
+		t.Fatal("listener GET must return an SSE body")
 	}
-
-	reqCtx, cancel := context.WithTimeout(context.Background(), 5300*time.Millisecond)
-	defer cancel()
-
-	start := time.Now()
-	out, err := app.HandleLambda(reqCtx, eventBody)
-	if err != nil {
-		t.Fatalf("handle lambda: %v", err)
-	}
-
-	resp, ok := out.(*events.APIGatewayProxyStreamingResponse)
-	if !ok {
-		t.Fatalf("expected streaming response, got %T", out)
-	}
-	if resp.StatusCode != 200 {
-		t.Fatalf("listener GET: status=%d", resp.StatusCode)
-	}
-	if resp.Body == nil {
-		t.Fatalf("expected session listener BodyReader")
-	}
-
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.BodyReader)
 	if err != nil {
 		t.Fatalf("read listener body: %v", err)
 	}
-
-	elapsed := time.Since(start)
-	if reqCtx.Err() != nil {
-		t.Fatalf("expected listener to close before parent deadline, got %v", reqCtx.Err())
+	if !strings.Contains(string(body), "keepalive") {
+		t.Fatalf("listener body = %q, want keepalive", string(body))
 	}
-	if len(body) == 0 {
-		t.Fatalf("expected non-empty listener body")
+	if elapsed := time.Since(startedAt); elapsed > time.Second {
+		t.Fatalf("idle listener retained Lambda execution for %v", elapsed)
 	}
-	if !containsKeepaliveFrame(string(body)) {
-		t.Fatalf("expected keepalive frame, got %q", string(body))
-	}
-	if elapsed < 100*time.Millisecond {
-		t.Fatalf("listener closed too quickly, elapsed=%v body=%q", elapsed, string(body))
-	}
-	if elapsed > 2*time.Second {
-		t.Fatalf("listener did not close on lambda budget, elapsed=%v body=%q", elapsed, string(body))
-	}
-}
-
-func containsKeepaliveFrame(body string) bool {
-	return len(body) > 0 && (body == ": keepalive\n\n" ||
-		body == ":keepalive\n\n" ||
-		body == ": keepalive\r\n\r\n" ||
-		body == ":keepalive\r\n\r\n" ||
-		strings.Contains(body, ": keepalive") ||
-		strings.Contains(body, ":keepalive"))
 }

--- a/internal/mcpapp/well_known.go
+++ b/internal/mcpapp/well_known.go
@@ -106,9 +106,7 @@ func WellKnownMcpHandler(srv *mcpserver.Server, name string, version string) app
 	}
 }
 
-func WellKnownOAuthProtectedResourceHandler(probedAuthorizationServerIssuer string) apptheory.Handler {
-	probedAuthorizationServerIssuer = strings.TrimSpace(probedAuthorizationServerIssuer)
-
+func WellKnownOAuthProtectedResourceHandler(probeAuthorizationServerIssuer bool) apptheory.Handler {
 	return func(ctx *apptheory.Context) (*apptheory.Response, error) {
 		endpoint, err := publicDiscoveryMcpEndpointForRequest(ctx)
 		if err != nil {
@@ -118,8 +116,13 @@ func WellKnownOAuthProtectedResourceHandler(probedAuthorizationServerIssuer stri
 			return apptheory.MustJSON(404, map[string]string{"error": "not_found"}), nil
 		}
 
-		authorizationServerURL := probedAuthorizationServerIssuer
-		if authorizationServerURL == "" {
+		authorizationServerURL := ""
+		if probeAuthorizationServerIssuer {
+			authorizationServerURL, err = authorizationServerIssuerForMcpEndpoint(ctx.Context(), endpoint)
+			if err != nil {
+				return authorizationServerMetadataUnavailableResponse(), nil
+			}
+		} else {
 			authorizationServerURL, err = authorizationServerURLForMcpEndpoint(endpoint)
 			if err != nil {
 				return invalidDiscoveryConfigResponse(fmt.Errorf("derive authorization server URL from MCP endpoint: %w", err)), nil
@@ -150,6 +153,16 @@ func WellKnownOAuthProtectedResourceHandler(probedAuthorizationServerIssuer stri
 			Body: body,
 		}, nil
 	}
+}
+
+func authorizationServerMetadataUnavailableResponse() *apptheory.Response {
+	resp := apptheory.MustJSON(503, map[string]string{
+		"error":             "temporarily_unavailable",
+		"error_description": "authorization server metadata is temporarily unavailable",
+	})
+	resp.Headers["cache-control"] = []string{"no-store"}
+	resp.Headers["retry-after"] = []string{"1"}
+	return resp
 }
 
 func protectedResourceNameForRequest(ctx *apptheory.Context) string {

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -20,9 +20,7 @@ const (
 	envMcpStreamTable    = "MCP_STREAM_TABLE"
 	envMcpTaskTable      = "MCP_TASK_TABLE"
 
-	initialSessionListenerSafetyBuffer = 5 * time.Second
-	initialSessionListenerMaxDuration  = 25 * time.Second
-	taskRuntimeMaxTTL                  = time.Hour
+	taskRuntimeMaxTTL = time.Hour
 )
 
 var newMCPDB = func() (tablecore.DB, error) {
@@ -58,10 +56,6 @@ func New(name, version string) (*Server, error) {
 func buildServerOptionsFromEnv() ([]ServerOption, error) {
 	opts := []ServerOption{
 		mcpruntime.WithCapabilityConfig(bodyCapabilityConfig()),
-		mcpruntime.WithInitialSessionListenerBudget(mcpruntime.InitialSessionListenerBudgetOptions{
-			SafetyBuffer: initialSessionListenerSafetyBuffer,
-			MaxDuration:  initialSessionListenerMaxDuration,
-		}),
 		mcpruntime.WithCompletionHooks(promptCompletion, resourceCompletion),
 	}
 


### PR DESCRIPTION
## Summary

Prevent authenticated Ka MCP calls from failing before tool dispatch when a small Lambda concurrency pool is saturated.

- defer authoritative OAuth issuer reachability probing from Lambda process startup to the protected-resource metadata request
- cache the successfully resolved issuer while failing transient metadata requests closed with a sanitized `503`
- stop opting initial session-listener GETs into a 25-second Lambda hold; use AppTheory's default keepalive-and-close behavior
- retain durable `Last-Event-ID` replay and all existing MCP/OAuth response shapes on success
- document the TheoryLive Silas incident evidence, diagnosis, and operator verification path

## Root cause

During the reported TheoryLive window, seven long-lived initial `GET /mcp/{actor}` listeners consumed most of an account-wide concurrency quota of 10. New Body executions then synchronously probed Lesser's public OAuth metadata route, which returned `503` under saturation and caused process-startup panics. The affected broad reads never reached Body's tool-call audit boundary or Lesser's conversation/notification handlers.

This fixes the Body availability loop rather than changing `conversations_read`, `notifications_read`, actor content, or Lesser social response parsing.

## Contract and integration audit

- `.well-known/mcp.json`: unchanged
- OAuth protected-resource success shape, issuer, actor resource identifier, scopes, and cache contract: unchanged
- JSON-RPC request/response shapes: unchanged
- initial MCP GET remains a successful SSE response with a keepalive; the server closes the optional idle stream promptly
- resumed GET with `Last-Event-ID`: preserved through AppTheory's durable replay path
- tool scopes and runtime profiles: unchanged
- JWT validation, Lesser DynamoDB access, Lesser REST API shapes, SSM exports, `soulEnabled`, and deploy order: unchanged
- no framework patch or vendoring; the change restores AppTheory's idiomatic default listener behavior

Compatibility classification: semantic availability refinement; no protocol-version or endpoint change.

## Validation

- `git diff --check`
- `gofmt -l .` clean
- `go build ./...`
- `go test ./...`
- `go vet ./...`
- `bash scripts/build.sh`
- repo-local governance rubric: **PASS — 19 pass / 0 fail / 0 blocked**
- every commit carries a matching DCO `Signed-off-by` trailer

## Rollout verification

After factory merges to git branch `staging`, deploy and soak through lab/dev before promotion. Canary:

1. authenticated initialize for Silas and another actor
2. `conversations_read`, `notifications_read`, and `direct_messages_read`
3. multiple simultaneous actor clients
4. Body concurrency returns to baseline between requests
5. no cold-start OAuth-probe panics, Lambda integration throttles, or JSON-RPC `-32603` failures

Rollback if OAuth metadata returns an incorrect issuer, `Last-Event-ID` replay regresses, or clients fail to reconnect after the short-lived idle GET response.

## Provenance note

TheoryMCP routing was unavailable when this branch and PR were published. The operator explicitly directed use of the local GitHub CLI fallback. Implementation and governance evidence were produced locally; merge authority remains with factory.
