### PR TITLE
fix(mcp): normalize article_get missing article

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -697,16 +697,16 @@ Scope key:
 | `notification_get` | Read | Expand a compact notification ref through Lesser's notification read route. |
 | `notification_dismiss` | Write | Dismiss one notification or all notifications by marking them read through Lesser. |
 | `article_draft_create` | Write | Create an owner-scoped unpublished Article draft for the authenticated actor through Lesser CMS; defaults to a compact draft ref, never auto-publishes, and creates no cross-actor read grant. |
-| `article_draft_update` | Write | Update an owner-scoped unpublished Article draft belonging to the authenticated actor; defaults compact and does not grant reviewer access, preview, or publish. |
-| `article_draft_get` | Read | Read one Article draft when Lesser authorizes the caller as its owner or through an active reviewer grant. Owner reads retain the existing `draft(id:)` projection; authorized reviewer reads fall back to the exact `DraftReview` source/hash/revision snapshot. Revoked or unauthorized cross-actor ids return not found. Compact refs expand with `article_draft_get(view=standard)`. |
+| `article_draft_update` | Write | Update an owner-scoped unpublished Article draft belonging to the authenticated actor; defaults compact and does not grant reviewer access, preview, or publish. Missing or cross-actor ids return `not_found`/404 with `details.lookup="id"`. |
+| `article_draft_get` | Read | Read one Article draft when Lesser authorizes the caller as its owner or through an active reviewer grant. Owner reads retain the existing `draft(id:)` projection; authorized reviewer reads fall back to the exact `DraftReview` source/hash/revision snapshot. Revoked, unauthorized, or missing ids return `not_found`/404 with `details.lookup="id"`. Compact refs expand with `article_draft_get(view=standard)`. |
 | `article_draft_list` | Read | List only the authenticated actor's owner-scoped unpublished Article draft refs through Lesser CMS; compact results include title, save/create/update timestamps, `contentHash`, and `revision` for triage and concurrency checks, while full content still requires `article_draft_get`. |
-| `article_draft_preview` | Read | Render one Article draft through Lesser's canonical renderer/sanitizer when Lesser authorizes the caller as its owner or through an active reviewer grant. Body uses caller-authorized review state for the `DRAFT` preflight; revoked or unauthorized cross-actor ids return not found, and raw draft content is not returned by preview. |
+| `article_draft_preview` | Read | Render one Article draft through Lesser's canonical renderer/sanitizer when Lesser authorizes the caller as its owner or through an active reviewer grant. Body uses caller-authorized review state for the `DRAFT` preflight; revoked, unauthorized, or missing ids return `not_found`/404 with `details.lookup="id"`, and raw draft content is not returned by preview. |
 | `article_draft_review_submit` | Write | Submit an owner-scoped Article draft to one Lesser reviewer by creating or refreshing Lesser's revocable review grant. Every MCP-created Article draft is agent-generated, so Lesser requires unanimous current approval from every active reviewer plus active approval from the configured instance principal before publishing. |
-| `article_draft_review_read` | Read | With `draft_id`, read the caller-authorized Lesser review state; without it, list the caller's active paginated compact review queue. State mode defaults to compact metadata, while `view=standard` returns Lesser's complete, untruncated source and canonical rendering from the same authoritative snapshot as the hash/revision binding, grants, verdict staleness, and publish eligibility. Every MCP-created Article draft is agent-generated, so Lesser requires unanimous current approval from every active reviewer plus active approval from the configured instance principal before publishing. |
+| `article_draft_review_read` | Read | With `draft_id`, read the caller-authorized Lesser review state; without it, list the caller's active paginated compact review queue. State mode defaults to compact metadata, while `view=standard` returns Lesser's complete, untruncated source and canonical rendering from the same authoritative snapshot as the hash/revision binding, grants, verdict staleness, and publish eligibility. Missing state lookups return `not_found`/404 with `details.lookup="draft_id"`. Every MCP-created Article draft is agent-generated, so Lesser requires unanimous current approval from every active reviewer plus active approval from the configured instance principal before publishing. |
 | `article_draft_review_verdict` | Write | Submit Lesser's `APPROVED` or `CHANGES_REQUESTED` verdict with optional notes; Lesser records reviewer attribution and remains the publish-gate authority. Every MCP-created Article draft is agent-generated, so Lesser requires unanimous current approval from every active reviewer plus active approval from the configured instance principal before publishing. |
-| `article_draft_publish` | Write | Publish an owner-scoped Article draft belonging to the authenticated actor through Lesser CMS; cross-actor ids return not found and success returns the canonical published Article ID and URL. |
-| `article_update` | Write | Update a published Article by canonical Article ID; canonical slug/URL changes are not exposed. |
-| `article_get` | Read | Read one published Article by canonical Article ID/URL or slug; defaults compact with `article_get(view=standard)` expansion. |
+| `article_draft_publish` | Write | Publish an owner-scoped Article draft belonging to the authenticated actor through Lesser CMS; cross-actor or missing draft ids return `not_found`/404 with `details.lookup="id"`, and success returns the canonical published Article ID and URL. |
+| `article_update` | Write | Update a published Article by canonical Article ID; canonical slug/URL changes are not exposed. Missing ids return `not_found`/404 with `details.lookup="id"`. |
+| `article_get` | Read | Read one published Article by canonical Article ID/URL or slug; defaults compact with `article_get(view=standard)` expansion. Missing records return `not_found`/404 with `details.lookup` equal to the caller's actual field (`id` or `slug`). |
 | `article_list` | Read | List the authenticated actor's published Article refs through Lesser CMS; defaults compact. |
 | `post_create` | Write | Create a new post. |
 | `post_boost` | Write | Boost/reblog a post. |
@@ -1548,7 +1548,8 @@ index/ref pages and expand only the items they need:
   `policy.autoPublishes=false` plus `policy.canonicalArticleId=not_promised_until_publish` so clients do not treat a
   draft id as a final published Article id. Authoring mutations and publish remain owner-scoped. In addition to
   `article_draft_review_read`, an actively granted reviewer can use `article_draft_get` and
-  `article_draft_preview`; Lesser remains the authorization authority and revoked/absent grants fail as not found.
+  `article_draft_preview`; Lesser remains the authorization authority and revoked/absent grants fail as `not_found`/404
+  with `details.lookup="id"`.
 - `article_draft_preview({"id":"<draft-id>"})` calls Lesser's additive `draftPreview(id: ID!)` GraphQL field and
   returns Lesser-rendered, sanitized Article HTML. Compact view defaults to a bounded `renderedHtmlPreview` plus
   byte metadata; `view:"standard"` is the explicit expansion for full `renderedHtml`. Renderer failures surface as
@@ -1562,7 +1563,11 @@ index/ref pages and expand only the items they need:
 - `article_list({"limit":10})` lists the authenticated actor's published Article refs with compact defaults and
   `article_get(view=standard)` expansion metadata. `article_get` may read by canonical `id`/URL or by `slug`; `id`
   is preferred when available. `article_update` updates bounded scalar content fields and does not expose slug mutation,
-  because canonical published Article slugs/URLs are stable in the Lesser M1 contract.
+  because canonical published Article slugs/URLs are stable in the Lesser M1 contract. `article_get` missing lookups
+  return `not_found`/404 with `details.lookup` echoing the request field (`id` or `slug`), `article_update` returns
+  the same shape with `details.lookup="id"`, and the owner/reviewer sibling reads `article_draft_get`,
+  `article_draft_update`, `article_draft_preview`, `article_draft_review_read`, and `article_draft_publish` return
+  `details.lookup="id"`, `"id"`, `"id"`, `"draft_id"`, and `"id"` respectively on missing record paths.
 
 ### Named-counterpart DM workflow
 

--- a/gov-infra/evidence/CDK-SYNTH-output.log
+++ b/gov-infra/evidence/CDK-SYNTH-output.log
@@ -239,7 +239,7 @@ Resources:
         - arm64
       Code:
         S3Bucket: cdk-hnb659fds-assets-000000000000-us-east-1
