### PR TITLE
fix(dms): recover pending counterpart requests

### DIFF
--- a/docs/investigation-silas-pending-dm-404-2026-08-10.md
+++ b/docs/investigation-silas-pending-dm-404-2026-08-10.md
@@ -1,0 +1,57 @@
+# Investigation: Silas pending direct message returned 404 (2026-08-10)
+
+## Reported symptom
+
+Silas called `direct_messages_read` for Della and received `404 conversation not found`, even though Della had sent him
+a direct message.
+
+## Verified evidence
+
+- TheoryLive Lesser accepted Della's direct-message create request at 2026-08-10 15:07:00 UTC with HTTP 201.
+- Lesser assigned message id `1c2ddc2b-b345-4d12-b2ef-22fa1947dc6b` and conversation id
+  `efc75d63-4766-4dbf-8a08-d145bb4c3397`.
+- The conversation metadata names `della-marlowe` and `silas-vane` as participants and records one message.
+- Della's viewer state is `ACCEPTED` in `INBOX`.
+- Silas's recipient state is `PENDING` in `REQUESTS`, with one unread item and `della-marlowe` as the counterpart.
+- Lesser's named `/api/v1/conversations/lookup` route searches the accepted inbox surface, so it can return 404 while a
+  first-contact conversation exists in the recipient's request folder.
+
+The message exists. This is not message loss and is distinct from the pre-dispatch concurrency failure addressed by
+PR #552.
+
+## Fix-locus verdict
+
+Fix the recovery behavior in Body without weakening Lesser's request gate. `direct_messages_read` already owns the
+named-counterpart MCP workflow and Body already consumes Lesser's recipient-authorized request-folder GraphQL query.
+On an inbox lookup miss, Body can make one bounded request-folder read, identify a matching pending counterpart, and
+return the existing preview and decision actions. No Lesser contract or data migration is required.
+
+## Authorization and tool-surface audit
+
+- `direct_messages_read` remains read-scoped and available in both drone and souled profiles.
+- The fallback forwards the same actor OAuth bearer to Lesser and reads only the authenticated recipient's `REQUESTS`
+  folder.
+- The read tool never accepts or declines a request. It returns the existing write-scoped
+  `message_request_accept` / `message_request_decline` actions for an explicit subsequent decision.
+- Existing success output and input schemas remain unchanged. A matching pending request changes a misleading
+  `not_found` into the more precise `message_request_pending` tool error with status 409 and bounded request metadata.
+- A true miss remains `not_found` and now includes a machine-readable `message_requests_list` action.
+- The fallback reads at most 80 pending requests, performs no pagination loop, and does not scan notifications,
+  timelines, email, or Lesser tables at runtime.
+
+## Lesser-integration and MCP-contract audit
+
+- Uses the existing Lesser REST lookup and existing `BodyMessageRequests` GraphQL operation; no endpoint, query shape,
+  JWT, DynamoDB, SSM, or deploy-order change.
+- `.well-known/mcp.json`, tool registration, input schema, and success output schema remain stable.
+- Compatibility classification: semantic refinement with an additive observable error code for the pending-request
+  case. MCP clients that handle tool errors generically remain compatible; clients can follow the returned action.
+
+## Verification
+
+1. With a pending first-contact message, call `direct_messages_read` by username and confirm
+   `message_request_pending`, the correct conversation id, bounded preview, and explicit accept/decline actions.
+2. Confirm the read call does not change the request state.
+3. Call `message_request_accept` using the returned conversation id.
+4. Retry `direct_messages_read` and confirm the accepted conversation and messages are returned.
+5. Call with a truly absent counterpart and confirm `not_found` plus `checkPendingRequests` guidance.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -668,7 +668,7 @@ Scope key:
 | `following_list` | Read | List accounts the agent follows. |
 | `conversations_read` | Read | Read direct-message conversations; supports opt-in compact conversation refs. |
 | `conversation_get` | Read | Expand one direct-message conversation into bounded recent message previews; defaults to compact and requires explicit standard/full opt-in for message bodies/raw payloads. |
-| `direct_messages_read` | Read | Read bounded recent direct-message previews from a named counterpart via Lesser's one-to-one conversation lookup; defaults to compact and returns explicit `not_found` instead of scanning unrelated surfaces. |
+| `direct_messages_read` | Read | Read bounded recent direct-message previews from a named counterpart via Lesser's one-to-one conversation lookup; defaults to compact. If the inbox lookup misses, it checks the bounded recipient request folder and returns `message_request_pending` plus an explicit accept action for a matching first-contact request without accepting it at read scope. |
 | `message_requests_list` | Read | List the authenticated recipient's pending direct-message requests through Lesser GraphQL with bounded previews and explicit decision actions. |
 | `message_request_accept` | Write | Accept a recipient-owned pending direct-message request through Lesser and move it into the recipient's inbox. |
 | `message_request_decline` | Write | Decline a recipient-owned pending direct-message request through Lesser and remove it from the active request folder. |
