### PR TITLE
fix(mcp): log app.internal boundary failures so 500s are diagnosable

### DIFF
--- a/internal/mcpapp/app.go
+++ b/internal/mcpapp/app.go
@@ -31,7 +31,7 @@ func New(name, version string) (*apptheory.App, error) {
 
 	rootHandler := WithBrowserCORS(SharedMcpRetiredHandler())
 	runtimeHandler := withActorOAuthSessionRecovery(srv.Handler())
-	actorHandler := WithBrowserCORS(WithClientCompatibilityHeaders(WithMCPAuthorization(WithActorBinding(WithRuntimePolicy(WithAudit(WithToolContext(runtimeHandler), logger))))))
+	actorHandler := WithErrorBoundary(WithBrowserCORS(WithClientCompatibilityHeaders(WithMCPAuthorization(WithActorBinding(WithRuntimePolicy(WithAudit(WithToolContext(runtimeHandler), logger)))))), logger)
 
 	app.Post("/mcp/{actor}", actorHandler)
 	app.Get("/mcp/{actor}", actorHandler)

--- a/internal/mcpapp/error_logging.go
+++ b/internal/mcpapp/error_logging.go
@@ -1,0 +1,163 @@
+package mcpapp
+
+import (
+	"errors"
+	"log/slog"
+	"runtime/debug"
+	"strings"
+
+	"github.com/equaltoai/lesser-body/internal/auth"
+	"github.com/equaltoai/lesser-body/internal/mcpserver"
+	apptheory "github.com/theory-cloud/apptheory/v3/runtime"
+)
+
+// WithErrorBoundary logs any unhandled error or panic that is about to become
+// an `app.internal` HTTP 500 at the AppTheory error boundary. It must be the
+// outermost actor-route middleware so it observes every downstream gate and the
+// MCP runtime itself, including the grantee-only share-caller path.
+//
+// The log record carries the wrapped error message, the request_id, the route
+// and resolved actor, and a best-effort caller class. It deliberately never
+// reads or logs the Authorization header, the request body, bearer tokens,
+// x402 grant material, or any other secret-bearing input.
+func WithErrorBoundary(next apptheory.Handler, logger *slog.Logger) apptheory.Handler {
+	if next == nil {
+		return nil
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	return func(ctx *apptheory.Context) (resp *apptheory.Response, err error) {
+		defer func() {
+			if r := recover(); r != nil {
+				logBoundaryFailure(logger, ctx, "panic", strings.TrimSpace(string(debug.Stack())))
+				resp = nil
+				err = &apptheory.AppError{Code: "app.internal", Message: "internal error"}
+			}
+		}()
+
+		resp, err = next(ctx)
+		if err != nil && shouldLogBoundaryError(err) {
+			logBoundaryFailure(logger, ctx, "error", strings.TrimSpace(err.Error()))
+		}
+		return resp, err
+	}
+}
+
+// shouldLogBoundaryError reports whether err will surface as an app.internal
+// 500 rather than an intentional, structured 4xx. Plain errors and panics are
+// the cases the boundary previously emitted silently; structured AppErrors and
+// AppTheoryErrors keep their existing audit paths.
+func shouldLogBoundaryError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var appErr *apptheory.AppError
+	if errors.As(err, &appErr) {
+		return appErr.Code == "" || appErr.Code == "app.internal"
+	}
+	var portableErr *apptheory.AppTheoryError
+	if errors.As(err, &portableErr) {
+		return portableErr.Code == "" || portableErr.Code == "app.internal"
+	}
+	return true
+}
+
+func logBoundaryFailure(logger *slog.Logger, ctx *apptheory.Context, kind string, detail string) {
+	if logger == nil {
+		return
+	}
+
+	requestID := ""
+	if ctx != nil {
+		requestID = strings.TrimSpace(ctx.RequestID)
+	}
+
+	attrs := []any{
+		"event", "mcp_error_boundary",
+		"kind", kind,
+		"error", detail,
+		"request_id", requestID,
+	}
+	if ctx != nil {
+		attrs = append(attrs,
+			"route", strings.TrimSpace(ctx.Request.Path),
+			"actor", actorFromRequestContext(ctx),
+			"caller_class", boundaryCallerClass(ctx),
+			"principal_type", boundaryPrincipalType(ctx),
+			"identity", boundaryIdentity(ctx),
+			"delegated_by", boundaryDelegatedBy(ctx),
+			"share_caller", boundaryShareCaller(ctx),
+		)
+	}
+
+	logger.Error("MCP request failed before a response was produced", attrs...)
+}
+
+func boundaryCallerClass(ctx *apptheory.Context) string {
+	if ctx == nil {
+		return "unknown"
+	}
+	principal := auth.PrincipalFromContext(ctx)
+	if principal == nil {
+		return "unknown"
+	}
+	switch principal.Type {
+	case auth.PrincipalTypeX402Grant:
+		return "public_paid"
+	case auth.PrincipalTypeInstanceKey:
+		return "instance_key"
+	case auth.PrincipalTypeOAuthToken:
+		if _, shared := mcpserver.ShareCallerFromContext(ctx.Context()); shared {
+			return "bound_body"
+		}
+		if boundaryDelegatedBy(ctx) != "" {
+			return "principal_operator"
+		}
+		return "bound_body"
+	default:
+		return "unknown"
+	}
+}
+
+func boundaryPrincipalType(ctx *apptheory.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	principal := auth.PrincipalFromContext(ctx)
+	if principal == nil {
+		return ""
+	}
+	return strings.TrimSpace(string(principal.Type))
+}
+
+func boundaryIdentity(ctx *apptheory.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	principal := auth.PrincipalFromContext(ctx)
+	if principal == nil {
+		return ""
+	}
+	return strings.TrimSpace(principal.Identity)
+}
+
+func boundaryDelegatedBy(ctx *apptheory.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	principal := auth.PrincipalFromContext(ctx)
+	if principal == nil || principal.Claims == nil {
+		return ""
+	}
+	return strings.TrimSpace(principal.Claims.DelegatedBy)
+}
+
+func boundaryShareCaller(ctx *apptheory.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	_, shared := mcpserver.ShareCallerFromContext(ctx.Context())
+	return shared
+}

--- a/internal/mcpapp/error_logging_test.go
+++ b/internal/mcpapp/error_logging_test.go
@@ -1,0 +1,85 @@
+package mcpapp
+
+import (
+	"bytes"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/equaltoai/lesser-body/internal/auth"
+	apptheory "github.com/theory-cloud/apptheory/v3/runtime"
+)
+
+func TestWithErrorBoundary_LogsErrorWithoutSecrets(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+
+	handler := WithErrorBoundary(func(ctx *apptheory.Context) (*apptheory.Response, error) {
+		return nil, errors.New("dynamodb read soul binding: timeout")
+	}, logger)
+
+	ctx := &apptheory.Context{
+		RequestID: "req-123",
+		Request: apptheory.Request{
+			Path:    "/mcp/della-marlowe",
+			Headers: map[string][]string{"authorization": {"Bearer super-secret-token"}},
+		},
+		Params: map[string]string{"actor": "della-marlowe"},
+	}
+	auth.WithPrincipal(ctx, &auth.Principal{
+		Type:     auth.PrincipalTypeOAuthToken,
+		Identity: "della-marlowe",
+		Claims:   &auth.Claims{DelegatedBy: "aron"},
+	})
+
+	resp, err := handler(ctx)
+	if resp != nil {
+		t.Fatalf("expected nil response, got %+v", resp)
+	}
+	if err == nil || err.Error() != "dynamodb read soul binding: timeout" {
+		t.Fatalf("expected the wrapped error to propagate unchanged, got %v", err)
+	}
+
+	out := buf.String()
+	for _, want := range []string{"dynamodb read soul binding: timeout", "req-123", "della-marlowe", "oauth_token", "aron", "error"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected boundary log to contain %q, got:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "super-secret-token") || strings.Contains(out, "Bearer") || strings.Contains(out, "authorization") {
+		t.Fatalf("boundary log leaked bearer material:\n%s", out)
+	}
+}
+
+func TestWithErrorBoundary_RecoversPanicAndReturnsInternalError(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+
+	handler := WithErrorBoundary(func(ctx *apptheory.Context) (*apptheory.Response, error) {
+		panic("secret panic value")
+	}, logger)
+
+	ctx := &apptheory.Context{
+		RequestID: "req-panic",
+		Request:   apptheory.Request{Path: "/mcp/arch"},
+		Params:    map[string]string{"actor": "arch"},
+	}
+
+	resp, err := handler(ctx)
+	if resp != nil {
+		t.Fatalf("expected nil response after recovered panic, got %+v", resp)
+	}
+	appErr, ok := err.(*apptheory.AppError)
+	if !ok || appErr.Code != "app.internal" || appErr.Message != "internal error" {
+		t.Fatalf("expected recovered panic to become app.internal, got %T %+v", err, err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "panic") || !strings.Contains(out, "req-panic") {
+		t.Fatalf("expected panic boundary log, got:\n%s", out)
+	}
+	if strings.Contains(out, "secret panic value") {
+		t.Fatalf("boundary log leaked the panic value:\n%s", out)
+	}
+}

--- a/internal/mcpapp/grantee_initialize_regression_test.go
+++ b/internal/mcpapp/grantee_initialize_regression_test.go
@@ -1,0 +1,80 @@
+package mcpapp_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/theory-cloud/apptheory/v3/testkit"
+	mcpruntime "github.com/theory-cloud/apptheory/v3/runtime/mcp"
+	tablecore "github.com/theory-cloud/tabletheory/v3/pkg/core"
+
+	"github.com/equaltoai/lesser-body/internal/auth"
+	"github.com/equaltoai/lesser-body/internal/mcpapp"
+	"github.com/equaltoai/lesser-body/internal/soulbinding"
+)
+
+// TestGranteeInitializeSucceeds drives the full production app through the
+// composed chain (WithMCPAuthorization → WithActorBinding → … → initialize)
+// with a grantee-shaped principal: token subject is the agent della-marlowe,
+// IsAgent=true, DelegatedBy=aron, an active share grant exists, and the agent
+// has a soul binding. The grantee must be admitted and initialize must return
+// HTTP 200. This locks the grantee handshake path that the live incident
+// reported as an app.internal 500.
+func TestGranteeInitializeSucceeds(t *testing.T) {
+	t.Setenv("MCP_SESSION_TABLE", "")
+	t.Setenv("MCP_STREAM_TABLE", "")
+	t.Setenv("MCP_TASK_TABLE", "")
+	t.Setenv("MCP_ALLOWED_ORIGINS", "")
+	t.Setenv("MCP_ENDPOINT", "https://api.theory.greater.website/mcp/{actor}")
+	t.Setenv("LESSER_TABLE_NAME", "test-main-table")
+	t.Setenv("JWT_SECRET", "test-secret")
+	t.Setenv("JWT_SECRET_ARN", "")
+	auth.ResetForTests()
+	t.Cleanup(auth.ResetForTests)
+	installTrustConfigIsolation(t)
+
+	state := &composedAdmissionState{owner: "theory", grantExists: true, grantRevoked: false}
+	installComposedAgentShareDB(t, state)
+
+	soulbinding.ResetForTests()
+	t.Cleanup(soulbinding.ResetForTests)
+	soulbinding.SetDBFactoryForTests(func() (tablecore.DB, error) {
+		return &fakeTableTheoryDB{
+			firstFn: func(dest any, where map[string]any) error {
+				return setStructFields(dest, map[string]string{
+					"PK":       "SOUL_BODY_BINDING_USERNAME#della-marlowe",
+					"SK":       "SOUL_BODY_BINDING",
+					"Username": "della-marlowe",
+					"AgentID":  "0x1234567890abcdef",
+				})
+			},
+		}, nil
+	})
+
+	app, err := mcpapp.New("test", "dev")
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+
+	token := composedTestJWT(t, "della-marlowe", "@aron")
+
+	env := testkit.New()
+	resp := invokeJSONAtPath(t, env, app, "/mcp/della-marlowe", map[string][]string{
+		"authorization": {"Bearer " + token},
+	}, &mcpruntime.Request{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "initialize",
+	})
+
+	if resp.Status != 200 {
+		t.Fatalf("expected grantee initialize to return HTTP 200, got %d (%s)", resp.Status, string(resp.Body))
+	}
+	var rpc mcpruntime.Response
+	if err := json.Unmarshal(resp.Body, &rpc); err != nil {
+		t.Fatalf("unmarshal initialize response: %v", err)
+	}
+	if rpc.Error != nil {
+		t.Fatalf("expected grantee initialize to have no JSON-RPC error, got %+v", rpc.Error)
+	}
+}

--- a/internal/mcpapp/grantee_initialize_regression_test.go
+++ b/internal/mcpapp/grantee_initialize_regression_test.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/theory-cloud/apptheory/v3/testkit"
 	mcpruntime "github.com/theory-cloud/apptheory/v3/runtime/mcp"
+	"github.com/theory-cloud/apptheory/v3/testkit"
 	tablecore "github.com/theory-cloud/tabletheory/v3/pkg/core"
 
 	"github.com/equaltoai/lesser-body/internal/auth"


### PR DESCRIPTION
Live incident support: body returns `app.internal` 500s that are **invisible to every observability surface**. This adds an error boundary at the outermost actor-handler layer so the next failure names itself.

## Why this is needed

Grantee MCP `initialize` is failing in TheoryLive with:

```
HTTP 500 {"error":{"code":"app.internal","message":"internal error",
 "request_id":"4a63bbe719d9810970c226d36d0a36e9","trace_id":"1-6a7de3eb-..."}}
```

Diagnosing it cost roughly an hour and did not reach root cause, because:

- **No CloudWatch application log.** That `request_id` appears in **no log group**.
- **No X-Ray fault.** All 329 traces in the failure window report 200/202; the failing trace records HTTP **200**, because the Lambda invocation succeeds while the 500 rides in the response payload.
- By contrast lesser logs structured entries carrying `request_id` — which is how the OAuth authorize/consent/token sequence was reconstructed in seconds.

## What this changes

`WithErrorBoundary` wraps the actor handler outermost (`internal/mcpapp/app.go`), logging the wrapped error, `request_id`, route/actor, and caller class on `app.internal` failures. No behavior change: instrumentation plus tests only.

## Scope

`internal/mcpapp/error_logging.go` (new), its tests, a grantee-initialize regression test, and the one-line wiring. No auth logic, no admission changes, no weakening of per-request grant enforcement or fail-closed behavior.

## Honest status

The implementing session could **not** reproduce the production failure locally against live fixtures, and neither could factory — both run with admin credentials outside Lambda. This PR is the enabler, not the fix: once deployed, the next occurrence pins the cause in one request instead of another hour of log archaeology.

Refs #560