-        S3Key: 50191b1dfb0b64def7b5e834d6269c699fc8d05a3f28fa009718357514d0bc94.zip
+        S3Key: 542150d2095d85f196994792f10609556cf677e9868d298075e02c541504da1c.zip
       Environment:
         Variables:
           SERVICE_VERSION: dev
@@ -285,7 +285,7 @@ Resources:
       - McpHandlerServiceRole4A94FED3
     Metadata:
       aws:cdk:path: lesser-dev-lesser-body/McpHandler/Resource
-      aws:asset:path: asset.50191b1dfb0b64def7b5e834d6269c699fc8d05a3f28fa009718357514d0bc94.zip
+      aws:asset:path: asset.542150d2095d85f196994792f10609556cf677e9868d298075e02c541504da1c.zip
       aws:asset:is-bundled: false
       aws:asset:property: Code
   McpServerApiAccessLogs6D5B26D2:
@@ -1364,7 +1364,7 @@ Resources:
         - arm64
       Code:
         S3Bucket: cdk-hnb659fds-assets-000000000000-us-east-1
-        S3Key: 5e2f734922bedbcea50b01094164bb9564a454ada9879d73777fb820a8d9c8f4.zip
+        S3Key: f4958fee2deb3daff4d853efe0d0bdfaaa74180ed416e860e2c8d3940959e636.zip
       Environment:
         Variables:
           SERVICE_VERSION: dev
@@ -1400,7 +1400,7 @@ Resources:
       - InstanceMcpHandlerServiceRoleF472AD79
     Metadata:
       aws:cdk:path: lesser-dev-lesser-body/InstanceMcpHandler/Resource
-      aws:asset:path: asset.5e2f734922bedbcea50b01094164bb9564a454ada9879d73777fb820a8d9c8f4.zip
+      aws:asset:path: asset.f4958fee2deb3daff4d853efe0d0bdfaaa74180ed416e860e2c8d3940959e636.zip
       aws:asset:is-bundled: false
       aws:asset:property: Code
   InstanceMcpLambdaArnParam:

--- a/gov-infra/evidence/CDK-SYNTH-output.log
+++ b/gov-infra/evidence/CDK-SYNTH-output.log
@@ -239,7 +239,7 @@ Resources:
         - arm64
       Code:
         S3Bucket: cdk-hnb659fds-assets-000000000000-us-east-1
-        S3Key: 83f7a6361ea0dbefe2a304cea334f8a4322448153ee302ff50bcccede3e006cc.zip
+        S3Key: 50191b1dfb0b64def7b5e834d6269c699fc8d05a3f28fa009718357514d0bc94.zip
       Environment:
         Variables:
           SERVICE_VERSION: dev
@@ -285,7 +285,7 @@ Resources:
       - McpHandlerServiceRole4A94FED3
     Metadata:
       aws:cdk:path: lesser-dev-lesser-body/McpHandler/Resource
-      aws:asset:path: asset.83f7a6361ea0dbefe2a304cea334f8a4322448153ee302ff50bcccede3e006cc.zip
+      aws:asset:path: asset.50191b1dfb0b64def7b5e834d6269c699fc8d05a3f28fa009718357514d0bc94.zip
       aws:asset:is-bundled: false
       aws:asset:property: Code
   McpServerApiAccessLogs6D5B26D2:
@@ -1364,7 +1364,7 @@ Resources:
         - arm64
       Code:
         S3Bucket: cdk-hnb659fds-assets-000000000000-us-east-1
-        S3Key: 91c57977b2f4725e70e19f19a9f0794992804cb3867f56321898dd1f03555c91.zip
+        S3Key: 5e2f734922bedbcea50b01094164bb9564a454ada9879d73777fb820a8d9c8f4.zip
       Environment:
         Variables:
           SERVICE_VERSION: dev
@@ -1400,7 +1400,7 @@ Resources:
       - InstanceMcpHandlerServiceRoleF472AD79
     Metadata:
       aws:cdk:path: lesser-dev-lesser-body/InstanceMcpHandler/Resource
-      aws:asset:path: asset.91c57977b2f4725e70e19f19a9f0794992804cb3867f56321898dd1f03555c91.zip
+      aws:asset:path: asset.5e2f734922bedbcea50b01094164bb9564a454ada9879d73777fb820a8d9c8f4.zip
       aws:asset:is-bundled: false
       aws:asset:property: Code
   InstanceMcpLambdaArnParam:

--- a/gov-infra/evidence/CDK-TEST-output.log
+++ b/gov-infra/evidence/CDK-TEST-output.log
@@ -7,23 +7,23 @@ $ cd cdk && npm test
 > lesser-body-cdk@0.0.0 build
 > tsc
 
-✔ secret read policy includes legacy and managed instance-key patterns (644.198665ms)
-✔ managed template supports an exact lesser-host instance key ARN (135.08659ms)
-✔ managed template declares the Ptah and Ba soul-binding bearer prerequisite (101.293966ms)
-✔ managed template requires app-scoped Lesser parameter paths (94.331717ms)
-✔ lesser table policy uses least-privilege primary table access (77.247311ms)
-✔ managed template pins MCP table logical IDs (95.30511ms)
-✔ every MCP-serving lambda uses the 24-hour session TTL (167.750831ms)
-✔ runtime stack uses AppTheory durable stream table schema (71.604176ms)
-✔ runtime stack provisions internal MCP task storage without SSM export (74.209923ms)
-✔ remote MCP server uses actor-path wiring (71.698424ms)
-✔ runtime stack preserves named MCP table fingerprints (74.840279ms)
-✔ stream table export name stays stable across baseline reset (70.834958ms)
-✔ runtime stack provisions instance-plane lambda with owned tables (69.357777ms)
-✔ Ka self-recovery receives only the Body content and registry tables (71.852714ms)
-✔ instance-plane lambda receives managed Lesser/Host genesis configuration (88.315671ms)
-✔ instance-plane Lesser table read includes binding lookup without memory access (89.705918ms)
-✔ runtime stack publishes additive instance-plane SSM exports (80.652833ms)
+✔ secret read policy includes legacy and managed instance-key patterns (644.688726ms)
+✔ managed template supports an exact lesser-host instance key ARN (138.159002ms)
+✔ managed template declares the Ptah and Ba soul-binding bearer prerequisite (98.068223ms)
+✔ managed template requires app-scoped Lesser parameter paths (96.275137ms)
+✔ lesser table policy uses least-privilege primary table access (75.974666ms)
+✔ managed template pins MCP table logical IDs (90.57388ms)
+✔ every MCP-serving lambda uses the 24-hour session TTL (162.034706ms)
+✔ runtime stack uses AppTheory durable stream table schema (73.851178ms)
+✔ runtime stack provisions internal MCP task storage without SSM export (72.976781ms)
+✔ remote MCP server uses actor-path wiring (76.61398ms)
+✔ runtime stack preserves named MCP table fingerprints (71.275177ms)
+✔ stream table export name stays stable across baseline reset (71.985214ms)
+✔ runtime stack provisions instance-plane lambda with owned tables (68.889324ms)
+✔ Ka self-recovery receives only the Body content and registry tables (68.774387ms)
+✔ instance-plane lambda receives managed Lesser/Host genesis configuration (87.205797ms)
+✔ instance-plane Lesser table read includes binding lookup without memory access (85.898084ms)
+✔ runtime stack publishes additive instance-plane SSM exports (72.285709ms)
 ℹ tests 17
 ℹ suites 0
 ℹ pass 17
@@ -31,4 +31,4 @@ $ cd cdk && npm test
 ℹ cancelled 0
 ℹ skipped 0
 ℹ todo 0
-ℹ duration_ms 2136.095805
+ℹ duration_ms 2109.276328

--- a/gov-infra/evidence/CDK-TEST-output.log
+++ b/gov-infra/evidence/CDK-TEST-output.log
@@ -7,23 +7,23 @@ $ cd cdk && npm test
 > lesser-body-cdk@0.0.0 build
 > tsc
 