@@ -1506,6 +1506,10 @@ index/ref pages and expand only the items they need:
   Lesser's named-counterpart one-to-one lookup and returns compact message previews for that conversation. Use the
   returned conversation ref's `expand` metadata, or call
   `conversation_get({"conversationId":"<conversation-id>","view":"compact"})`, to continue a focused expansion path.
+  When Lesser's accepted-inbox lookup returns not found, Body makes one bounded, recipient-authorized check of the
+  `REQUESTS` folder. A matching first-contact request returns the `message_request_pending` tool error with its bounded
+  preview and ready-to-use `message_request_accept` / `message_request_decline` actions. The read-scoped call never
+  decides the request automatically.
 - `message_requests_list({"limit":10})` reads Lesser's recipient-scoped `REQUESTS` folder. Each bounded request ref
   carries its stable `conversationId`, request state, actor refs, last-message preview, and explicit
   `message_request_accept` / `message_request_decline` arguments. Full message bodies are not returned by this list.
@@ -1580,15 +1584,17 @@ search:
   {"tool":"message_request_decline","arguments":{"conversationId":"<content[0].text JSON payload.requests[].conversationId or structuredContent.data.requests[].conversationId>"}}
   ```
 
-`direct_messages_read` uses Lesser's named counterpart lookup and returns either the focused one-to-one conversation or
-an explicit `not_found` tool error with suggested fallbacks. It never silently scans unrelated conversations,
-notifications, timelines, or email. Existing advisor check-in workflows should migrate from broad mailbox/email search
-to "read DMs from the named advisor first; use `conversation_get` only for focused expansion; use `email_search` only
-when the DM path reports `not_found` or the advisor explicitly coordinated by email."
+`direct_messages_read` uses Lesser's named counterpart lookup and returns the focused one-to-one conversation when it
+is in the authenticated recipient's inbox. If that lookup returns not found, Body checks at most 80 entries in the same
+recipient's `REQUESTS` folder. A counterpart match returns `message_request_pending`, the stable conversation id, a
+bounded last-message preview, and explicit accept/decline actions. No match returns `not_found` with a machine-readable
+`message_requests_list` action. It never scans notifications, timelines, or email. Existing advisor check-in workflows
+should migrate from broad mailbox/email search to "read DMs from the named advisor first; explicitly decide a surfaced
+first-contact request; use `conversation_get` only for focused expansion."
 
 First-contact DMs remain governed by Lesser's request lifecycle. Lesser may accept the initial direct message while
 rejecting a subsequent message with `403 Message request pending` until the recipient decides the request. Body does
-not bypass that guard: `message_requests_list` calls Lesser GraphQL
+not bypass that guard: `direct_messages_read` only detects and reports a matching request, `message_requests_list` calls Lesser GraphQL
 `conversations(folder: REQUESTS, first:, after:)`, `message_request_accept` calls
 `acceptMessageRequest(conversationId:)`, and `message_request_decline` calls
 `declineMessageRequest(conversationId:)`, always with the recipient's OAuth bearer. Accepting moves the thread to the

--- a/gov-infra/evidence/CDK-SYNTH-output.log
+++ b/gov-infra/evidence/CDK-SYNTH-output.log
@@ -239,7 +239,7 @@ Resources:
         - arm64
       Code:
         S3Bucket: cdk-hnb659fds-assets-000000000000-us-east-1
-        S3Key: a11d925ee81d434bbd9cea53d511ee26c8de641c72f16399249fccce2b8f71de.zip
+        S3Key: 9212a03320e4ac508863169d4d4d359eea76b1ae3bfa064322d7a657860cb1f4.zip
       Environment:
         Variables:
           SERVICE_VERSION: dev
@@ -285,7 +285,7 @@ Resources:
       - McpHandlerServiceRole4A94FED3
     Metadata:
       aws:cdk:path: lesser-dev-lesser-body/McpHandler/Resource
-      aws:asset:path: asset.a11d925ee81d434bbd9cea53d511ee26c8de641c72f16399249fccce2b8f71de.zip
+      aws:asset:path: asset.9212a03320e4ac508863169d4d4d359eea76b1ae3bfa064322d7a657860cb1f4.zip
       aws:asset:is-bundled: false
       aws:asset:property: Code
   McpServerApiAccessLogs6D5B26D2:
@@ -1364,7 +1364,7 @@ Resources:
         - arm64
       Code:
         S3Bucket: cdk-hnb659fds-assets-000000000000-us-east-1
-        S3Key: ec5594daa694f8e87450650d50c6df596adda0aba64d32c0d7c54298a37daa86.zip
+        S3Key: 1b4962e025ace455495e2f24704bc4e2b74e19ddbdaeaf964c03d02aac725b5b.zip
       Environment:
         Variables:
           SERVICE_VERSION: dev
@@ -1400,7 +1400,7 @@ Resources:
       - InstanceMcpHandlerServiceRoleF472AD79
     Metadata:
       aws:cdk:path: lesser-dev-lesser-body/InstanceMcpHandler/Resource
-      aws:asset:path: asset.ec5594daa694f8e87450650d50c6df596adda0aba64d32c0d7c54298a37daa86.zip
+      aws:asset:path: asset.1b4962e025ace455495e2f24704bc4e2b74e19ddbdaeaf964c03d02aac725b5b.zip
       aws:asset:is-bundled: false
       aws:asset:property: Code
   InstanceMcpLambdaArnParam:

--- a/gov-infra/evidence/CDK-TEST-output.log
+++ b/gov-infra/evidence/CDK-TEST-output.log
@@ -7,23 +7,23 @@ $ cd cdk && npm test
 > lesser-body-cdk@0.0.0 build
 > tsc
 
-✔ secret read policy includes legacy and managed instance-key patterns (692.075683ms)
-✔ managed template supports an exact lesser-host instance key ARN (143.933315ms)
-✔ managed template declares the Ptah and Ba soul-binding bearer prerequisite (97.200969ms)
-✔ managed template requires app-scoped Lesser parameter paths (99.271619ms)
-✔ lesser table policy uses least-privilege primary table access (78.594602ms)
-✔ managed template pins MCP table logical IDs (94.655635ms)
-✔ every MCP-serving lambda uses the 24-hour session TTL (168.294611ms)
-✔ runtime stack uses AppTheory durable stream table schema (76.86275ms)
-✔ runtime stack provisions internal MCP task storage without SSM export (75.142008ms)
-✔ remote MCP server uses actor-path wiring (77.564101ms)
-✔ runtime stack preserves named MCP table fingerprints (75.660756ms)
-✔ stream table export name stays stable across baseline reset (76.097378ms)
-✔ runtime stack provisions instance-plane lambda with owned tables (73.981622ms)
-✔ Ka self-recovery receives only the Body content and registry tables (74.16591ms)
-✔ instance-plane lambda receives managed Lesser/Host genesis configuration (90.065308ms)
-✔ instance-plane Lesser table read includes binding lookup without memory access (88.703984ms)
-✔ runtime stack publishes additive instance-plane SSM exports (75.518217ms)
+✔ secret read policy includes legacy and managed instance-key patterns (658.234789ms)
+✔ managed template supports an exact lesser-host instance key ARN (138.627152ms)
+✔ managed template declares the Ptah and Ba soul-binding bearer prerequisite (99.379897ms)
+✔ managed template requires app-scoped Lesser parameter paths (96.23832ms)
+✔ lesser table policy uses least-privilege primary table access (82.438485ms)
+✔ managed template pins MCP table logical IDs (95.640293ms)
+✔ every MCP-serving lambda uses the 24-hour session TTL (174.02693ms)
+✔ runtime stack uses AppTheory durable stream table schema (75.429715ms)
+✔ runtime stack provisions internal MCP task storage without SSM export (77.064227ms)
+✔ remote MCP server uses actor-path wiring (74.53343ms)
+✔ runtime stack preserves named MCP table fingerprints (77.672183ms)
+✔ stream table export name stays stable across baseline reset (74.306117ms)
+✔ runtime stack provisions instance-plane lambda with owned tables (73.942448ms)
+✔ Ka self-recovery receives only the Body content and registry tables (76.81838ms)
+✔ instance-plane lambda receives managed Lesser/Host genesis configuration (91.108951ms)
+✔ instance-plane Lesser table read includes binding lookup without memory access (92.201212ms)
+✔ runtime stack publishes additive instance-plane SSM exports (73.704323ms)
 ℹ tests 17
 ℹ suites 0
 ℹ pass 17
@@ -31,4 +31,4 @@ $ cd cdk && npm test
 ℹ cancelled 0
 ℹ skipped 0
 ℹ todo 0
-ℹ duration_ms 2212.065954
+ℹ duration_ms 2199.193216

--- a/gov-infra/evidence/GOV-3-output.log
+++ b/gov-infra/evidence/GOV-3-output.log
@@ -1,4 +1,4 @@
 context=local
-HEAD=bee78204c407c48abea47ccfb37675e267b62d62
-origin/staging=e09bfba58f55a52a47a2147a3cd5c4da0830d576
+HEAD=470c797aa33eaeed599ef59e26679f60f1fc1372
+origin/staging=21795268846c17d4299baa7d28fec7f6c0609991
 local current-staging lineage PASS

--- a/gov-infra/evidence/RELEASE-ASSETS-output.log
+++ b/gov-infra/evidence/RELEASE-ASSETS-output.log
@@ -34,5 +34,5 @@ lesser-body-managed-live.template.json: OK
 deploy-lesser-body-from-release.sh: OK
 lesser-body-release.json: OK
 apptheory-s3-auto-delete-objects-provider-faa95a81ae7d7373f3e1f242268f904eb748d8d0fdd306e8a6fe515a1905a7d6.zip: OK
-cdk-file-asset-ec5594daa694f8e8.zip: OK
+cdk-file-asset-1b4962e025ace455.zip: OK
 Verified release assets in dist/release-test

--- a/gov-infra/evidence/gov-rubric-report.json
+++ b/gov-infra/evidence/gov-rubric-report.json
@@ -16,12 +16,12 @@
     "reject_relationship": "abandoned_sibling_or_non_ancestor",
     "required_relationship_to_review_head": "ancestor_or_equal"
   },
-  "generated_at": "2026-08-10T17:16:56.337396Z",
+  "generated_at": "2026-08-10T17:30:53.584278Z",
   "git": {
-    "head": "bee78204c407c48abea47ccfb37675e267b62d62",
-    "head_tree": "329d414c1bc6e4f7f19f9cab925f6bd69d3655fc",
-    "merge_base_origin_staging": "e09bfba58f55a52a47a2147a3cd5c4da0830d576",
-    "ref": "fix/mcp-cold-start-concurrency",
+    "head": "470c797aa33eaeed599ef59e26679f60f1fc1372",
+    "head_tree": "c86cadf15a893cea3465ae6540b40a477b305717",
+    "merge_base_origin_staging": "21795268846c17d4299baa7d28fec7f6c0609991",
+    "ref": "fix/direct-message-pending-recovery",
     "working_tree_after_run": "5 changed paths after verifier run"
   },
   "namespace_genome": {

--- a/internal/mcpapp/message_request_tools_test.go
+++ b/internal/mcpapp/message_request_tools_test.go
@@ -111,6 +111,24 @@ func TestMessageRequestLifecycleAcrossActorScopedMCP(t *testing.T) {
 				t.Fatalf("unexpected GraphQL operation %q", op.OperationName)
 			}
 
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/conversations/lookup":
+			if got := r.Header.Get("Authorization"); got != recipientAuth {
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = w.Write([]byte(`{"error":"wrong recipient"}`))
+				return
+			}
+			if got := r.URL.Query().Get("counterpart"); got != "sender" {
+				t.Fatalf("counterpart lookup = %q", got)
+			}
+			state.Lock()
+			defer state.Unlock()
+			if !state.accepted {
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte(`{"error":"not found"}`))
+				return
+			}
+			_, _ = w.Write([]byte(socialConversationDetailFixtureJSON("conv-1", "", "", "")))
+
 		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/conversations":
 			if got := r.Header.Get("Authorization"); got != senderAuth && got != recipientAuth {
 				w.WriteHeader(http.StatusUnauthorized)
@@ -165,7 +183,24 @@ func TestMessageRequestLifecycleAcrossActorScopedMCP(t *testing.T) {
 		t.Fatalf("pending-request rejection lost upstream reason: %+v", blocked.StructuredContent)
 	}
 
-	listed := callActorTool(t, env, app, "/mcp/recipient", recipientAuth, recipientSession, 12, "message_requests_list", map[string]any{"limit": 10})
+	focusedPending := callActorTool(t, env, app, "/mcp/recipient", recipientAuth, recipientSession, 12, "direct_messages_read", map[string]any{
+		"counterpart": "sender",
+	})
+	if !focusedPending.IsError {
+		t.Fatalf("focused pending read must require the recipient's explicit decision: %+v", focusedPending.StructuredContent)
+	}
+	focusedError, _ := focusedPending.StructuredContent["error"].(map[string]any)
+	focusedDetails, _ := focusedError["details"].(map[string]any)
+	if focusedError["code"] != "message_request_pending" || focusedDetails["conversationId"] != "conv-1" {
+		t.Fatalf("focused pending request = %+v", focusedPending.StructuredContent)
+	}
+	focusedAction, _ := focusedDetails["nextAction"].(map[string]any)
+	focusedActionArgs, _ := focusedAction["arguments"].(map[string]any)
+	if focusedAction["tool"] != "message_request_accept" || focusedActionArgs["conversationId"] != "conv-1" {
+		t.Fatalf("focused pending action = %+v", focusedAction)
+	}
+
+	listed := callActorTool(t, env, app, "/mcp/recipient", recipientAuth, recipientSession, 13, "message_requests_list", map[string]any{"limit": 10})
 	listedData := requireToolData(t, listed)
 	if listedData["folder"] != "REQUESTS" || listedData["count"] != float64(2) {
 		t.Fatalf("message request list = %+v", listedData)
@@ -180,7 +215,7 @@ func TestMessageRequestLifecycleAcrossActorScopedMCP(t *testing.T) {
 		t.Fatalf("message request preview was not bounded: %+v", lastMessage)
 	}
 
-	accepted := callActorTool(t, env, app, "/mcp/recipient", recipientAuth, recipientSession, 13, "message_request_accept", map[string]any{"conversationId": "conv-1"})
+	accepted := callActorTool(t, env, app, "/mcp/recipient", recipientAuth, recipientSession, 14, "message_request_accept", map[string]any{"conversationId": "conv-1"})
 	acceptedData := requireToolData(t, accepted)
 	if acceptedData["requestState"] != "ACCEPTED" || acceptedData["decision"] != "accepted" {
 		t.Fatalf("accept result = %+v", acceptedData)
@@ -192,14 +227,23 @@ func TestMessageRequestLifecycleAcrossActorScopedMCP(t *testing.T) {
 		{path: "/mcp/sender", authHeader: senderAuth, sessionID: senderSession},
 		{path: "/mcp/recipient", authHeader: recipientAuth, sessionID: recipientSession},
 	} {
-		visible := callActorTool(t, env, app, actor.path, actor.authHeader, actor.sessionID, 14, "conversations_read", map[string]any{"limit": 10})
+		visible := callActorTool(t, env, app, actor.path, actor.authHeader, actor.sessionID, 15, "conversations_read", map[string]any{"limit": 10})
 		data := requireToolData(t, visible)
 		if data["count"] != float64(1) {
 			t.Fatalf("accepted conversation not visible to %s: %+v", actor.path, data)
 		}
 	}
+	focusedAccepted := callActorTool(t, env, app, "/mcp/recipient", recipientAuth, recipientSession, 16, "direct_messages_read", map[string]any{
+		"counterpart": "sender",
+	})
+	if focusedAccepted.IsError {
+		t.Fatalf("focused direct read failed after explicit acceptance: %+v", focusedAccepted.StructuredContent)
+	}
+	if data := requireToolData(t, focusedAccepted); data["id"] != "conv-1" {
+		t.Fatalf("focused accepted conversation = %+v", data)
+	}
 
-	flowing := callActorTool(t, env, app, "/mcp/sender", senderAuth, senderSession, 15, "post_create", map[string]any{
+	flowing := callActorTool(t, env, app, "/mcp/sender", senderAuth, senderSession, 17, "post_create", map[string]any{
 		"content":    "@recipient second after accept",
 		"visibility": "direct",
 	})
@@ -207,13 +251,13 @@ func TestMessageRequestLifecycleAcrossActorScopedMCP(t *testing.T) {
 		t.Fatalf("second direct message remained pending after accept: %+v", flowing.StructuredContent)
 	}
 
-	declined := callActorTool(t, env, app, "/mcp/recipient", recipientAuth, recipientSession, 16, "message_request_decline", map[string]any{"conversationId": "conv-2"})
+	declined := callActorTool(t, env, app, "/mcp/recipient", recipientAuth, recipientSession, 18, "message_request_decline", map[string]any{"conversationId": "conv-2"})
 	declinedData := requireToolData(t, declined)
 	if declinedData["requestState"] != "DECLINED" || declinedData["success"] != true {
 		t.Fatalf("decline result = %+v", declinedData)
 	}
 
-	empty := callActorTool(t, env, app, "/mcp/recipient", recipientAuth, recipientSession, 17, "message_requests_list", map[string]any{})
+	empty := callActorTool(t, env, app, "/mcp/recipient", recipientAuth, recipientSession, 19, "message_requests_list", map[string]any{})
 	if data := requireToolData(t, empty); data["count"] != float64(0) {
 		t.Fatalf("resolved requests remained in request folder: %+v", data)
 	}

--- a/internal/mcpapp/social_tools_test.go
+++ b/internal/mcpapp/social_tools_test.go
@@ -1605,23 +1605,42 @@ func TestM5_DirectMessagesReadLooksUpNamedCounterpartWithCompactBudgetedRefs(t *
 	const debugPayload = "DIRECT_MESSAGES_READ_DEBUG_PAYLOAD_SHOULD_NOT_APPEAR"
 
 	var gotQueries []string
+	var lastLookupCounterpart string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet {
-			t.Fatalf("unexpected method: %s", r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodPost && r.URL.Path == "/api/graphql" {
+			var op struct {
+				OperationName string `json:"operationName"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&op); err != nil {
+				t.Fatalf("decode pending-request query: %v", err)
+			}
+			if op.OperationName != "BodyMessageRequests" {
+				t.Fatalf("unexpected GraphQL operation: %s", op.OperationName)
+			}
+			if lastLookupCounterpart == "inconclusive" {
+				w.WriteHeader(http.StatusServiceUnavailable)
+				_, _ = w.Write([]byte(`{"error":"temporarily unavailable"}`))
+				return
+			}
+			_, _ = w.Write([]byte(`{"data":{"conversations":[` +
+				messageRequestFixture("conv-pending", "pending", "PENDING", "hello from pending") + `,` +
+				messageRequestFixture("conv-unrelated", "unrelated", "PENDING", "unrelated request") + `]}}`))
+			return
 		}