-✔ secret read policy includes legacy and managed instance-key patterns (660.639834ms)
-✔ managed template supports an exact lesser-host instance key ARN (142.373655ms)
-✔ managed template declares the Ptah and Ba soul-binding bearer prerequisite (102.065135ms)
-✔ managed template requires app-scoped Lesser parameter paths (93.547415ms)
-✔ lesser table policy uses least-privilege primary table access (79.904838ms)
-✔ managed template pins MCP table logical IDs (94.282472ms)
-✔ every MCP-serving lambda uses the 24-hour session TTL (168.798461ms)
-✔ runtime stack uses AppTheory durable stream table schema (73.01631ms)
-✔ runtime stack provisions internal MCP task storage without SSM export (77.536645ms)
-✔ remote MCP server uses actor-path wiring (74.581411ms)
-✔ runtime stack preserves named MCP table fingerprints (77.63546ms)
-✔ stream table export name stays stable across baseline reset (73.488755ms)
-✔ runtime stack provisions instance-plane lambda with owned tables (73.631051ms)
-✔ Ka self-recovery receives only the Body content and registry tables (74.840696ms)
-✔ instance-plane lambda receives managed Lesser/Host genesis configuration (89.064011ms)
-✔ instance-plane Lesser table read includes binding lookup without memory access (93.963415ms)
-✔ runtime stack publishes additive instance-plane SSM exports (71.520741ms)
+✔ secret read policy includes legacy and managed instance-key patterns (644.198665ms)
+✔ managed template supports an exact lesser-host instance key ARN (135.08659ms)
+✔ managed template declares the Ptah and Ba soul-binding bearer prerequisite (101.293966ms)
+✔ managed template requires app-scoped Lesser parameter paths (94.331717ms)
+✔ lesser table policy uses least-privilege primary table access (77.247311ms)
+✔ managed template pins MCP table logical IDs (95.30511ms)
+✔ every MCP-serving lambda uses the 24-hour session TTL (167.750831ms)
+✔ runtime stack uses AppTheory durable stream table schema (71.604176ms)
+✔ runtime stack provisions internal MCP task storage without SSM export (74.209923ms)
+✔ remote MCP server uses actor-path wiring (71.698424ms)
+✔ runtime stack preserves named MCP table fingerprints (74.840279ms)
+✔ stream table export name stays stable across baseline reset (70.834958ms)
+✔ runtime stack provisions instance-plane lambda with owned tables (69.357777ms)
+✔ Ka self-recovery receives only the Body content and registry tables (71.852714ms)
+✔ instance-plane lambda receives managed Lesser/Host genesis configuration (88.315671ms)
+✔ instance-plane Lesser table read includes binding lookup without memory access (89.705918ms)
+✔ runtime stack publishes additive instance-plane SSM exports (80.652833ms)
 ℹ tests 17
 ℹ suites 0
 ℹ pass 17
@@ -31,4 +31,4 @@ $ cd cdk && npm test
 ℹ cancelled 0
 ℹ skipped 0
 ℹ todo 0
-ℹ duration_ms 2195.350652
+ℹ duration_ms 2136.095805

--- a/gov-infra/evidence/GOV-3-output.log
+++ b/gov-infra/evidence/GOV-3-output.log
@@ -1,4 +1,4 @@
 context=local
-HEAD=0bed3a7c5dca3c28cc7a2ba0c0b14aa1ab7b1043
+HEAD=e0b77498e303fa5f4b9f2d8023f33d4b697f16e0
 origin/staging=aee6a258f9e5eba3b8f4863bc50469f322d64175
 local current-staging lineage PASS

--- a/gov-infra/evidence/GOV-3-output.log
+++ b/gov-infra/evidence/GOV-3-output.log
@@ -1,4 +1,4 @@
 context=local
-HEAD=e4a7e23f79841a7a115e304a56f9d7120878e956
-origin/staging=372bb17cf132ad4716cda3d0f4e1d71ad6fac09b
+HEAD=0bed3a7c5dca3c28cc7a2ba0c0b14aa1ab7b1043
+origin/staging=aee6a258f9e5eba3b8f4863bc50469f322d64175
 local current-staging lineage PASS

--- a/gov-infra/evidence/RELEASE-ASSETS-output.log
+++ b/gov-infra/evidence/RELEASE-ASSETS-output.log
@@ -34,5 +34,5 @@ lesser-body-managed-live.template.json: OK
 deploy-lesser-body-from-release.sh: OK
 lesser-body-release.json: OK
 apptheory-s3-auto-delete-objects-provider-faa95a81ae7d7373f3e1f242268f904eb748d8d0fdd306e8a6fe515a1905a7d6.zip: OK
-cdk-file-asset-5e2f734922bedbce.zip: OK
+cdk-file-asset-f4958fee2deb3daf.zip: OK
 Verified release assets in dist/release-test

--- a/gov-infra/evidence/RELEASE-ASSETS-output.log
+++ b/gov-infra/evidence/RELEASE-ASSETS-output.log
@@ -34,5 +34,5 @@ lesser-body-managed-live.template.json: OK
 deploy-lesser-body-from-release.sh: OK
 lesser-body-release.json: OK
 apptheory-s3-auto-delete-objects-provider-faa95a81ae7d7373f3e1f242268f904eb748d8d0fdd306e8a6fe515a1905a7d6.zip: OK
-cdk-file-asset-91c57977b2f4725e.zip: OK
+cdk-file-asset-5e2f734922bedbce.zip: OK
 Verified release assets in dist/release-test

--- a/gov-infra/evidence/gov-rubric-report.json
+++ b/gov-infra/evidence/gov-rubric-report.json
@@ -16,12 +16,12 @@
     "reject_relationship": "abandoned_sibling_or_non_ancestor",
     "required_relationship_to_review_head": "ancestor_or_equal"
   },
-  "generated_at": "2026-08-14T15:04:49.667436Z",
+  "generated_at": "2026-08-14T15:26:30.690450Z",
   "git": {
-    "head": "e4a7e23f79841a7a115e304a56f9d7120878e956",
-    "head_tree": "bc26b34172b7388b57365974ede7e0a6ed0e76a2",
-    "merge_base_origin_staging": "372bb17cf132ad4716cda3d0f4e1d71ad6fac09b",
-    "ref": "theorymcp/equaltoai/body/issue-571-restore-article-list",
+    "head": "0bed3a7c5dca3c28cc7a2ba0c0b14aa1ab7b1043",
+    "head_tree": "55968f1e5dcccf1ff53c39983b909e9a142b8ffc",
+    "merge_base_origin_staging": "aee6a258f9e5eba3b8f4863bc50469f322d64175",
+    "ref": "codex/issue-568-article-get-not-found",
     "working_tree_after_run": "5 changed paths after verifier run"
   },
   "namespace_genome": {

--- a/gov-infra/evidence/gov-rubric-report.json
+++ b/gov-infra/evidence/gov-rubric-report.json
@@ -16,10 +16,10 @@
     "reject_relationship": "abandoned_sibling_or_non_ancestor",
     "required_relationship_to_review_head": "ancestor_or_equal"
   },