-		if r.URL.Path != "/api/v1/conversations/lookup" {
-			t.Fatalf("direct_messages_read should not scan unrelated surfaces; got path %s", r.URL.Path)
+		if r.Method != http.MethodGet || r.URL.Path != "/api/v1/conversations/lookup" {
+			t.Fatalf("direct_messages_read should only use the named lookup and recipient request folder; got %s %s", r.Method, r.URL.Path)
 		}
 		gotQueries = append(gotQueries, r.URL.RawQuery)
-		w.Header().Set("Content-Type", "application/json")
-		switch r.URL.Query().Get("counterpart") {
+		lastLookupCounterpart = r.URL.Query().Get("counterpart")
+		switch lastLookupCounterpart {
 		case "ops":
 			w.Header().Set("Link", `<https://example.com/api/v1/conversations/lookup?counterpart=ops&max_id=cursor-next>; rel="next"`)
 			_, _ = w.Write([]byte(socialConversationDetailFixtureJSON("conv-ops", contentTail, accountNote, debugPayload)))
 		case "medic":
 			body := strings.Replace(socialConversationDetailFixtureJSON("conv-medic", contentTail, accountNote, debugPayload), `"unread":true`, `"unread":false`, 1)
 			_, _ = w.Write([]byte(body))
-		case "missing":
+		case "pending", "missing", "inconclusive":
 			w.WriteHeader(http.StatusNotFound)
 			_, _ = w.Write([]byte(`{"error":"not found"}`))
 		case "expired":
@@ -1758,8 +1777,45 @@ func TestM5_DirectMessagesReadLooksUpNamedCounterpartWithCompactBudgetedRefs(t *
 	if fallbacks, _ := details["suggestedFallbacks"].([]any); len(fallbacks) == 0 {
 		t.Fatalf("not-found details should include suggested fallbacks, got %+v", details)
 	}
+	checkPending, _ := details["checkPendingRequests"].(map[string]any)
+	if checkPending["tool"] != "message_requests_list" {
+		t.Fatalf("not-found details should identify the recipient request folder, got %+v", details)
+	}
 
-	expired := callSocialTool(t, env, app, authHeader, sessionID, 7, "direct_messages_read", map[string]any{
+	pending := callSocialTool(t, env, app, authHeader, sessionID, 7, "direct_messages_read", map[string]any{
+		"counterpart": "pending",
+	})
+	if !pending.Result.IsError {
+		t.Fatalf("pending direct message request must require an explicit write-scoped decision: %+v", pending.Result)
+	}
+	pendingError, _ := pending.Result.StructuredContent["error"].(map[string]any)
+	if pendingError["code"] != "message_request_pending" || pendingError["status"] != float64(http.StatusConflict) {
+		t.Fatalf("unexpected pending-request payload: %+v", pendingError)
+	}
+	pendingDetails, _ := pendingError["details"].(map[string]any)
+	if pendingDetails["counterpart"] != "pending" || pendingDetails["conversationId"] != "conv-pending" || pendingDetails["requestState"] != "PENDING" {
+		t.Fatalf("pending-request details = %+v", pendingDetails)
+	}
+	pendingRef, _ := pendingDetails["pendingRequest"].(map[string]any)
+	actions, _ := pendingRef["actions"].(map[string]any)
+	accept, _ := actions["accept"].(map[string]any)
+	acceptArgs, _ := accept["arguments"].(map[string]any)
+	if accept["tool"] != "message_request_accept" || acceptArgs["conversationId"] != "conv-pending" {
+		t.Fatalf("pending-request accept action = %+v", accept)
+	}
+
+	inconclusive := callSocialTool(t, env, app, authHeader, sessionID, 8, "direct_messages_read", map[string]any{
+		"counterpart": "inconclusive",
+	})
+	if !inconclusive.Result.IsError {
+		t.Fatalf("failed pending-request check must not be reported as a definitive 404: %+v", inconclusive.Result)
+	}
+	inconclusiveError, _ := inconclusive.Result.StructuredContent["error"].(map[string]any)
+	if inconclusiveError["code"] != "pending_request_check_failed" || inconclusiveError["status"] != float64(http.StatusBadGateway) {
+		t.Fatalf("unexpected inconclusive pending-request payload: %+v", inconclusiveError)
+	}
+
+	expired := callSocialTool(t, env, app, authHeader, sessionID, 9, "direct_messages_read", map[string]any{
 		"counterpart": "expired",
 	})
 	if !expired.Result.IsError {

--- a/internal/mcpserver/direct_messages_pending_test.go
+++ b/internal/mcpserver/direct_messages_pending_test.go
@@ -1,0 +1,42 @@
+package mcpserver
+
+import (
+	"testing"
+
+	"github.com/equaltoai/lesser-body/internal/lesserapi"
+)
+
+func TestPendingMessageRequestForCounterpartMatchesRecipientVisibleIdentity(t *testing.T) {
+	requests := []lesserapi.MessageRequestConversation{
+		{
+			ID: "accepted",
+			Accounts: []lesserapi.MessageRequestAccount{{
+				ID:       "acct-accepted",
+				Username: "accepted-user",
+			}},
+			ViewerMetadata: lesserapi.MessageRequestViewerMetadata{RequestState: "ACCEPTED"},
+		},
+		{
+			ID: "pending",
+			Accounts: []lesserapi.MessageRequestAccount{{
+				ID:       "acct-della",
+				Username: "Della-Marlowe",
+				Domain:   "theory.greater.website",
+			}},
+			ViewerMetadata: lesserapi.MessageRequestViewerMetadata{RequestState: "pending"},
+		},
+	}
+
+	for _, selector := range []string{"acct-della", "della-marlowe", "@DELLA-MARLOWE", "della-marlowe@theory.greater.website"} {
+		request := pendingMessageRequestForCounterpart(requests, selector)
+		if request == nil || request.ID != "pending" {
+			t.Fatalf("selector %q matched %+v, want pending request", selector, request)
+		}
+	}
+	if request := pendingMessageRequestForCounterpart(requests, "accepted-user"); request != nil {
+		t.Fatalf("accepted conversation must not be reported as pending: %+v", request)
+	}
+	if request := pendingMessageRequestForCounterpart(requests, "missing"); request != nil {
+		t.Fatalf("missing counterpart matched unexpected request: %+v", request)
+	}
+}

--- a/internal/mcpserver/social_tools.go
+++ b/internal/mcpserver/social_tools.go
@@ -862,6 +862,15 @@ func handleDirectMessagesRead(ctx context.Context, args json.RawMessage) (*mcpru
 
 	out, headers, err := client.DoJSONWithHeaders(ctx, "GET", "/api/v1/conversations/lookup", query, token, nil)
 	if err != nil {
+		if directMessagesLookupNotFound(err) {
+			pending, pendingErr := client.ListMessageRequests(ctx, token, messageRequestMaxLimit, "")
+			if pendingErr != nil {
+				return directMessagesPendingCheckToolResultFromError(counterpart, pendingErr)
+			}
+			if request := pendingMessageRequestForCounterpart(pending, counterpart); request != nil {
+				return directMessagesPendingRequestToolResult(counterpart, *request)
+			}
+		}
 		return directMessagesReadToolResultFromError(counterpart, err)
 	}
 	raw, err := conversationDetailFromAPI(out)
@@ -1038,14 +1047,90 @@ func directMessagesReadToolResultFromError(counterpart string, err error) (*mcpr
 			"counterpart":  strings.TrimSpace(counterpart),
 			"source":       "lesser-api",
 			"upstreamCode": apiErr.Status,
+			"checkPendingRequests": map[string]any{
+				"tool":      "message_requests_list",
+				"arguments": map[string]any{"limit": messageRequestMaxLimit},
+			},
 			"suggestedFallbacks": []any{
+				"check message_requests_list and explicitly accept or decline any matching first-contact request",
 				"confirm the teammate local id, acct, or actor URL with identity_lookup",
-				"ask the teammate to start a direct-message thread",
-				"use email_search only as a fallback coordination path",
+				"ask the teammate to start a direct-message thread only when no matching request exists",
 			},
 		})
 	}
 	return authToolResultFromError(err)
+}
+
+func directMessagesLookupNotFound(err error) bool {
+	var apiErr *lesserapi.APIError
+	return errors.As(err, &apiErr) && apiErr.Status == http.StatusNotFound
+}
+
+func pendingMessageRequestForCounterpart(requests []lesserapi.MessageRequestConversation, counterpart string) *lesserapi.MessageRequestConversation {
+	selector := normalizeMessageRequestCounterpart(counterpart)
+	if selector == "" {
+		return nil
+	}
+	for i := range requests {
+		request := &requests[i]
+		if strings.TrimSpace(request.ID) == "" || !strings.EqualFold(strings.TrimSpace(request.ViewerMetadata.RequestState), "PENDING") {
+			continue
+		}
+		for _, account := range request.Accounts {
+			candidates := []string{account.ID, account.Username}
+			if username, domain := strings.TrimSpace(account.Username), strings.TrimSpace(account.Domain); username != "" && domain != "" {
+				candidates = append(candidates, username+"@"+domain)
+			}
+			for _, candidate := range candidates {
+				if normalizeMessageRequestCounterpart(candidate) == selector {
+					return request
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func normalizeMessageRequestCounterpart(value string) string {
+	return strings.ToLower(strings.TrimPrefix(strings.TrimSpace(value), "@"))
+}
+
+func directMessagesPendingCheckToolResultFromError(counterpart string, err error) (*mcpruntime.ToolResult, error) {
+	if failure := mcpAuthFailureFromError(err); failure != nil {
+		return toolErrorResult(failure.Code, failure.Message, failure.Status, failure.Details)
+	}
+	details := map[string]any{
+		"counterpart": strings.TrimSpace(counterpart),
+		"source":      "lesser-graphql",
+		"retryable":   true,
+	}
+	var gqlErr *lesserapi.MessageRequestGraphQLErrors
+	if errors.As(err, &gqlErr) {
+		details["errorCount"] = gqlErr.Count
+		if len(gqlErr.Codes) > 0 {
+			details["errorCodes"] = gqlErr.Codes
+		}
+	}
+	var apiErr *lesserapi.APIError
+	if errors.As(err, &apiErr) {
+		details["upstreamCode"] = apiErr.Status
+	}
+	return toolErrorResult("pending_request_check_failed", "could not determine whether the direct message is pending recipient review", http.StatusBadGateway, details)
+}
+
+func directMessagesPendingRequestToolResult(counterpart string, request lesserapi.MessageRequestConversation) (*mcpruntime.ToolResult, error) {
+	conversationID := strings.TrimSpace(request.ID)
+	return toolErrorResult("message_request_pending", "direct message is pending recipient review", http.StatusConflict, map[string]any{
+		"counterpart":    strings.TrimSpace(counterpart),
+		"source":         "lesser-graphql",
+		"conversationId": conversationID,
+		"requestState":   "PENDING",
+		"pendingRequest": messageRequestRef(request, true),
+		"nextAction": map[string]any{
+			"tool":      "message_request_accept",
+			"arguments": map[string]any{"conversationId": conversationID},
+		},
+	})
 }
 
 func compactSocialConversationRef(raw map[string]any, previewRunes int) map[string]any {
@@ -2510,7 +2595,7 @@ func conversationGetDef() mcpruntime.ToolDef {
 func directMessagesReadDef() mcpruntime.ToolDef {
 	return mcpruntime.ToolDef{
 		Name:         "direct_messages_read",
-		Description:  "Read recent direct-message previews from a named counterpart using Lesser's one-to-one conversation lookup. Examples: recent DMs from Ops with {\"counterpart\":\"ops\",\"limit\":10,\"view\":\"compact\"}; unread DMs from Medic with {\"counterpart\":\"medic\",\"unreadOnly\":true,\"view\":\"compact\"}. Defaults to compact and returns explicit not_found rather than scanning unrelated surfaces.",
+		Description:  "Read recent direct-message previews from a named counterpart using Lesser's one-to-one conversation lookup. Examples: recent DMs from Ops with {\"counterpart\":\"ops\",\"limit\":10,\"view\":\"compact\"}; unread DMs from Medic with {\"counterpart\":\"medic\",\"unreadOnly\":true,\"view\":\"compact\"}. Defaults to compact. When the inbox lookup misses, checks the bounded recipient request folder and returns message_request_pending with an explicit accept action for a matching first-contact request; it never accepts at read scope.",
 		Annotations:  readOnlyToolAnnotations(),
 		OutputSchema: directMessagesReadOutputSchema(),
 		InputSchema: json.RawMessage(`{


### PR DESCRIPTION
## Summary

Make a named direct-message read recoverable when the counterpart's first message is still waiting in the authenticated recipient's Lesser `REQUESTS` folder.

- after the accepted-inbox lookup returns 404, perform one bounded recipient-authorized request-folder read
- return `message_request_pending` with the correct conversation id, bounded preview, and explicit accept/decline actions when the counterpart matches
- keep `direct_messages_read` read-only; it never accepts or declines automatically
- return `pending_request_check_failed` rather than a false definitive 404 if the request-folder check is unavailable
- retain `not_found` for a true miss, now with a machine-readable `message_requests_list` action

## TheoryLive evidence

Della's message was not lost:

- Lesser accepted it at 2026-08-10 15:07:00 UTC with HTTP 201
- message id: `1c2ddc2b-b345-4d12-b2ef-22fa1947dc6b`
- conversation id: `efc75d63-4766-4dbf-8a08-d145bb4c3397`
- participants: `della-marlowe`, `silas-vane`
- Della state: `ACCEPTED` / `INBOX`
- Silas state: `PENDING` / `REQUESTS`, unread count 1

The existing named lookup reads the accepted inbox surface, so its 404 concealed an actionable first-contact request from the focused MCP workflow. This is distinct from the pre-dispatch concurrency failure fixed in merged PR #552; this branch starts from the resulting `staging` head.

## Authorization and contract audit

- tool: `direct_messages_read` (modified behavior only)
- group: social
- scope: remains `read`
- profiles: remains available in drone and souled
- input and success output schemas: unchanged
- side effects: none
- request decisions remain explicit calls to the existing write-scoped `message_request_accept` or `message_request_decline`
- downstream authorization: same actor OAuth bearer; Lesser remains recipient/request lifecycle authority
- bounded fallback: at most 80 entries from the existing `BodyMessageRequests` GraphQL operation
- no notification, timeline, email, or runtime DynamoDB scan
- no registration, JWT, SSM, CDK, deploy-order, dependency, or Lesser API contract change

Compatibility classification: semantic refinement with an additive observable error code for the pending-request case. Generic MCP tool-error handling remains compatible.

## Tests

Regression coverage proves:

- a matching pending counterpart returns `message_request_pending`, the stable conversation id, preview, and decision actions
- unrelated pending requests do not match
- account id, username, `@username`, case, and `username@domain` selectors match
- accepted request records are ignored by the fallback
- a failed request-folder check is inconclusive, not a false 404
- the focused flow returns the pending action before acceptance and conversation messages after explicit acceptance
- authorization failures remain authorization failures

## Validation

- `git diff --check`
- `gofmt -l .` clean
- `go build ./...`
- `go test ./...`
- `go vet ./...`
- `bash scripts/build.sh`
- repo-local governance rubric: **PASS — 19 pass / 0 fail / 0 blocked**
- DCO trailers verified for every commit

## Rollout verification

After factory merges to git branch `staging`, deploy and soak through lab/dev before promotion. With a fresh first-contact request:

1. call `direct_messages_read` as the recipient and confirm `message_request_pending`
2. confirm the request remains `PENDING` after the read
3. call the returned `message_request_accept` action
4. retry `direct_messages_read` and confirm the conversation/messages are returned
5. repeat with an absent counterpart and confirm actionable `not_found`

## Provenance note

TheoryMCP routing remains unavailable. The operator explicitly directed use of the local GitHub CLI fallback. Merge authority remains with factory.