-  "generated_at": "2026-08-14T15:26:30.690450Z",
+  "generated_at": "2026-08-14T15:50:29.345317Z",
   "git": {
-    "head": "0bed3a7c5dca3c28cc7a2ba0c0b14aa1ab7b1043",
-    "head_tree": "55968f1e5dcccf1ff53c39983b909e9a142b8ffc",
+    "head": "e0b77498e303fa5f4b9f2d8023f33d4b697f16e0",
+    "head_tree": "c09d18c7a8833b8bb966ec7dfa7179920745d915",
     "merge_base_origin_staging": "aee6a258f9e5eba3b8f4863bc50469f322d64175",
     "ref": "codex/issue-568-article-get-not-found",
     "working_tree_after_run": "5 changed paths after verifier run"

--- a/internal/cmsapi/articles.go
+++ b/internal/cmsapi/articles.go
@@ -31,6 +31,25 @@ type Article struct {
 	UpdatedAt          string  `json:"updatedAt,omitempty"`
 }
 
+// ArticleNotFoundError reports a missing published article lookup in a way the
+// MCP tool layer can classify without parsing free-form error text.
+type ArticleNotFoundError struct {
+	Lookup string
+	Value  string
+}
+
+func (e *ArticleNotFoundError) Error() string {
+	if e == nil {
+		return "article not found"
+	}
+	switch strings.TrimSpace(e.Lookup) {
+	case "slug":
+		return fmt.Sprintf("article slug %q not found", e.Value)
+	default:
+		return fmt.Sprintf("article %q not found", e.Value)
+	}
+}
+
 // UpdateArticleInput is the bounded subset of Lesser UpdateArticleInput exposed
 // through body. Slug changes are intentionally not surfaced because canonical
 // published Article slugs are immutable in Lesser M1.
@@ -144,7 +163,7 @@ func (c *Client) GetArticle(ctx context.Context, bearerToken string, id string, 
 		return nil, err
 	}
 	if data.Article == nil {
-		return nil, fmt.Errorf("article %q not found", id)
+		return nil, &ArticleNotFoundError{Lookup: articleLookup(id), Value: id}
 	}
 	return data.Article, nil
 }
@@ -169,7 +188,7 @@ func (c *Client) GetArticleBySlug(ctx context.Context, bearerToken string, slug 
 		return nil, err
 	}
 	if data.ArticleBySlug == nil {
-		return nil, fmt.Errorf("article slug %q not found", slug)
+		return nil, &ArticleNotFoundError{Lookup: "slug", Value: slug}
 	}
 	return data.ArticleBySlug, nil
 }
@@ -227,4 +246,12 @@ func articleFields(includeContent bool) string {
 		fields += " content"
 	}
 	return fields
+}
+
+func articleLookup(value string) string {
+	value = strings.TrimSpace(value)
+	if strings.HasPrefix(value, "http://") || strings.HasPrefix(value, "https://") {
+		return "url"
+	}
+	return "id"
 }

--- a/internal/cmsapi/articles.go
+++ b/internal/cmsapi/articles.go
@@ -32,7 +32,9 @@ type Article struct {
 }
 
 // ArticleNotFoundError reports a missing published article lookup in a way the
-// MCP tool layer can classify without parsing free-form error text.
+// MCP tool layer can classify without parsing free-form error text. Lookup
+// names the caller-visible input field (`id` or `slug`), not an inferred value
+// shape.
 type ArticleNotFoundError struct {
 	Lookup string
 	Value  string
@@ -139,7 +141,7 @@ func (c *Client) UpdateArticle(ctx context.Context, bearerToken string, id strin
 		return nil, err
 	}
 	if data.UpdateArticle == nil {
-		return nil, fmt.Errorf("updateArticle returned no article")
+		return nil, &ArticleNotFoundError{Lookup: "id", Value: id}
 	}
 	return data.UpdateArticle, nil
 }
@@ -163,7 +165,7 @@ func (c *Client) GetArticle(ctx context.Context, bearerToken string, id string, 
 		return nil, err
 	}
 	if data.Article == nil {
-		return nil, &ArticleNotFoundError{Lookup: articleLookup(id), Value: id}
+		return nil, &ArticleNotFoundError{Lookup: "id", Value: id}
 	}
 	return data.Article, nil
 }
@@ -246,12 +248,4 @@ func articleFields(includeContent bool) string {
 		fields += " content"
 	}
 	return fields
-}
-
-func articleLookup(value string) string {
-	value = strings.TrimSpace(value)
-	if strings.HasPrefix(value, "http://") || strings.HasPrefix(value, "https://") {
-		return "url"
-	}
-	return "id"
 }

--- a/internal/cmsapi/articles_test.go
+++ b/internal/cmsapi/articles_test.go
@@ -146,7 +146,7 @@ func TestGetArticleMissingReturnsArticleNotFoundErrorForIDAndURL(t *testing.T) {
 		wantLookup string
 	}{
 		{name: "id", locator: "article-123", wantLookup: "id"},
-		{name: "url", locator: "https://example.com/articles/missing", wantLookup: "url"},
+		{name: "canonical url in id field", locator: "https://example.com/articles/missing", wantLookup: "id"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/cmsapi/articles_test.go
+++ b/internal/cmsapi/articles_test.go
@@ -3,6 +3,7 @@ package cmsapi
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -135,5 +136,60 @@ func TestPublishedArticleOperationsBuildM1GraphQLContract(t *testing.T) {
 	}
 	if !strings.Contains(operations[5].Query, "edges { cursor node {") || !strings.Contains(operations[5].Query, " content ") {
 		t.Fatalf("standard list query must select node content, got %s", operations[5].Query)
+	}
+}
+
+func TestGetArticleMissingReturnsArticleNotFoundErrorForIDAndURL(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		locator    string
+		wantLookup string
+	}{
+		{name: "id", locator: "article-123", wantLookup: "id"},
+		{name: "url", locator: "https://example.com/articles/missing", wantLookup: "url"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"data":{"article":null}}`))
+			}))
+			defer server.Close()
+
+			client := newTestClient(t, server.URL)
+			got, err := client.GetArticle(context.Background(), "token", tc.locator, true)
+			if got != nil {
+				t.Fatalf("GetArticle = %+v, want nil on missing article", got)
+			}
+
+			var notFound *ArticleNotFoundError
+			if !errors.As(err, &notFound) {
+				t.Fatalf("GetArticle error = %T %v, want *ArticleNotFoundError", err, err)
+			}
+			if notFound.Lookup != tc.wantLookup || notFound.Value != tc.locator {
+				t.Fatalf("ArticleNotFoundError = %+v, want lookup=%q value=%q", notFound, tc.wantLookup, tc.locator)
+			}
+		})
+	}
+}
+
+func TestGetArticleBySlugMissingReturnsArticleNotFoundError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"articleBySlug":null}}`))
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server.URL)
+	got, err := client.GetArticleBySlug(context.Background(), "token", "missing-slug", true)
+	if got != nil {
+		t.Fatalf("GetArticleBySlug = %+v, want nil on missing article", got)
+	}
+
+	var notFound *ArticleNotFoundError
+	if !errors.As(err, &notFound) {
+		t.Fatalf("GetArticleBySlug error = %T %v, want *ArticleNotFoundError", err, err)
+	}
+	if notFound.Lookup != "slug" || notFound.Value != "missing-slug" {
+		t.Fatalf("ArticleNotFoundError = %+v, want lookup=%q value=%q", notFound, "slug", "missing-slug")
 	}
 }

--- a/internal/cmsapi/drafts.go
+++ b/internal/cmsapi/drafts.go
@@ -44,6 +44,21 @@ type Draft struct {
 	UpdatedAt       string  `json:"updatedAt,omitempty"`
 }
 
+// DraftNotFoundError reports a missing ARTICLE draft lookup in a way the MCP
+// tool layer can classify without parsing free-form error text. Lookup names
+// the caller-visible input field (`id`).
+type DraftNotFoundError struct {
+	Lookup string
+	Value  string
+}
+
+func (e *DraftNotFoundError) Error() string {
+	if e == nil {
+		return "draft not found"
+	}
+	return fmt.Sprintf("draft %q not found", e.Value)
+}
+
 // DraftPreview is Lesser's canonical ARTICLE draft preview contract. The HTML
 // is rendered and sanitized by Lesser; body never renders draft source locally.
 type DraftPreview struct {
@@ -180,7 +195,7 @@ func (c *Client) GetArticleDraft(ctx context.Context, bearerToken string, id str
 		return nil, err
 	}
 	if data.Draft == nil {
-		return nil, fmt.Errorf("draft %q not found", id)
+		return nil, &DraftNotFoundError{Lookup: "id", Value: id}
 	}
 	return data.Draft, nil
 }

--- a/internal/cmsapi/drafts_test.go
+++ b/internal/cmsapi/drafts_test.go
@@ -3,6 +3,7 @@ package cmsapi
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -153,6 +154,28 @@ func TestArticleDraftPreviewOperationBuildsM45GraphQLContract(t *testing.T) {
 	}
 	if strings.Contains(query, "draft(id:") {
 		t.Fatalf("preview query must use draftPreview contract, got %s", query)
+	}
+}
+
+func TestGetArticleDraftMissingReturnsDraftNotFoundError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"draft":null}}`))
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server.URL)
+	got, err := client.GetArticleDraft(context.Background(), "token", "missing-draft", true)
+	if got != nil {
+		t.Fatalf("GetArticleDraft = %+v, want nil on missing draft", got)
+	}
+
+	var notFound *DraftNotFoundError
+	if !errors.As(err, &notFound) {
+		t.Fatalf("GetArticleDraft error = %T %v, want *DraftNotFoundError", err, err)
+	}
+	if notFound.Lookup != "id" || notFound.Value != "missing-draft" {
+		t.Fatalf("DraftNotFoundError = %+v, want lookup=%q value=%q", notFound, "id", "missing-draft")
 	}
 }
 

--- a/internal/cmsapi/reviews.go
+++ b/internal/cmsapi/reviews.go
@@ -50,6 +50,22 @@ type DraftReview struct {
 	PublishEligibility        DraftPublishEligibility    `json:"publishEligibility"`
 }
 
+// DraftReviewNotFoundError reports a missing caller-authorized draftReview
+// lookup in a way the MCP tool layer can classify without parsing free-form
+// error text. Lookup names the Lesser review-state identifier (`id`); the tool
+// layer may remap that to a caller-facing argument name such as `draft_id`.
+type DraftReviewNotFoundError struct {
+	Lookup string
+	Value  string
+}
+
+func (e *DraftReviewNotFoundError) Error() string {
+	if e == nil {
+		return "draft review not found"
+	}
+	return fmt.Sprintf("draft review %q not found", e.Value)
+}
+
 // DraftReviewGrant is Lesser's caller-visible grant and reviewer projection.
 type DraftReviewGrant struct {
 	ReviewerID string  `json:"reviewerId"`
@@ -178,7 +194,7 @@ func (c *Client) readArticleDraftReview(ctx context.Context, bearerToken, draftI
 		return nil, err
 	}
 	if data.DraftReview == nil {
-		return nil, fmt.Errorf("draft review %q not found", draftID)
+		return nil, &DraftReviewNotFoundError{Lookup: "id", Value: draftID}
 	}
 	normalizeDraftReview(data.DraftReview)
 	return data.DraftReview, nil

--- a/internal/cmsapi/reviews_test.go
+++ b/internal/cmsapi/reviews_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -147,5 +148,27 @@ func TestArticleDraftReviewClientValidatesInputsBeforeRequest(t *testing.T) {
 	}
 	if requests != 0 {
 		t.Fatalf("requests = %d, want 0", requests)
+	}
+}
+
+func TestReadArticleDraftReviewMissingReturnsDraftReviewNotFoundError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"draftReview":null}}`))
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server.URL)
+	got, err := client.ReadArticleDraftReview(context.Background(), "token", "missing-review")
+	if got != nil {
+		t.Fatalf("ReadArticleDraftReview = %+v, want nil on missing review", got)
+	}
+
+	var notFound *DraftReviewNotFoundError
+	if !errors.As(err, &notFound) {
+		t.Fatalf("ReadArticleDraftReview error = %T %v, want *DraftReviewNotFoundError", err, err)
+	}
+	if notFound.Lookup != "id" || notFound.Value != "missing-review" {
+		t.Fatalf("DraftReviewNotFoundError = %+v, want lookup=%q value=%q", notFound, "id", "missing-review")
 	}
 }

--- a/internal/mcpserver/article_published_tools_test.go
+++ b/internal/mcpserver/article_published_tools_test.go
@@ -26,6 +26,151 @@ type articleFixtureOptions struct {
 	excerptRunes   int
 }
 
+func TestArticleGetReturnsCleanNotFoundForMissingSlugIDAndURL(t *testing.T) {
+	var operations []cmsapi.Operation
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("Authorization = %q, want exact caller bearer", got)
+			http.Error(w, "unexpected bearer", http.StatusInternalServerError)
+			return
+		}
+		var op cmsapi.Operation
+		if err := json.NewDecoder(r.Body).Decode(&op); err != nil {
+			t.Errorf("decode operation: %v", err)
+			http.Error(w, "invalid operation", http.StatusBadRequest)
+			return
+		}
+		operations = append(operations, op)
+		w.Header().Set("Content-Type", "application/json")
+		switch op.OperationName {
+		case "BodyArticle":
+			_, _ = w.Write([]byte(`{"data":{"article":null}}`))
+		case "BodyArticleBySlug":
+			_, _ = w.Write([]byte(`{"data":{"articleBySlug":null}}`))
+		default:
+			t.Fatalf("unexpected operation %q", op.OperationName)
+		}
+	}))
+	t.Cleanup(func() {
+		server.Close()
+		lesserapi.ResetForTests()
+	})
+	t.Setenv("LESSER_API_BASE_URL", server.URL)
+	lesserapi.ResetForTests()
+
+	for _, tc := range []struct {
+		name       string
+		args       string
+		wantOp     string
+		wantLookup string
+	}{
+		{name: "missing by id", args: `{"id":"article-123"}`, wantOp: "BodyArticle", wantLookup: "id"},
+		{name: "missing by url", args: `{"id":"https://example.com/articles/missing"}`, wantOp: "BodyArticle", wantLookup: "url"},
+		{name: "missing by slug", args: `{"slug":"missing-slug"}`, wantOp: "BodyArticleBySlug", wantLookup: "slug"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			before := len(operations)
+			result, err := handleArticleGet(articleDraftTestContext(), json.RawMessage(tc.args))
+			if err != nil {
+				t.Fatalf("handleArticleGet: %v", err)
+			}
+			payload := toolErrorPayloadForTest(t, result)
+			if payload["code"] != "not_found" || intFromAny(payload["status"]) != http.StatusNotFound {
+				t.Fatalf("error payload = %#v, want not_found/404", payload)
+			}
+			details, _ := payload["details"].(map[string]any)
+			if details["lookup"] != tc.wantLookup || details["tool"] != "article_get" {
+				t.Fatalf("error details = %#v, want lookup=%q tool=article_get", details, tc.wantLookup)
+			}
+			if len(operations) != before+1 || operations[before].OperationName != tc.wantOp {
+				t.Fatalf("operations = %+v, want trailing op %q", operations, tc.wantOp)
+			}
+		})
+	}
+}
+
+func TestArticleGetReturnsSuccessForExistingSlugIDAndURL(t *testing.T) {
+	const articleURL = "https://example.com/articles/hello"
+	var operations []cmsapi.Operation
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("Authorization = %q, want exact caller bearer", got)
+			http.Error(w, "unexpected bearer", http.StatusInternalServerError)
+			return
+		}
+		var op cmsapi.Operation
+		if err := json.NewDecoder(r.Body).Decode(&op); err != nil {
+			t.Errorf("decode operation: %v", err)
+			http.Error(w, "invalid operation", http.StatusBadRequest)
+			return
+		}
+		operations = append(operations, op)
+		w.Header().Set("Content-Type", "application/json")
+		switch op.OperationName {
+		case "BodyArticle":
+			_, _ = fmt.Fprintf(w, `{"data":{"article":{"id":%q,"slug":"hello","title":"Hello","content":"body","contentFormat":"MARKDOWN","readingTimeMinutes":1,"wordCount":10,"publishedAt":"2026-05-19T23:00:00Z","createdAt":"2026-05-19T23:00:00Z","updatedAt":"2026-05-19T23:00:00Z"}}}`, articleURL)
+		case "BodyArticleBySlug":
+			_, _ = fmt.Fprintf(w, `{"data":{"articleBySlug":{"id":%q,"slug":"hello","title":"Hello","content":"body","contentFormat":"MARKDOWN","readingTimeMinutes":1,"wordCount":10,"publishedAt":"2026-05-19T23:00:00Z","createdAt":"2026-05-19T23:00:00Z","updatedAt":"2026-05-19T23:00:00Z"}}}`, articleURL)
+		default:
+			t.Fatalf("unexpected operation %q", op.OperationName)
+		}
+	}))
+	t.Cleanup(func() {
+		server.Close()
+		lesserapi.ResetForTests()
+	})
+	t.Setenv("LESSER_API_BASE_URL", server.URL)
+	lesserapi.ResetForTests()
+
+	for _, tc := range []struct {
+		name   string
+		args   string
+		wantOp string
+	}{
+		{name: "existing by id", args: `{"id":"article-123","view":"standard"}`, wantOp: "BodyArticle"},
+		{name: "existing by url", args: `{"id":"https://example.com/articles/hello","view":"standard"}`, wantOp: "BodyArticle"},
+		{name: "existing by slug", args: `{"slug":"hello","view":"standard"}`, wantOp: "BodyArticleBySlug"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			before := len(operations)
+			result, err := handleArticleGet(articleDraftTestContext(), json.RawMessage(tc.args))
+			if err != nil {
+				t.Fatalf("handleArticleGet: %v", err)
+			}
+			if result == nil || result.IsError {
+				t.Fatalf("result = %+v, want success", result)
+			}
+			if len(operations) != before+1 || operations[before].OperationName != tc.wantOp {
+				t.Fatalf("operations = %+v, want trailing op %q", operations, tc.wantOp)
+			}
+
+			data := articleListStructuredData(t, result)
+			if data["tool"] != "article_get" || data["operation"] != "read" || data["view"] != readViewStandard {
+				t.Fatalf("structured data = %#v", data)
+			}
+			article, _ := data["article"].(map[string]any)
+			if article["id"] != articleURL || article["slug"] != "hello" || article["content"] != "body" {
+				t.Fatalf("article = %#v", article)
+			}
+		})
+	}
+}
+
+func TestArticleToolErrorFallbackDoesNotLeakRawErrors(t *testing.T) {
+	result, err := articleDraftToolResultFromError("article_get", errors.New("raw transport secret must not escape"))
+	if err != nil {
+		t.Fatalf("articleDraftToolResultFromError: %v", err)
+	}
+	payload := toolErrorPayloadForTest(t, result)
+	if payload["code"] != "internal_error" || intFromAny(payload["status"]) != http.StatusInternalServerError {
+		t.Fatalf("error payload = %#v, want internal_error/500", payload)
+	}
+	encoded, _ := json.Marshal(result)
+	if strings.Contains(string(encoded), "raw transport secret") {
+		t.Fatalf("raw handler text escaped in result: %s", encoded)
+	}
+}
+
 func TestArticleListDefaultCompactPageFitsListBudgetAndShapesNodes(t *testing.T) {
 	conn := realisticArticleConnection(articleDraftDefaultLimit, articleFixtureOptions{})
 	var operation cmsapi.Operation

--- a/internal/mcpserver/article_published_tools_test.go
+++ b/internal/mcpserver/article_published_tools_test.go
@@ -65,7 +65,7 @@ func TestArticleGetReturnsCleanNotFoundForMissingSlugIDAndURL(t *testing.T) {
 		wantLookup string
 	}{
 		{name: "missing by id", args: `{"id":"article-123"}`, wantOp: "BodyArticle", wantLookup: "id"},
-		{name: "missing by url", args: `{"id":"https://example.com/articles/missing"}`, wantOp: "BodyArticle", wantLookup: "url"},
+		{name: "missing by canonical url in id field", args: `{"id":"https://example.com/articles/missing"}`, wantOp: "BodyArticle", wantLookup: "id"},
 		{name: "missing by slug", args: `{"slug":"missing-slug"}`, wantOp: "BodyArticleBySlug", wantLookup: "slug"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -84,6 +84,62 @@ func TestArticleGetReturnsCleanNotFoundForMissingSlugIDAndURL(t *testing.T) {
 			}
 			if len(operations) != before+1 || operations[before].OperationName != tc.wantOp {
 				t.Fatalf("operations = %+v, want trailing op %q", operations, tc.wantOp)
+			}
+		})
+	}
+}
+
+func TestArticleUpdateReturnsCleanNotFoundForMissingCanonicalIDAndURL(t *testing.T) {
+	var operations []cmsapi.Operation
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("Authorization = %q, want exact caller bearer", got)
+			http.Error(w, "unexpected bearer", http.StatusInternalServerError)
+			return
+		}
+		var op cmsapi.Operation
+		if err := json.NewDecoder(r.Body).Decode(&op); err != nil {
+			t.Errorf("decode operation: %v", err)
+			http.Error(w, "invalid operation", http.StatusBadRequest)
+			return
+		}
+		operations = append(operations, op)
+		w.Header().Set("Content-Type", "application/json")
+		if op.OperationName != "BodyUpdateArticle" {
+			t.Fatalf("unexpected operation %q", op.OperationName)
+		}
+		_, _ = w.Write([]byte(`{"data":{"updateArticle":null}}`))
+	}))
+	t.Cleanup(func() {
+		server.Close()
+		lesserapi.ResetForTests()
+	})
+	t.Setenv("LESSER_API_BASE_URL", server.URL)
+	lesserapi.ResetForTests()
+
+	for _, tc := range []struct {
+		name string
+		args string
+	}{
+		{name: "missing by id", args: `{"id":"article-123","title":"Updated"}`},
+		{name: "missing by canonical url in id field", args: `{"id":"https://example.com/articles/missing","title":"Updated"}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			before := len(operations)
+			result, err := handleArticleUpdate(articleDraftTestContext(), json.RawMessage(tc.args))
+			if err != nil {
+				t.Fatalf("handleArticleUpdate: %v", err)
+			}
+			payload := toolErrorPayloadForTest(t, result)
+			if payload["code"] != "not_found" || intFromAny(payload["status"]) != http.StatusNotFound {
+				t.Fatalf("error payload = %#v, want not_found/404", payload)
+			}
+			details, _ := payload["details"].(map[string]any)
+			if details["lookup"] != "id" || details["tool"] != "article_update" {
+				t.Fatalf("error details = %#v, want lookup=id tool=article_update", details)
+			}
+			if len(operations) != before+1 || operations[before].OperationName != "BodyUpdateArticle" {
+				t.Fatalf("operations = %+v, want trailing op %q", operations, "BodyUpdateArticle")
 			}
 		})
 	}

--- a/internal/mcpserver/article_review_tools_test.go
+++ b/internal/mcpserver/article_review_tools_test.go
@@ -249,6 +249,46 @@ func TestArticleDraftReviewStandardStateTransportsExactLesserSnapshot(t *testing
 	}
 }
 
+func TestArticleDraftReviewReadReturnsNotFoundForTypedMissingState(t *testing.T) {
+	var operations []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var op cmsapi.Operation
+		if err := json.NewDecoder(r.Body).Decode(&op); err != nil {
+			t.Errorf("decode operation: %v", err)
+			http.Error(w, "invalid operation", http.StatusBadRequest)
+			return
+		}
+		operations = append(operations, op.OperationName)
+		w.Header().Set("Content-Type", "application/json")
+		if op.OperationName != "BodyArticleDraftReview" {
+			t.Fatalf("unexpected operation %q", op.OperationName)
+		}
+		_, _ = w.Write([]byte(`{"data":{"draftReview":null}}`))
+	}))
+	t.Cleanup(func() {
+		server.Close()
+		lesserapi.ResetForTests()
+	})
+	t.Setenv("LESSER_API_BASE_URL", server.URL)
+	lesserapi.ResetForTests()
+
+	result, err := handleArticleDraftReviewRead(articleDraftTestContext(), json.RawMessage(`{"draft_id":"draft-missing"}`))
+	if err != nil {
+		t.Fatalf("article_draft_review_read: %v", err)
+	}
+	payload := toolErrorPayloadForTest(t, result)
+	if payload["code"] != "not_found" || intFromAny(payload["status"]) != http.StatusNotFound {
+		t.Fatalf("error payload = %#v, want not_found/404", payload)
+	}
+	details, _ := payload["details"].(map[string]any)
+	if details["lookup"] != "draft_id" || details["tool"] != "article_draft_review_read" {
+		t.Fatalf("error details = %#v, want lookup=draft_id tool=article_draft_review_read", details)
+	}
+	if len(operations) != 1 || operations[0] != "BodyArticleDraftReview" {
+		t.Fatalf("operations = %+v, want only BodyArticleDraftReview", operations)
+	}
+}
+
 func TestArticleDraftReviewDefaultQueueFitsDefaultBudget(t *testing.T) {
 	budget := reviewOutputBudget(0)
 	for _, tc := range []struct {

--- a/internal/mcpserver/article_tools.go
+++ b/internal/mcpserver/article_tools.go
@@ -405,6 +405,10 @@ func articleDraftOwnerLookupNotFound(err error) bool {
 	if err == nil {
 		return false
 	}
+	var draftNotFound *cmsapi.DraftNotFoundError
+	if errors.As(err, &draftNotFound) {
+		return true
+	}
 	var gqlErr *cmsapi.GraphQLErrors
 	if errors.As(err, &gqlErr) {
 		code, status := articleDraftGraphQLErrorContract(gqlErr)
@@ -902,14 +906,19 @@ func articleDraftToolResultFromError(toolName string, err error) (*mcpruntime.To
 	}
 	var articleNotFound *cmsapi.ArticleNotFoundError
 	if errors.As(err, &articleNotFound) {
-		details := map[string]any{
-			"source": "lesser_cms_graphql",
-			"tool":   toolName,
+		return articleNotFoundToolResult(toolName, "Article not found", articleNotFound.Lookup)
+	}
+	var draftNotFound *cmsapi.DraftNotFoundError
+	if errors.As(err, &draftNotFound) {
+		return articleNotFoundToolResult(toolName, "Article draft not found", draftNotFound.Lookup)
+	}
+	var reviewNotFound *cmsapi.DraftReviewNotFoundError
+	if errors.As(err, &reviewNotFound) {
+		message := "Article draft not found"
+		if toolName == "article_draft_review_read" {
+			message = "Article draft review not found"
 		}
-		if lookup := strings.TrimSpace(articleNotFound.Lookup); lookup != "" {
-			details["lookup"] = lookup
-		}
-		return toolErrorResult("not_found", "Article not found", http.StatusNotFound, details)
+		return articleNotFoundToolResult(toolName, message, reviewNotFound.Lookup)
 	}
 	var gqlErr *cmsapi.GraphQLErrors
 	if errors.As(err, &gqlErr) {
@@ -929,6 +938,28 @@ func articleDraftToolResultFromError(toolName string, err error) (*mcpruntime.To
 		})
 	}
 	return normalizedToolResultFromError(toolName, err)
+}
+
+func articleNotFoundToolResult(toolName, message, lookup string) (*mcpruntime.ToolResult, error) {
+	details := map[string]any{
+		"source": "lesser_cms_graphql",
+		"tool":   toolName,
+	}
+	if lookup = strings.TrimSpace(articleNotFoundLookup(toolName, lookup)); lookup != "" {
+		details["lookup"] = lookup
+	}
+	return toolErrorResult("not_found", message, http.StatusNotFound, details)
+}
+
+func articleNotFoundLookup(toolName, lookup string) string {
+	lookup = strings.TrimSpace(lookup)
+	switch toolName {
+	case "article_draft_review_read":
+		if lookup == "" || lookup == "id" {
+			return "draft_id"
+		}
+	}
+	return lookup
 }
 
 func articleDraftGraphQLErrorContract(gqlErr *cmsapi.GraphQLErrors) (string, int) {

--- a/internal/mcpserver/article_tools.go
+++ b/internal/mcpserver/article_tools.go
@@ -900,6 +900,17 @@ func articleDraftToolResultFromError(toolName string, err error) (*mcpruntime.To
 	if failure := mcpAuthFailureFromError(err); failure != nil {
 		return toolErrorResult(failure.Code, failure.Message, failure.Status, failure.Details)
 	}
+	var articleNotFound *cmsapi.ArticleNotFoundError
+	if errors.As(err, &articleNotFound) {
+		details := map[string]any{
+			"source": "lesser_cms_graphql",
+			"tool":   toolName,
+		}
+		if lookup := strings.TrimSpace(articleNotFound.Lookup); lookup != "" {
+			details["lookup"] = lookup
+		}
+		return toolErrorResult("not_found", "Article not found", http.StatusNotFound, details)
+	}
 	var gqlErr *cmsapi.GraphQLErrors
 	if errors.As(err, &gqlErr) {
 		details := map[string]any{"source": "lesser_cms_graphql", "tool": toolName}
@@ -917,7 +928,7 @@ func articleDraftToolResultFromError(toolName string, err error) (*mcpruntime.To
 			"upstreamCode": apiErr.Status,
 		})
 	}
-	return nil, err
+	return normalizedToolResultFromError(toolName, err)
 }
 
 func articleDraftGraphQLErrorContract(gqlErr *cmsapi.GraphQLErrors) (string, int) {

--- a/internal/mcpserver/article_tools_test.go
+++ b/internal/mcpserver/article_tools_test.go
@@ -66,7 +66,7 @@ func TestArticleDraftGetUsesCallerAuthorizedReviewAfterOwnerLookupNotFound(t *te
 		w.Header().Set("Content-Type", "application/json")
 		switch op.OperationName {
 		case "BodyArticleDraft":
-			_, _ = w.Write([]byte(`{"data":{"draft":null},"errors":[{"message":"draft not found","path":["draft"],"extensions":{"code":"NOT_FOUND","http_status":404}}]}`))
+			_, _ = w.Write([]byte(`{"data":{"draft":null}}`))
 		case "BodyArticleDraftReview":
 			_, _ = fmt.Fprintf(w, `{"data":{"draftReview":{"draftId":"draft-1","ownerId":"author","title":"Review me","slug":"review-me","content":%q,"renderedHtml":"<h1>Review me</h1>","renderErrors":[],"contentFormat":"MARKDOWN","status":"DRAFT","updatedAt":"2026-08-09T12:00:00Z","createdAt":"2026-08-09T11:00:00Z","contentHash":"sha256:review","revision":4,"activeReviewerIds":["reviewer"],"publishEligible":false,"publishBlockingReasons":["REVIEW_APPROVAL_REQUIRED"],"reviewersApproved":false,"principalApprovalRequired":true,"principalApproved":false,"grantCount":1,"grantsTruncated":false,"grants":[{"reviewerId":"reviewer","grantedAt":"2026-08-09T11:30:00Z","status":"ACTIVE"}],"grant":{"reviewerId":"reviewer","grantedAt":"2026-08-09T11:30:00Z","status":"ACTIVE"},"verdicts":[],"publishEligibility":{"eligible":false,"blockingReasons":["REVIEW_APPROVAL_REQUIRED"],"reviewersApproved":false,"principalApprovalRequired":true,"principalApproved":false}}}}`, source)
 		default:
@@ -197,7 +197,7 @@ func TestArticleDraftPreviewDelegatesOwnerOrActiveReviewerAuthorizationToLesser(
 		switch op.OperationName {
 		case "BodyArticleDraftReview":
 			if op.Variables["id"] == "draft-revoked" {
-				_, _ = w.Write([]byte(`{"data":{"draftReview":null},"errors":[{"message":"draft review not found","path":["draftReview"],"extensions":{"code":"NOT_FOUND","http_status":404}}]}`))
+				_, _ = w.Write([]byte(`{"data":{"draftReview":null}}`))
 				return
 			}
 			_, _ = w.Write([]byte(`{"data":{"draftReview":{"draftId":"draft-1","contentFormat":"MARKDOWN","status":"DRAFT","updatedAt":"2026-08-09T12:00:00Z","createdAt":"2026-08-09T11:00:00Z","contentHash":"sha256:review","revision":4,"activeReviewerIds":["reviewer"],"publishEligible":false,"publishBlockingReasons":[],"reviewersApproved":false,"principalApprovalRequired":true,"principalApproved":false,"grantCount":1,"grantsTruncated":false,"grants":[],"grant":{"reviewerId":"reviewer","grantedAt":"2026-08-09T11:30:00Z","status":"ACTIVE"},"verdicts":[],"publishEligibility":{"eligible":false,"blockingReasons":[],"reviewersApproved":false,"principalApprovalRequired":true,"principalApproved":false}}}}`))
@@ -238,8 +238,94 @@ func TestArticleDraftPreviewDelegatesOwnerOrActiveReviewerAuthorizationToLesser(
 	if revoked == nil || !revoked.IsError {
 		t.Fatalf("revoked reviewer preview = %+v", revoked)
 	}
+	revokedPayload := toolErrorPayloadForTest(t, revoked)
+	revokedDetails, _ := revokedPayload["details"].(map[string]any)
+	if revokedPayload["code"] != "not_found" || intFromAny(revokedPayload["status"]) != http.StatusNotFound ||
+		revokedDetails["lookup"] != "id" || revokedDetails["tool"] != "article_draft_preview" {
+		t.Fatalf("revoked preview payload = %#v, details = %#v", revokedPayload, revokedDetails)
+	}
 	if len(operations) != 3 || operations[0] != "BodyArticleDraftReview" || operations[1] != "BodyArticleDraftPreview" || operations[2] != "BodyArticleDraftReview" {
 		t.Fatalf("preview must use Lesser's caller-authorized review preflight and grant-aware draftPreview, operations = %+v", operations)
+	}
+}
+
+func TestArticleDraftUpdateReturnsNotFoundForTypedMissingOwnerLookup(t *testing.T) {
+	var operations []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var op cmsapi.Operation
+		if err := json.NewDecoder(r.Body).Decode(&op); err != nil {
+			t.Errorf("decode operation: %v", err)
+			http.Error(w, "invalid operation", http.StatusBadRequest)
+			return
+		}
+		operations = append(operations, op.OperationName)
+		w.Header().Set("Content-Type", "application/json")
+		if op.OperationName != "BodyArticleDraft" {
+			t.Fatalf("unexpected operation %q", op.OperationName)
+		}
+		_, _ = w.Write([]byte(`{"data":{"draft":null}}`))
+	}))
+	t.Cleanup(func() {
+		server.Close()
+		lesserapi.ResetForTests()
+	})
+	t.Setenv("LESSER_API_BASE_URL", server.URL)
+	lesserapi.ResetForTests()
+
+	result, err := handleArticleDraftUpdate(articleDraftTestContext(), json.RawMessage(`{"id":"draft-missing","title":"Updated"}`))
+	if err != nil {
+		t.Fatalf("article_draft_update: %v", err)
+	}
+	payload := toolErrorPayloadForTest(t, result)
+	if payload["code"] != "not_found" || intFromAny(payload["status"]) != http.StatusNotFound {
+		t.Fatalf("error payload = %#v, want not_found/404", payload)
+	}
+	details, _ := payload["details"].(map[string]any)
+	if details["lookup"] != "id" || details["tool"] != "article_draft_update" {
+		t.Fatalf("error details = %#v, want lookup=id tool=article_draft_update", details)
+	}
+	if len(operations) != 1 || operations[0] != "BodyArticleDraft" {
+		t.Fatalf("update preflight operations = %+v, want only BodyArticleDraft", operations)
+	}
+}
+
+func TestArticleDraftPublishReturnsNotFoundForTypedMissingOwnerLookup(t *testing.T) {
+	var operations []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var op cmsapi.Operation
+		if err := json.NewDecoder(r.Body).Decode(&op); err != nil {
+			t.Errorf("decode operation: %v", err)
+			http.Error(w, "invalid operation", http.StatusBadRequest)
+			return
+		}
+		operations = append(operations, op.OperationName)
+		w.Header().Set("Content-Type", "application/json")
+		if op.OperationName != "BodyArticleDraft" {
+			t.Fatalf("unexpected operation %q", op.OperationName)
+		}
+		_, _ = w.Write([]byte(`{"data":{"draft":null}}`))
+	}))
+	t.Cleanup(func() {
+		server.Close()
+		lesserapi.ResetForTests()
+	})
+	t.Setenv("LESSER_API_BASE_URL", server.URL)
+	lesserapi.ResetForTests()
+
+	result, err := handleArticleDraftPublish(articleDraftTestContext(), json.RawMessage(`{"id":"draft-missing"}`))
+	if err != nil {
+		t.Fatalf("article_draft_publish: %v", err)
+	}
+	payload := toolErrorPayloadForTest(t, result)
+	if payload["code"] != "not_found" || intFromAny(payload["status"]) != http.StatusNotFound {
+		t.Fatalf("error payload = %#v, want not_found/404", payload)
+	}
+	details, _ := payload["details"].(map[string]any)
+	if details["lookup"] != "id" || details["tool"] != "article_draft_publish" {
+		t.Fatalf("error details = %#v, want lookup=id tool=article_draft_publish", details)
+	}
+	if len(operations) != 1 || operations[0] != "BodyArticleDraft" {
+		t.Fatalf("publish preflight operations = %+v, want only BodyArticleDraft", operations)
 	}
 }
 


### PR DESCRIPTION
## Milestone
lesser-body#568 — normalize article-family missing-record lookups to clean not_found tool errors.

## Classification
bug-fix, tool-surface, contract-refinement

## Corrected diagnosis
The signal was **not** lost twice. `registerTool` already normalized handler-returned errors through the shared tool error wrapper. The 500s came from the unclassified fallback after plain cmsapi nil-payload errors (`fmt.Errorf(...)`) reached the handler layer without a typed not-found classification.

This PR fixes that by:
- typing missing published Article, Article draft, and DraftReview records at the cmsapi boundary;
- mapping those typed misses to the shared `not_found`/404 tool envelope across the article family;
- deriving `details.lookup` from the caller's actual input field (`id`, `slug`, `draft_id`) instead of locator-prefix sniffing;
- documenting the article-family not-found contract and pinning it with mutation-sensitive tests.

## Surfaces affected
- `internal/cmsapi/articles.go`
- `internal/cmsapi/drafts.go`
- `internal/cmsapi/reviews.go`
- `internal/mcpserver/article_tools.go`
- article/draft/review published + draft tool tests
- `docs/mcp.md`
- gov rubric evidence

## Specialist walks referenced
- Tool surface: `evolve-tool-surface`
- MCP contract: `preserve-mcp-contract` (semantic refinement only; no discovery/OAuth shape break)
- Lesser integration: `coordinate-with-lesser` (no lesser-side change required; body consumes existing CMS nil-payload behavior)
- Rubric gate: `run-rubric-gate`

## Consumer impact
- `article_get` now returns `not_found`/404 for missing `id` and `slug` lookups, with `details.lookup` equal to the caller's actual field (`id` or `slug`) even when the canonical Article ID value is a URL.
- The sibling tools that used the same untyped missing-record path now return clean `not_found`/404 instead of the unclassified 500 fallback:
  - `article_update`
  - `article_draft_get`
  - `article_draft_update`
  - `article_draft_preview`
  - `article_draft_publish`
  - `article_draft_review_read`
- No auth, scope, profile, JWT, DynamoDB, or lesser-host delegation behavior changes.

## Tasks
- [x] Type missing published Article records at the cmsapi boundary.
- [x] Type missing Article draft and DraftReview records at the cmsapi boundary.
- [x] Normalize article-family missing-record paths to `not_found`/404 through the shared tool helper.
- [x] Derive `details.lookup` from the caller's actual input field rather than value-prefix sniffing.
- [x] Add mutation-sensitive handler/client regressions for the affected sibling tools.
- [x] Document the article-family not-found contract in `docs/mcp.md`.
- [x] Refresh rubric evidence.

## Validation
- `go build ./...`
- `go test ./internal/cmsapi/... ./internal/mcpserver/...`
- `go test ./...`
- `go vet ./...`
- `gofmt -l .` (empty)
- `bash scripts/build.sh`
- `bash gov-infra/verifiers/gov-verify-rubric.sh`

## Cross-repo coordination
None.

Closes #568